### PR TITLE
ci: gate tests on /test PR comment instead of every push

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,13 +1,25 @@
 name: Test
 
+# Tests run automatically on:
+#   - push to main (post-merge verification)
+#   - manual workflow_dispatch
+# Tests run on PRs ONLY when a maintainer comments "/test" — keeps CI minutes
+# out of every push during a long-running feature branch and prevents fork PRs
+# from exercising the runners without review.
 on:
   push:
     branches: [main]
     tags-ignore:
       - '**'
-  pull_request:
-    branches: [main]
   workflow_dispatch:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  pull-requests: read
+  statuses: write
+  checks: write
 
 env:
   NODE_VERSION: 22
@@ -21,11 +33,75 @@ env:
   VITE_PUBLIC_POSTHOG_CONVERSATIONS_TOKEN: ${{ secrets.VITE_PUBLIC_POSTHOG_CONVERSATIONS_TOKEN || '4GDD07pVU98dgX9qHiFHNswimJuq7gD1hE6nvTHXMBY' }}
 
 jobs:
+  # Gate job: validates a comment-triggered run and resolves the PR head SHA.
+  # All other jobs depend on this. For push / workflow_dispatch, it short-
+  # circuits with the current SHA.
+  gate:
+    runs-on: ubuntu-latest
+    if: >-
+      github.event_name != 'issue_comment' ||
+      (github.event.issue.pull_request != null &&
+       startsWith(github.event.comment.body, '/test'))
+    outputs:
+      sha: ${{ steps.resolve.outputs.sha }}
+      pr_number: ${{ steps.resolve.outputs.pr_number }}
+    steps:
+      - name: Check commenter permission
+        if: github.event_name == 'issue_comment'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { data: perm } = await github.rest.repos.getCollaboratorPermissionLevel({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              username: context.payload.comment.user.login,
+            });
+            const allowed = ['admin', 'maintain', 'write'].includes(perm.permission);
+            if (!allowed) {
+              core.setFailed(
+                `${context.payload.comment.user.login} (permission=${perm.permission}) is not allowed to trigger CI. Required: write+.`
+              );
+            }
+
+      - name: Acknowledge comment with reaction
+        if: github.event_name == 'issue_comment'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.reactions.createForIssueComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: context.payload.comment.id,
+              content: 'rocket',
+            });
+
+      - name: Resolve target SHA
+        id: resolve
+        uses: actions/github-script@v7
+        with:
+          script: |
+            if (context.eventName === 'issue_comment') {
+              const { data: pr } = await github.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: context.payload.issue.number,
+              });
+              core.setOutput('sha', pr.head.sha);
+              core.setOutput('pr_number', String(pr.number));
+              core.info(`Resolved PR #${pr.number} head ${pr.head.sha}`);
+            } else {
+              core.setOutput('sha', context.sha);
+              core.setOutput('pr_number', '');
+            }
+
   unit-tests:
+    needs: gate
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.gate.outputs.sha }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -55,10 +131,13 @@ jobs:
         run: bun run test:unit
 
   server-tests:
+    needs: gate
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.gate.outputs.sha }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -89,10 +168,12 @@ jobs:
 
   e2e-tests:
     runs-on: ubuntu-latest
-    needs: [unit-tests, server-tests]
+    needs: [gate, unit-tests, server-tests]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.gate.outputs.sha }}
 
       - name: Install system dependencies
         run: |
@@ -175,6 +256,7 @@ jobs:
   # and asserts /ping returns 200 within the timeout.
   release-build-smoke:
     name: Release build smoke (${{ matrix.os }})
+    needs: gate
     strategy:
       fail-fast: false
       matrix:
@@ -183,6 +265,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.gate.outputs.sha }}
 
       - name: Install Linux audio + MIDI deps
         if: matrix.os == 'ubuntu-latest'
@@ -232,3 +316,52 @@ jobs:
             app/apps/server/test-results/
           retention-days: 7
           if-no-files-found: ignore
