### PR TITLE
Claude Code automations: hooks, subagents, skills

### DIFF
--- a/.claude/agents/cross-platform-reviewer.md
+++ b/.claude/agents/cross-platform-reviewer.md
@@ -1,0 +1,53 @@
+---
+name: cross-platform-reviewer
+description: Reviews staged/branch diffs for cross-platform (macOS/Windows/Linux) regressions in the Tauri shell + Bun sidecar. Triggers on changes to scripts, server entry, native modules, path resolution, or spawn/exec call sites. Use before merging anything that touches the build, sidecar bootstrapping, or native bindings.
+model: sonnet
+tools: Bash, Read, Glob, Grep
+---
+
+You enforce the cross-platform rules in `CLAUDE.md` for this Tauri + Bun project.
+
+# Context — the incident this protects against
+
+v0.1.60 exited silently 4s after launch on macOS. Root cause: a darwin-only `checkMidiSafety` spawned `process.execPath -e <code>` — Bun's standalone binary ignores Node-style `-e` flags and **re-runs the whole binary**, which on macOS triggered the port-3000 cleanup and SIGKILL'd the parent. Your job is to catch this class of bug pre-merge.
+
+# Forbidden patterns — flag every occurrence
+
+1. **`process.execPath` with Node-style flags** (`-e`, `--inspect`, `--eval`, `--experimental-*`) anywhere in `apps/server/`. The Bun-compiled sidecar ignores them. Use a dedicated CLI flag handled at the top of `apps/server/src/index.ts` (e.g. `--probe-midi`).
+2. **Shell-interpolated paths in `exec`/`spawn`** — especially with Windows-incompatible quoting. Prefer `execFileSync(<bin>, [args], { stdio: 'pipe', timeout })` with an args array.
+3. **Hardcoded path separators** — `'/'` joins where `path.join()` should be used, or `\\` escapes only valid on Windows.
+4. **Missing `process.platform` branching** for bundle layout (`darwin` → `<App>.app/Contents/{MacOS,Resources}/`, `win32`/`linux` → flat next to executable).
+5. **Native modules without per-OS prebuilds** for darwin-arm64, darwin-x64, win32-x64, linux-x64 (check `apps/server/scripts/compile.ts` for the prebuild-copy list).
+6. **`bash`/`sh` invocations** assuming a Unix shell — won't run on Windows without WSL.
+7. **`os.tmpdir()` assumptions** — Windows has different permissions/locking semantics; flag any file lock or rename across `tmpdir → app dir`.
+8. **Long-lived `execFileSync` without `timeout`** — a hung subprocess will hang the sidecar.
+
+# Workflow
+
+1. Run `git diff main...HEAD --name-only` (or against the user-specified base) to scope.
+2. Read each changed file in `apps/server/`, `app/scripts/`, `app/tauri/`, and any `compile.ts` / build script.
+3. For each forbidden pattern hit, report:
+   - **file:line**
+   - **what's wrong** (one line)
+   - **what to do** (one line, concrete)
+4. Also verify: did the change touch native modules, the Tauri config, or the compile script without an update to `.github/workflows/release-build.yml` smoke checks? If so, flag it.
+
+# Output
+
+Confidence-rated punch list. Skip nits — surface only items you'd block a release for:
+
+```
+## Cross-platform review
+
+🔴 BLOCKER — apps/server/src/midi/check.ts:14
+  process.execPath called with `-e` flag — Bun standalone ignores; re-runs sidecar; will SIGKILL parent on macOS (v0.1.60 incident).
+  Fix: replace with a `--probe-midi` CLI flag handled at top of index.ts.
+
+🟡 RISK — apps/server/src/audio/spawn.ts:32
+  execFileSync without timeout — a hung ffmpeg child will hang the sidecar.
+  Fix: add `{ timeout: 5000 }`.
+
+✅ Otherwise clean.
+```
+
+If diff is clean, say so in one line. Never edit files — this is a review pass.

