### PR TITLE
chore(deps): security bump (HIGH severity)

### DIFF
--- a/app/tauri/Cargo.lock
+++ b/app/tauri/Cargo.lock
@@ -3753,9 +3753,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",


### PR DESCRIPTION
## Summary

- Bumps `rustls-webpki` from `0.103.10` to `0.103.13` in `app/tauri/Cargo.lock`
- Fixes GHSA-82j2-j2ch-gfr8: Denial of service via panic on malformed CRL BIT STRING (HIGH)
- Change is within the same semver minor (0.103.x), making this a non-breaking patch fix

## Resolved

- **GHSA-82j2-j2ch-gfr8**: `rustls-webpki` `0.103.10` → `0.103.13` — DoS via panic on malformed CRL BIT STRING

## Deferred (require major bump or peer conflict)

- none

## Test plan

- [ ] CI passes (build + tests for `app/tauri`)
- [ ] Tauri app builds successfully with updated lockfile
- [ ] No regressions in TLS certificate validation behaviour

🤖 Generated with [Claude Code](https://claude.com/claude-code)