### PR TITLE
fix(churchhub-backend): guard against undefined ALLOWED_ORIGINS

### DIFF
--- a/churchhub-backend/src/middleware/security.ts
+++ b/churchhub-backend/src/middleware/security.ts
@@ -47,9 +47,9 @@ export function createCorsMiddleware(): MiddlewareHandler<{
  */
 export function isAllowedOrigin(
   origin: string | undefined,
-  allowedOrigins: string
+  allowedOrigins: string | undefined
 ): boolean {
-  if (!origin) return false
+  if (!origin || !allowedOrigins) return false
   const origins = allowedOrigins.split(',').map((o) => o.trim())
   return origins.includes(origin)
 }


### PR DESCRIPTION
## Summary
- `isAllowedOrigin()` was called with `c.env.ALLOWED_ORIGINS` which is `undefined` when the secret is unset in production.
- `.split(',')` on undefined throws an unhandled TypeError → `/auth/youtube` returns HTTP 500 to every caller.
- Fix: treat missing `allowedOrigins` the same as a non-allowed origin (returns 403 from the route handler).

## Test plan
- [x] Caller without secret set → HTTP 403 (not 500)
- [ ] Caller with secret set + matching Origin → still proceeds to OAuth flow

Note: production also needs `wrangler secret put ALLOWED_ORIGINS --name churchhub-backend` with the real frontend origins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)