--- a/.claude/agents/i18n-completeness.md
+++ b/.claude/agents/i18n-completeness.md
@@ -1,0 +1,55 @@
+---
+name: i18n-completeness
+description: Audits app/apps/client/src/i18n/locales/ — reports keys missing or orphaned across locales vs the en/ baseline. Use before tagging a release, after adding new user-facing strings, or when locale files have drifted.
+model: sonnet
+tools: Bash, Read, Glob, Grep
+---
+
+You audit the i18n locale tree at `app/apps/client/src/i18n/locales/`.
+
+# Baseline
+- `en/` is the source of truth. The codebase has `fallbackLng: 'en'`, so a missing locale key falls back to English at runtime — silent but degraded UX.
+- `ro/` is the second primary locale (CLAUDE.md mandates en + ro for every namespace).
+- ~13 namespace files per locale; ~51 locales total.
+
+# What to report
+
+For each namespace file under `en/`:
+1. **Missing in ro** — keys present in en but absent in ro. These are bugs (Romanian users see English fallback).
+2. **Missing in other locales** — aggregate per-locale count of keys missing relative to en (one line per locale, sorted by count desc). Don't list every key — counts only.
+3. **Orphans** — keys present in any non-en locale but NOT in en. These are dead code or typos.
+4. **Empty values** — keys with empty-string values in any locale.
+
+# Method
+
+- Use Bash + `jq` (or `python3 -c`) to flatten each JSON to dot-path keys.
+- For each namespace, diff en's key set against every other locale's key set.
+- Read files with the Read tool when you need to quote a specific value; otherwise stick to scripted counts.
+
+# Output
+
+A compact punch list, no preamble:
+
+```
+## i18n parity report
+
+### Missing in ro (BLOCKER — en+ro required)
+- songs.json: actions.archive, editor.subtitlePlaceholder
+- presentation.json: controls.fadeOut
+
+### Locales with most gaps vs en (top 10)
+- sw: 142 keys missing across 9 namespaces
+- ...
+
+### Orphan keys (not in en)
+- de/sidebar.json: legacy.menuItem
+- ...
+
+### Empty values
+- ru/songs.json: editor.titlePlaceholder ("")
+- ...
+```
+
+If everything is in sync, say so in one line. Don't pad.
+
+Never edit files — this is a read-only audit. If asked to fix, refer the user to the `/add-i18n-string` skill or suggest a follow-up task.

--- a/.claude/hooks/biome-format.sh
+++ b/.claude/hooks/biome-format.sh
@@ -9,10 +9,11 @@ payload="$(cat)"
 file_path="$(printf '%s' "$payload" | /usr/bin/python3 -c 'import json,sys; d=json.loads(sys.stdin.read()); print(d.get("tool_input",{}).get("file_path",""))' 2>/dev/null)"
 
 [ -z "$file_path" ] && exit 0
+[ -z "${CLAUDE_PROJECT_DIR:-}" ] && exit 0
 
 # Only operate on files inside the app/ workspace (Biome lives there)
 case "$file_path" in
-  */church-hub/app/*) ;;
+  "$CLAUDE_PROJECT_DIR"/app/*) ;;
   *) exit 0 ;;
 esac
 
@@ -22,8 +23,7 @@ case "$file_path" in
   *) exit 0 ;;
 esac
 
-repo_root="${file_path%%/church-hub/*}/church-hub"
-cd "$repo_root/app" 2>/dev/null || exit 0
+cd "$CLAUDE_PROJECT_DIR/app" 2>/dev/null || exit 0
 
 # Run biome quietly; never propagate non-zero
 bunx --bun biome check --write "$file_path" >/dev/null 2>&1 || true

--- a/.claude/hooks/biome-format.sh
+++ b/.claude/hooks/biome-format.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# PostToolUse hook — runs Biome --write on the edited file.
+# Reads Claude Code hook payload from stdin: { tool_input: { file_path: "..." }, ... }
+# Always exits 0 so a Biome failure never blocks an edit.
+
+set -u
+
+payload="$(cat)"
+file_path="$(printf '%s' "$payload" | /usr/bin/python3 -c 'import json,sys; d=json.loads(sys.stdin.read()); print(d.get("tool_input",{}).get("file_path",""))' 2>/dev/null)"
+
+[ -z "$file_path" ] && exit 0
+
+# Only operate on files inside the app/ workspace (Biome lives there)
+case "$file_path" in
+  */church-hub/app/*) ;;
+  *) exit 0 ;;
+esac
+
+# Only JS/TS/JSON sources
+case "$file_path" in
+  *.ts|*.tsx|*.js|*.jsx|*.mjs|*.cjs|*.json) ;;
+  *) exit 0 ;;
+esac
+
+repo_root="${file_path%%/church-hub/*}/church-hub"
+cd "$repo_root/app" 2>/dev/null || exit 0
+
+# Run biome quietly; never propagate non-zero
+bunx --bun biome check --write "$file_path" >/dev/null 2>&1 || true
+exit 0

--- a/.claude/hooks/i18n-parity.sh
+++ b/.claude/hooks/i18n-parity.sh
@@ -13,10 +13,11 @@ payload="$(cat)"
 file_path="$(printf '%s' "$payload" | /usr/bin/python3 -c 'import json,sys; d=json.loads(sys.stdin.read()); print(d.get("tool_input",{}).get("file_path",""))' 2>/dev/null)"
 
 [ -z "$file_path" ] && exit 0
+[ -z "${CLAUDE_PROJECT_DIR:-}" ] && exit 0
 
-# Only operate on edits inside i18n/locales/<lang>/<ns>.json
+# Only operate on edits inside this repo's i18n/locales/<lang>/<ns>.json
 case "$file_path" in
-  */apps/client/src/i18n/locales/*/*.json) ;;
+  "$CLAUDE_PROJECT_DIR"/app/apps/client/src/i18n/locales/*/*.json) ;;
   *) exit 0 ;;
 esac
 