+
+  # Post commit statuses back to the PR head SHA so test results appear in
+  # the PR's "Checks" UI. issue_comment-triggered runs have head_sha == main,
+  # so without this step the runs are only visible in the Actions tab.
+  report-status:
+    needs: [gate, unit-tests, server-tests, e2e-tests, release-build-smoke]
+    if: always() && github.event_name == 'issue_comment'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Post commit statuses to PR head
+        uses: actions/github-script@v7
+        env:
+          PR_SHA: ${{ needs.gate.outputs.sha }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          UNIT_RESULT: ${{ needs.unit-tests.result }}
+          SERVER_RESULT: ${{ needs.server-tests.result }}
+          E2E_RESULT: ${{ needs.e2e-tests.result }}
+          SMOKE_RESULT: ${{ needs.release-build-smoke.result }}
+        with:
+          script: |
+            const sha = process.env.PR_SHA;
+            const runUrl = process.env.RUN_URL;
+            const mapResult = (r) => {
+              if (r === 'success') return 'success';
+              if (r === 'skipped' || r === 'cancelled') return 'error';
+              return 'failure';
+            };
+            const checks = [
+              ['unit-tests', process.env.UNIT_RESULT],
+              ['server-tests', process.env.SERVER_RESULT],
+              ['e2e-tests', process.env.E2E_RESULT],
+              ['release-build-smoke', process.env.SMOKE_RESULT],
+            ];
+            for (const [statusContext, result] of checks) {
+              try {
+                await github.rest.repos.createCommitStatus({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  sha,
+                  state: mapResult(result),
+                  context: statusContext,
+                  description: result,
+                  target_url: runUrl,
+                });
+                core.info(`Posted ${statusContext}=${mapResult(result)} for ${sha}`);
+              } catch (err) {
+                core.warning(`Failed to post status ${statusContext}: ${err.message}`);
+              }
+            }


### PR DESCRIPTION
## Summary

Removes the automatic `pull_request` trigger from `test.yml`. Tests now run only when a maintainer comments `/test` on the PR (plus on `push` to `main` and via `workflow_dispatch` for post-merge / manual cases). Saves CI minutes on iterative PRs and keeps fork PRs from exercising the runners without a maintainer go-ahead.

## What's in the PR

### 1. `ci(test)` — `/test`-comment trigger replaces auto-run on PR

The workflow's `on:` block drops `pull_request:` and adds `issue_comment: types: [created]`. A new `gate` job validates the run before any tests start:

- Checks the commenter has `write` / `maintain` / `admin` permission via `repos.getCollaboratorPermissionLevel`. Anything below `write` fails the gate immediately.
- Reacts to the triggering comment with 🚀 so the maintainer sees acknowledgement.
- Resolves the PR head SHA via `pulls.get` and exposes it as `outputs.sha`.

All four downstream jobs (`unit-tests`, `server-tests`, `e2e-tests`, `release-build-smoke`) now declare `needs: gate` and check out `${{ needs.gate.outputs.sha }}` instead of the default ref. For `push` / `workflow_dispatch` events the gate short-circuits and emits `context.sha`, so the existing post-merge / manual behavior is unchanged.

### 2. `ci(test)` — Commit-status reporting back to the PR head

`issue_comment`-triggered runs have `head_sha == main` by default, so the workflow run shows up in the **Actions** tab but not in the PR's **Checks** tab. Without remediation, you'd have to click through to Actions every time to see whether `/test` passed.

A new `report-status` job runs `if: always() && github.event_name == 'issue_comment'` after the four test jobs, iterates `needs.*.result`, and posts one commit status per context (`unit-tests`, `server-tests`, `e2e-tests`, `release-build-smoke`) on the PR head SHA via the Statuses API. Results then appear in the normal PR Checks UI.

## Test plan

- [ ] **Auto-trigger is gone:** open a PR without commenting `/test`. No test workflow run is created or executed.
- [ ] **`/test` triggers the run:** comment `/test` on a PR. Within seconds the gate adds a 🚀 reaction; within a minute or two the four test jobs start running.
- [ ] **Permission gating:** comment `/test` from a fork or read-only collaborator account — the gate job fails with a `not allowed to trigger CI` error, downstream jobs are skipped.
- [ ] **Status visibility:** after the run finishes, the PR's **Checks** tab shows four entries (`unit-tests`, `server-tests`, `e2e-tests`, `release-build-smoke`) with pass/fail/error status linking back to the workflow run.
- [ ] **Post-merge run still happens:** merge any PR; the existing `push: branches: [main]` trigger still fires the workflow on `main` post-merge.
- [ ] **`workflow_dispatch` still works:** trigger the workflow manually from the Actions tab.

## Files touched

1 file, **+136 / -3**. Only `.github/workflows/test.yml` is modified — no application code, no other workflows.

## Notes

- **Existing open PRs are not affected.** The `issue_comment` workflow definition is loaded from `main` at trigger time, so the behavior change kicks in only for runs that start after this PR merges. Branches with the old workflow on disk will still see `pull_request` triggers from their own copy of the file until they rebase.
- **Branch protection.** This repo's main-branch ruleset does NOT currently require status checks (only blocks deletion, force pushes, branch creation, and direct updates). If you add a required-checks rule later, the status names emitted by `report-status` are stable (`unit-tests`, `server-tests`, `e2e-tests`, `release-build-smoke`) and can be wired in directly.
- **`actionlint` clean.** No findings on the updated workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)