--- a/.claude/hooks/i18n-parity.sh
+++ b/.claude/hooks/i18n-parity.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# PostToolUse hook — warns when an i18n locale file was edited without
+# the matching en/ or ro/ counterpart having the same keys.
+# CLAUDE.md mandates en + ro parity for every namespace.
+#
+# Exit codes:
+#   0 — nothing to flag (or warning printed; doesn't block)
+# Output: structured JSON on stderr understood by Claude Code as a soft warning.
+
+set -u
+
+payload="$(cat)"
+file_path="$(printf '%s' "$payload" | /usr/bin/python3 -c 'import json,sys; d=json.loads(sys.stdin.read()); print(d.get("tool_input",{}).get("file_path",""))' 2>/dev/null)"
+
+[ -z "$file_path" ] && exit 0
+
+# Only operate on edits inside i18n/locales/<lang>/<ns>.json
+case "$file_path" in
+  */apps/client/src/i18n/locales/*/*.json) ;;
+  *) exit 0 ;;
+esac
+
+# Extract locale + namespace from the path
+ns_file="${file_path##*/}"            # e.g. songs.json
+locale_dir="${file_path%/*}"          # .../locales/en
+locale="${locale_dir##*/}"            # en
+locales_root="${locale_dir%/*}"       # .../locales
+
+# Find the two primary locales' counterparts
+en_file="$locales_root/en/$ns_file"
+ro_file="$locales_root/ro/$ns_file"
+
+[ ! -f "$en_file" ] && exit 0
+[ ! -f "$ro_file" ] && exit 0
+
+# Compare top-level key sets via python — simple, no jq dep
+diff_out="$(/usr/bin/python3 - "$en_file" "$ro_file" <<'PY' 2>/dev/null
+import json, sys
+
+def flat_keys(obj, prefix=""):
+    out = set()
+    if isinstance(obj, dict):
+        for k, v in obj.items():
+            out |= flat_keys(v, f"{prefix}{k}." if not prefix else f"{prefix}{k}.")
+            out.add(f"{prefix}{k}")
+    return out
+
+with open(sys.argv[1]) as f: en = json.load(f)
+with open(sys.argv[2]) as f: ro = json.load(f)
+
+en_keys = flat_keys(en)
+ro_keys = flat_keys(ro)
+missing_in_ro = sorted(en_keys - ro_keys)
+missing_in_en = sorted(ro_keys - en_keys)
+
+if missing_in_ro or missing_in_en:
+    if missing_in_ro:
+        print("missing in ro: " + ", ".join(missing_in_ro[:8]) + (f" (+{len(missing_in_ro)-8} more)" if len(missing_in_ro)>8 else ""))
+    if missing_in_en:
+        print("missing in en: " + ", ".join(missing_in_en[:8]) + (f" (+{len(missing_in_en)-8} more)" if len(missing_in_en)>8 else ""))
+PY
+)"
+
+if [ -n "$diff_out" ]; then
+  echo "[i18n-parity] $ns_file out of sync between en/ and ro/:" >&2
+  printf '  %s\n' "$diff_out" >&2
+fi
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PROJECT_DIR}/.claude/hooks/biome-format.sh"
+          },
+          {
+            "type": "command",
+            "command": "${CLAUDE_PROJECT_DIR}/.claude/hooks/i18n-parity.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/skills/add-i18n-string/SKILL.md
+++ b/.claude/skills/add-i18n-string/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: add-i18n-string
+description: Add a new i18n key with English + Romanian translations to a chosen namespace. Use whenever you introduce a new user-facing string in the React client. CLAUDE.md mandates en + ro for every namespace; this skill enforces parity in one step.
+disable-model-invocation: true
+---
+
+# add-i18n-string
+
+You are adding a new translation key to the project's i18n locale files.
+
+## Steps
+
+1. **Gather inputs** — if not provided, ask the user for:
+   - **namespace** (one of: `bible`, `bibleBooks`, `common`, `livestream`, `music`, `presentation`, `queue`, `schedules`, `settings`, `sidebar`, `songKey`, `songs`, `liveTranslation`)
+   - **key path** in dot notation (e.g. `actions.archive`, `editor.subtitlePlaceholder`)
+   - **English value**
+   - **Romanian value**
+
+2. **Run the helper**:
+   ```bash
+   .claude/skills/add-i18n-string/scripts/add-i18n-key.py <namespace> <key.path> <en_value> <ro_value>
+   ```
+   The script writes to both `app/apps/client/src/i18n/locales/en/<ns>.json` and `.../ro/<ns>.json`, preserves existing key order, and refuses to overwrite an existing key (unless `--force`).
+
+3. **Report the diff** — show the two-file change so the user can confirm.
+
+4. **Suggest the call site** — print the exact `t('<namespace>:<key.path>')` snippet the React code should use.
+
+## Constraints
+
+- Only `en/` and `ro/` are statically imported in `app/apps/client/src/i18n/config.ts`; the other 49 locale dirs are dormant. Do NOT touch them.
+- Never edit `app/apps/client/src/i18n/config.ts` from this skill — namespaces are already registered.
+- If the namespace doesn't exist yet, stop and tell the user; adding a namespace requires editing the config and is out of scope for this skill.

--- a/.claude/skills/add-i18n-string/scripts/add-i18n-key.py
+++ b/.claude/skills/add-i18n-string/scripts/add-i18n-key.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""Insert a new i18n key into en/<ns>.json and ro/<ns>.json.
+
+Usage:
+    add-i18n-key.py <namespace> <dot.key.path> <en_value> <ro_value> [--force]
+
+Preserves existing key order. Refuses to overwrite an existing key unless --force.
+"""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+VALID_NS = {
+    "bible", "bibleBooks", "common", "livestream", "music", "presentation",
+    "queue", "schedules", "settings", "sidebar", "songKey", "songs",
+    "liveTranslation",
+}
+
+
+def find_repo_root() -> Path:
+    here = Path(__file__).resolve()
+    for parent in here.parents:
+        if (parent / "app" / "apps" / "client" / "src" / "i18n" / "locales").is_dir():
+            return parent
+    sys.exit("error: could not locate repo root (looking for app/apps/client/src/i18n/locales/)")
+
+
+def set_nested(obj: dict, dotted: str, value: str, force: bool) -> str | None:
+    """Returns None on success, error message string on failure."""
+    parts = dotted.split(".")
+    cur = obj
+    for p in parts[:-1]:
+        if p in cur and not isinstance(cur[p], dict):
+            return f"path collision: '{p}' is a string, not an object"
+        if p not in cur:
+            cur[p] = {}
+        cur = cur[p]
+    leaf = parts[-1]
+    if leaf in cur and not force:
+        existing = cur[leaf]
+        return f"key already exists with value: {existing!r} (use --force to overwrite)"
+    cur[leaf] = value
+    return None
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("namespace")
+    ap.add_argument("key")
+    ap.add_argument("en_value")
+    ap.add_argument("ro_value")
+    ap.add_argument("--force", action="store_true")
+    args = ap.parse_args()
+
+    if args.namespace not in VALID_NS:
+        sys.exit(f"error: unknown namespace '{args.namespace}'. Valid: {sorted(VALID_NS)}")
+
+    root = find_repo_root()
+    locales_root = root / "app" / "apps" / "client" / "src" / "i18n" / "locales"
+
+    for locale, value in (("en", args.en_value), ("ro", args.ro_value)):
+        path = locales_root / locale / f"{args.namespace}.json"
+        if not path.is_file():
+            sys.exit(f"error: missing locale file: {path}")
+        with path.open() as f:
+            data = json.load(f)
+        err = set_nested(data, args.key, value, args.force)
+        if err:
+            sys.exit(f"error in {locale}/{args.namespace}.json at '{args.key}': {err}")
+        with path.open("w") as f:
+            json.dump(data, f, indent=2, ensure_ascii=False)
+            f.write("\n")
+        print(f"  wrote {locale}/{args.namespace}.json :: {args.key} = {value!r}")
+
+    print(f"\nUse in code:  t('{args.namespace}:{args.key}')")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/skills/documented-pr/SKILL.md
+++ b/.claude/skills/documented-pr/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: documented-pr
+description: Create a well-documented PR in the radio-crestin/church-hub#9 style — numbered feature sections with motivation+fix+highlights, a checkbox test plan, and a per-commit screen-recorded demo video uploaded as a draft GitHub release. Use when the user wants to open a PR with full reviewer-friendly documentation.
+disable-model-invocation: true
+---
+
+# documented-pr
+
+You produce a PR description that reviewers can actually act on, plus a screen-recorded video demo for every feature commit.
+
+## Reference style — radio-crestin/church-hub PR #9
+
+PR #9 is the canonical example. Match its shape:
+
+```markdown
+## Summary
+[1 paragraph: what's bundled, what's bug vs feature vs polish, whether new
+ architectural concepts were introduced.]
+
+## What's in the PR
+
+### 1. `<commit-prefix>(<scope>)` — <Feature title>
+[Bug or motivation paragraph (if a fix). Then fix/implementation. Then
+ "Implementation highlights:" bullets covering schema, hooks, edge cases.]
+
+<video src="<release-asset-url>" controls width="600"></video>
+
+### 2. `<commit-prefix>(<scope>)` — <Feature title>
+...
+
+## Test plan
+- [ ] **<Feature 1>:** concrete steps a reviewer can walk through.
+- [ ] **<Feature 2>:** ...
+
+## Files touched
+N files, **+X / -Y**. [One sentence on the shape of the change — new files,
+modified, removed; any breaking-change call-outs.]
+```
+
+Each numbered section MUST embed its corresponding `<video>` tag (or note "no demo" if the commit had no UI surface).
+
+## Workflow
+
+1. **Resolve base branch and commit list**:
+   ```bash
+   gh pr view --json baseRefName 2>/dev/null | jq -r .baseRefName  # if PR exists
+   git log --reverse --format='%h %s' <base>..HEAD
+   ```
+   If no PR exists yet, default base = `main`. Confirm with the user if the current branch is unusual.
+
+2. **For each commit (oldest → newest)**:
+   - Show the commit subject + body (`git log -1 <sha>`) and the file list (`git show --stat <sha>`).
+   - Ask: "Record a demo for this commit? [y / N / skip-all]"
+   - If **y** → call `scripts/record-feature.sh start <sha>` (runs ffmpeg in background, returns the PID). Tell the user to demonstrate the feature in the app. When they say "done", call `scripts/record-feature.sh stop <pid>` to finalize the mp4. Path is `/tmp/pr-demos/<sha>.mp4`.
+   - If **N** → note "no demo" for this commit; it will appear in the PR body without a `<video>` tag.
+   - If **skip-all** → skip recording for this and every remaining commit.
+
+3. **Synthesize the PR body** following the reference style:
+   - Read each commit message and the diff (`git show <sha>`) to write the motivation/fix/highlights paragraph.
+   - Use the commit's conventional-commits prefix (`feat(scope)`, `fix(scope)`, `chore`) verbatim in the section heading.
+   - For the **Test plan**, derive one checkbox per commit from what the diff actually changes — concrete UI steps for UI changes, observable behavior for backend changes.
+   - For **Files touched**, use the aggregate `git diff --stat <base>..HEAD` numbers.
+
+4. **Upload videos**:
+   ```bash
+   scripts/upload-demos.sh <branch-or-pr-name>
+   ```
+   This creates a draft GitHub release `pr-demos-<branch>` and uploads every `/tmp/pr-demos/*.mp4`. Prints a `sha → asset-url` mapping you substitute into the PR body's `<video src>` attributes.
+
+5. **Open or update the PR**:
+   - New PR: `gh pr create --title "<title>" --body "$(cat /tmp/pr-body.md)"`
+   - Existing PR: `gh pr edit --body "$(cat /tmp/pr-body.md)"`
+   - Title format: `<scope or domain>: <short summary>` — same compact style as PR #9 ("Presentation window management & sidebar improvements").
+
+6. **Print the PR URL** so the user can review.
+
+## Constraints
+
+- **Never push automatically.** Per CLAUDE.md: "NEVER push to remote unless the user explicitly asks." If the local branch isn't on the remote yet, ask before `git push -u`.
+- **One mp4 per commit**, not per file. Commits are the natural review unit.
+- **Keep the description grounded in what the diff actually contains** — do NOT invent test-plan items for behavior the diff doesn't touch.
+- **Don't commit the mp4s into the repo.** They live in `/tmp/pr-demos/` and end up as release assets only.
+- **Skip the video for commits with no UI surface** (pure refactors, dep bumps, migration-only) unless the user insists.
+- If a commit subject is `chore:` or `docs:`, default to "no demo" without asking.

--- a/.claude/skills/documented-pr/scripts/record-feature.sh
+++ b/.claude/skills/documented-pr/scripts/record-feature.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# Record a screen-capture mp4 for one feature using ffmpeg.
+# Cross-platform: avfoundation (macOS), x11grab (Linux), gdigrab (Windows/Git Bash).
+#
+# Usage:
+#   record-feature.sh start <sha-or-name>   # starts background ffmpeg, prints PID + output path
+#   record-feature.sh stop  <pid>           # gracefully stops ffmpeg via SIGINT (writes mp4 trailer)
+#
+# Output: /tmp/pr-demos/<sha-or-name>.mp4
+
+set -u
+
+out_dir="/tmp/pr-demos"
+mkdir -p "$out_dir"
+
+cmd="${1:-}"
+arg="${2:-}"
+
+if [ -z "$cmd" ]; then
+  echo "usage: $0 {start <name> | stop <pid>}" >&2
+  exit 1
+fi
+
+case "$cmd" in
+  start)
+    [ -z "$arg" ] && { echo "error: 'start' requires a name (commit sha)" >&2; exit 1; }
+    out="$out_dir/$arg.mp4"
+    log="$out_dir/$arg.log"
+
+    case "$(uname -s)" in
+      Darwin)
+        # avfoundation: '2:none' = "Capture screen 0", no audio.
+        # To pick a different screen, set SCREEN_INDEX (default 2).
+        screen="${SCREEN_INDEX:-2}"
+        ffmpeg -y -nostdin -f avfoundation -framerate 30 -capture_cursor 1 \
+          -i "${screen}:none" -vcodec libx264 -preset ultrafast -pix_fmt yuv420p \
+          "$out" >"$log" 2>&1 &
+        ;;
+      Linux)
+        display="${DISPLAY:-:0}"
+        size="${SCREEN_SIZE:-1920x1080}"
+        ffmpeg -y -nostdin -f x11grab -framerate 30 -video_size "$size" \
+          -i "$display" -vcodec libx264 -preset ultrafast -pix_fmt yuv420p \
+          "$out" >"$log" 2>&1 &
+        ;;
+      MINGW*|MSYS*|CYGWIN*)
+        ffmpeg -y -nostdin -f gdigrab -framerate 30 -i desktop \
+          -vcodec libx264 -preset ultrafast -pix_fmt yuv420p \
+          "$out" >"$log" 2>&1 &
+        ;;
+      *) echo "error: unsupported OS $(uname -s)" >&2; exit 1 ;;
+    esac
+
+    pid=$!
+    sleep 0.5
+    if ! kill -0 "$pid" 2>/dev/null; then
+      echo "error: ffmpeg exited immediately; see $log" >&2
+      cat "$log" >&2
+      exit 1
+    fi
+    echo "recording: pid=$pid out=$out log=$log"
+    echo "stop with: $0 stop $pid"
+    ;;
+
+  stop)
+    [ -z "$arg" ] && { echo "error: 'stop' requires a PID" >&2; exit 1; }
+    if ! kill -0 "$arg" 2>/dev/null; then
+      echo "error: pid $arg not running" >&2
+      exit 1
+    fi
+    # SIGINT lets ffmpeg write the moov atom; SIGTERM would corrupt the mp4
+    kill -INT "$arg"
+    # Wait up to 5s for it to finish flushing
+    for _ in $(seq 1 10); do
+      if ! kill -0 "$arg" 2>/dev/null; then break; fi
+      sleep 0.5
+    done
+    if kill -0 "$arg" 2>/dev/null; then
+      kill -9 "$arg" 2>/dev/null
+      echo "warning: ffmpeg did not exit cleanly; mp4 may be unplayable" >&2
+    fi
+    echo "stopped: pid=$arg"
+    ;;
+
+  *)
+    echo "usage: $0 {start <name> | stop <pid>}" >&2
+    exit 1
+    ;;
+esac

--- a/.claude/skills/documented-pr/scripts/upload-demos.sh
+++ b/.claude/skills/documented-pr/scripts/upload-demos.sh
@@ -16,11 +16,13 @@ if ! compgen -G "$src/*.mp4" > /dev/null; then
   exit 0
 fi
 
-# Create (or reuse) draft release. `gh release create` errors if tag exists.
+# Create (or reuse) a prerelease. NOT --draft: draft asset URLs return 404
+# for non-collaborators, breaking <video> tags for external PR reviewers.
+# --prerelease keeps them out of the "Latest" release while remaining public.
 if gh release view "$tag" >/dev/null 2>&1; then
   echo "release $tag already exists — uploading additional assets"
 else
-  gh release create "$tag" --draft --title "$tag" --notes "PR demo videos" >/dev/null
+  gh release create "$tag" --prerelease --title "$tag" --notes "PR demo videos" >/dev/null
 fi
 
 # Upload each mp4 (--clobber to replace if re-running)

--- a/.claude/skills/documented-pr/scripts/upload-demos.sh
+++ b/.claude/skills/documented-pr/scripts/upload-demos.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Upload all mp4s in /tmp/pr-demos/ to a draft GitHub release.
+# Prints a sha→url table the caller substitutes into the PR body.
+#
+# Usage: upload-demos.sh <release-tag>
+#   e.g. upload-demos.sh pr-demos-feat-something
+
+set -euo pipefail
+
+tag="${1:-}"
+[ -z "$tag" ] && { echo "usage: $0 <release-tag>" >&2; exit 1; }
+
+src="/tmp/pr-demos"
+if ! compgen -G "$src/*.mp4" > /dev/null; then
+  echo "no mp4s in $src — nothing to upload" >&2
+  exit 0
+fi
+
+# Create (or reuse) draft release. `gh release create` errors if tag exists.
+if gh release view "$tag" >/dev/null 2>&1; then
+  echo "release $tag already exists — uploading additional assets"
+else
+  gh release create "$tag" --draft --title "$tag" --notes "PR demo videos" >/dev/null
+fi
+
+# Upload each mp4 (--clobber to replace if re-running)
+for f in "$src"/*.mp4; do
+  name="$(basename "$f")"
+  gh release upload "$tag" "$f" --clobber >/dev/null
+  # Resolve to the final asset URL via API
+  url=$(gh release view "$tag" --json assets \
+        --jq ".assets[] | select(.name==\"$name\") | .url")
+  echo "${name%.mp4}	$url"
+done

--- a/.claude/skills/release-smoke-check/SKILL.md
+++ b/.claude/skills/release-smoke-check/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: release-smoke-check
+description: Smoke-test the bundled Bun sidecar by launching it headlessly and polling /ping until 200 (or failing on early exit). Use before tagging a release to catch the class of bug that killed v0.1.60 silently on macOS. CLAUDE.md mandates this check on every release-affecting change.
+disable-model-invocation: true
+---
+
+# release-smoke-check
+
+You verify the **bundled** sidecar artifact actually stays alive and answers `/ping`. The v0.1.60 macOS incident proved that `bun dev` succeeding does NOT mean the compiled binary will.
+
+## Steps
+
+1. **Resolve the binary path**. Default candidates by OS:
+   - macOS: `app/apps/server/dist/server` (or inside `tauri/target/release/bundle/macos/<App>.app/Contents/MacOS/server-bin`)
+   - Linux: `app/apps/server/dist/server`
+   - Windows: `app/apps/server/dist/server.exe`
+
+   If the binary doesn't exist, tell the user to run `bun run build:apps` (or `bun run tauri:build`) first. Do **not** rebuild silently.
+
+2. **Run the helper**:
+   ```bash
+   .claude/skills/release-smoke-check/scripts/smoke.sh [path-to-binary] [port]
+   ```
+   Defaults: auto-detected binary path; port `3000`.
+
+3. **Interpret the result**:
+   - exit 0 → `/ping` returned 200 within timeout → ship-ready signal
+   - exit 1 → process exited early; print the captured stdout/stderr (this is exactly the v0.1.60 scenario)
+   - exit 2 → process stayed alive but `/ping` never returned 200 within timeout → routing/port-bind regression
+
+4. **On failure**, suggest invoking `cross-platform-reviewer` on the diff that landed since the last green release, since that subagent's whole job is catching this class of bug.
+
+## Notes
+
+- The script does NOT build for you — building is the user's call. This skill is a verifier, not a builder.
+- Default timeout is 20s, which matches the v0.1.60 4-second-silent-exit symptom with headroom.
+- Logs are written to `/tmp/release-smoke-<pid>.log` so a post-mortem is possible after the script exits.

--- a/.claude/skills/release-smoke-check/scripts/smoke.sh
+++ b/.claude/skills/release-smoke-check/scripts/smoke.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Smoke-test the bundled sidecar — launch it, wait for /ping 200, fail on early exit.
+# Cross-platform: works on macOS, Linux, Windows (Git Bash / WSL).
+#
+# Exit codes:
+#   0 — /ping returned 200
+#   1 — process exited before responding (v0.1.60-class bug)
+#   2 — process alive but /ping never became ready
+
+set -u
+
+bin="${1:-}"
+port="${2:-3000}"
+timeout="${SMOKE_TIMEOUT:-20}"
+
+# Auto-detect binary path if not provided
+if [ -z "$bin" ]; then
+  case "$(uname -s)" in
+    Darwin|Linux) bin="app/apps/server/dist/server" ;;
+    MINGW*|MSYS*|CYGWIN*) bin="app/apps/server/dist/server.exe" ;;
+    *) echo "error: unknown OS $(uname -s)" >&2; exit 1 ;;
+  esac
+fi
+
+if [ ! -x "$bin" ]; then
+  echo "error: binary not found or not executable: $bin" >&2
+  echo "       run 'bun run build:apps' first" >&2
+  exit 1
+fi
+
+log="/tmp/release-smoke-$$.log"
+echo "smoke: launching $bin on port $port (timeout ${timeout}s, log: $log)"
+
+# Launch in background, redirect both streams to log
+PORT="$port" "$bin" >"$log" 2>&1 &
+pid=$!
+
+cleanup() {
+  if kill -0 "$pid" 2>/dev/null; then
+    kill "$pid" 2>/dev/null
+    sleep 0.5
+    kill -9 "$pid" 2>/dev/null
+  fi
+}
+trap cleanup EXIT INT TERM
+
+deadline=$(( $(date +%s) + timeout ))
+while [ "$(date +%s)" -lt "$deadline" ]; do
+  if ! kill -0 "$pid" 2>/dev/null; then
+    echo "smoke: process exited before /ping responded — this is the v0.1.60 failure mode" >&2
+    echo "---- captured output ----" >&2
+    cat "$log" >&2
+    exit 1
+  fi
+  if curl -fsS -o /dev/null -m 1 "http://127.0.0.1:${port}/ping" 2>/dev/null; then
+    echo "smoke: /ping returned 200 — sidecar is alive"
+    exit 0
+  fi
+  sleep 0.5
+done
+
+echo "smoke: timeout — process alive but /ping never returned 200" >&2
+echo "---- captured output ----" >&2
+cat "$log" >&2
+exit 2

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,7 @@
 
 ## DO:
 - ALWAYS DEBUG TO FIND THE ROOT CAUSE OF A PROBLEM AND FIX IT PERMANENTLY
+- Always create a feature branch BEFORE starting work — never commit directly to `main`. Name the branch after the PR scope (`feat/...`, `fix/...`, `chore/...`) and draft the PR description up front (use the `/documented-pr` skill at the end to flesh it out and attach per-feature demo videos)
 - Commit changes granularly after each task using the /commit skill
 - Analyze source code in spawned subtasks, return summaries with key insights and file paths (e.g., path/to/file.js:10:20)
 - Navigate to claude's cwd first, then cd into the correct folder before running commands


### PR DESCRIPTION
## Summary

Six commits adding a tailored Claude Code automation layer to the repo — two PostToolUse hooks, two read-only review subagents, three user-invocable skills, and a CLAUDE.md workflow rule mandating feature branches. Tooling-only changes; no application behavior is touched.

## What's in the PR

### 1. `feat(claude)` — Biome auto-fix + i18n parity-guard PostToolUse hooks

Two scripts wired into `.claude/settings.json` that run after every `Edit|Write|MultiEdit`:

- **`.claude/hooks/biome-format.sh`** runs `bunx biome check --write` on the edited file when it's a JS/TS/JSON source inside `app/`. Catches drift earlier than `lint-staged`'s pre-commit pass without changing the existing pre-commit setup.
- **`.claude/hooks/i18n-parity.sh`** warns (never blocks) when an edit to `i18n/locales/<lang>/<ns>.json` leaves the en/ and ro/ counterparts with mismatched key sets. CLAUDE.md mandates en + ro for every namespace; this catches the most common slip-up.

Both hooks `exit 0` unconditionally so a tool failure can't block an edit, and both gate on `$CLAUDE_PROJECT_DIR` so they no-op outside this repo.

### 2. `feat(claude)` — i18n-completeness + cross-platform-reviewer subagents

Two read-only `sonnet`-model reviewers under `.claude/agents/`:

- **`i18n-completeness`** audits the whole locale tree against the `en/` baseline. Reports missing-in-ro keys (BLOCKER per CLAUDE.md), per-locale gap counts, orphan keys not present in en, and empty-value keys. Intended to run before tagging a release.
- **`cross-platform-reviewer`** scans staged or branch-scoped diffs for the patterns documented in CLAUDE.md's "Cross-platform compatibility — REQUIRED" section: `process.execPath` with Node-style flags (the exact v0.1.60 macOS-silent-exit bug), missing `process.platform` branching, native modules without per-OS prebuilds, shell-interpolated paths, and unbounded `execFileSync`.

### 3. `feat(claude)` — `/add-i18n-string` skill

User-invocable skill (gated with `disable-model-invocation: true`) that adds a new translation key to both `en/<ns>.json` and `ro/<ns>.json` in one step, preserves existing key order, and refuses to overwrite an existing key without `--force`. The 49 other locale directories on disk are intentionally untouched — only en and ro are statically imported in `app/apps/client/src/i18n/config.ts`, and `fallbackLng: 'en'` covers the rest at runtime.

### 4. `feat(claude)` — `/release-smoke-check` skill

User-invocable skill that launches the bundled sidecar binary, polls `http://127.0.0.1:PORT/ping` for up to 20s, and fails with the captured stdout/stderr if the process exits early — the exact failure mode that hid the v0.1.60 macOS regression. Cross-platform: auto-detects the binary at `app/apps/server/dist/server[.exe]` per OS. Verifier only — does not rebuild.

### 5. `feat(claude)` — `/documented-pr` skill with per-feature video demos

User-invocable skill that produces PR descriptions in the same style as #9 — numbered feature sections (motivation → fix → highlights), a checkbox test plan, and a "Files touched" summary. For each commit on the branch it records a short screen-capture mp4 via `ffmpeg` (avfoundation on macOS, x11grab on Linux, gdigrab on Windows), uploads them to a `--prerelease` GitHub release for stable public URLs, and embeds them as inline `<video>` tags in the PR body. Recording is opt-in per commit; `chore:` and `docs:` commits skip by default.

### 6. `docs(claude.md)` — Feature-branch + up-front PR-description rule

New DO bullet in `CLAUDE.md` requiring a feature branch (`feat/`, `fix/`, `chore/`) before any work and a PR description drafted up front, completed via `/documented-pr` at the end. This PR follows the rule it adds.

## Test plan

- [ ] **Biome hook:** edit any `.ts` file under `app/` with broken formatting; after the edit, the file is auto-formatted (silently, exit 0). Edits under `churchhub-backend/` or to `.md` files are untouched.
- [ ] **i18n parity hook:** delete a key from `ro/songs.json` and edit `en/songs.json`. A `[i18n-parity]` warning lists `missing in ro: <key>` on stderr; the edit is not blocked.
- [ ] **`i18n-completeness` agent:** spawn it (`Use the i18n-completeness subagent`) — returns the punch list of missing/orphan/empty keys across all locales.
- [ ] **`cross-platform-reviewer` agent:** spawn it on the branch — returns a confidence-rated list of cross-platform risks. On a clean diff, prints "Otherwise clean" in one line.
- [ ] **`/add-i18n-string`:** `.claude/skills/add-i18n-string/scripts/add-i18n-key.py songs editor.testKey "Hello" "Salut"` writes both locale files; running it again without `--force` errors with the existing value quoted.
- [ ] **`/release-smoke-check`:** after `bun run build:apps`, `.claude/skills/release-smoke-check/scripts/smoke.sh` returns exit 0 and prints `/ping returned 200`. If the binary exits before /ping, exit 1 with captured output.
- [ ] **`/documented-pr`:** on a feature branch with commits, the skill walks the commits one by one, optionally records a video per commit via ffmpeg, uploads to a `gh release create --prerelease pr-demos-<branch>`, and either creates or edits the PR with the synthesized body.
- [ ] **CLAUDE.md rule:** future PRs land on feature branches, not directly on main.

## Files touched

13 files, **+654 / -0**. All additions: `.claude/hooks/*.sh`, `.claude/agents/*.md`, `.claude/skills/*/SKILL.md` + helper scripts, `.claude/settings.json`, plus one line in `CLAUDE.md`. No application code is touched; no migrations; no dependencies added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)