### PR TITLE
feat(presentation/screens): polish panel layout, rephrase toggle labels, default close-on-escape to OFF

### DIFF
--- a/app/apps/client/src/features/presentation/components/screen-manager/ScreenManager.tsx
+++ b/app/apps/client/src/features/presentation/components/screen-manager/ScreenManager.tsx
@@ -1,10 +1,10 @@
 import {
   AppWindow,
   Copy,
+  DoorClosed,
+  DoorOpen,
   Edit,
   ExternalLink,
-  Eye,
-  EyeOff,
   Loader2,
   MonitorUp,
   Pin,
@@ -308,31 +308,74 @@ export function ScreenManager() {
           {screens.map((screen) => (
             <div
               key={screen.id}
-              className="flex flex-col md:flex-row md:items-center md:justify-between gap-3 p-3 md:p-4 bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700"
+              className="flex flex-col gap-3 p-3 md:p-4 bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700"
             >
-              <div className="flex items-center gap-3 md:gap-4">
-                <div
-                  className={`w-3 h-3 rounded-full flex-shrink-0 ${
-                    screen.isActive ? 'bg-green-500' : 'bg-gray-400'
-                  }`}
-                />
-                <div className="min-w-0">
-                  <h3 className="font-medium text-gray-900 dark:text-white truncate">
-                    {screen.name}
-                  </h3>
-                  <div className="flex items-center gap-2 mt-1">
-                    <span
-                      className={`px-2 py-0.5 text-xs font-medium rounded-full text-white ${SCREEN_TYPE_COLORS[screen.type]}`}
-                    >
-                      {screen.type}
-                    </span>
-                    <span className="text-sm text-gray-500 dark:text-gray-400">
-                      {screen.width}×{screen.height}
-                    </span>
+              {/* Identity row: status + name/type + per-screen actions */}
+              <div className="flex flex-col md:flex-row md:items-start md:justify-between gap-3">
+                <div className="flex items-center gap-3 md:gap-4 min-w-0">
+                  <div
+                    className={`w-3 h-3 rounded-full flex-shrink-0 ${
+                      screen.isActive ? 'bg-green-500' : 'bg-gray-400'
+                    }`}
+                  />
+                  <div className="min-w-0">
+                    <h3 className="font-medium text-gray-900 dark:text-white truncate">
+                      {screen.name}
+                    </h3>
+                    <div className="flex items-center gap-2 mt-1">
+                      <span
+                        className={`px-2 py-0.5 text-xs font-medium rounded-full text-white ${SCREEN_TYPE_COLORS[screen.type]}`}
+                      >
+                        {screen.type}
+                      </span>
+                      <span className="text-sm text-gray-500 dark:text-gray-400">
+                        {screen.width}×{screen.height}
+                      </span>
+                    </div>
                   </div>
                 </div>
+                <div className="flex items-center gap-1 flex-shrink-0">
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => setExportScreen(screen)}
+                    title={t('sections.screens.export.title')}
+                  >
+                    <ExternalLink size={16} />
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => handleCopyUrl(screen)}
+                    title={t('sections.screens.actions.copyUrl')}
+                  >
+                    <Copy size={16} />
+                  </Button>
+                  <Button
+                    variant="secondary"
+                    size="sm"
+                    onClick={() => handleEdit(screen)}
+                    title={t('sections.screens.actions.edit')}
+                  >
+                    <Edit size={16} />
+                    <span className="ml-1">
+                      {t('sections.screens.actions.edit')}
+                    </span>
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => handleDelete(screen)}
+                    className="text-red-600 hover:text-red-700 hover:bg-red-50 dark:hover:bg-red-900/20"
+                    title={t('sections.screens.actions.delete')}
+                  >
+                    <Trash2 size={16} />
+                  </Button>
+                </div>
               </div>
-              <div className="flex items-center gap-2 flex-wrap">
+
+              {/* Toggle row: behavior controls, indented under the title */}
+              <div className="flex items-center gap-2 flex-wrap md:pl-7 pt-2 border-t border-gray-100 dark:border-gray-700/60">
                 <Button
                   variant={screen.isActive ? 'primary' : 'secondary'}
                   size="sm"
@@ -378,9 +421,9 @@ export function ScreenManager() {
                   title={t('sections.screens.closeOnEscape.tooltip')}
                 >
                   {screen.closeOnEscape ? (
-                    <EyeOff size={16} />
+                    <DoorClosed size={16} />
                   ) : (
-                    <Eye size={16} />
+                    <DoorOpen size={16} />
                   )}
                   <span className="ml-1">
                     {screen.closeOnEscape
@@ -388,45 +431,6 @@ export function ScreenManager() {
                       : t('sections.screens.closeOnEscape.off')}
                   </span>
                 </Button>
-                <div className="hidden md:block h-6 w-px bg-gray-200 dark:bg-gray-700" />
-                <div className="flex items-center gap-1">
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    onClick={() => setExportScreen(screen)}
-                    title={t('sections.screens.export.title')}
-                  >
-                    <ExternalLink size={16} />
-                  </Button>
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    onClick={() => handleCopyUrl(screen)}
-                    title={t('sections.screens.actions.copyUrl')}
-                  >
-                    <Copy size={16} />
-                  </Button>
-                  <Button
-                    variant="secondary"
-                    size="sm"
-                    onClick={() => handleEdit(screen)}
-                    title={t('sections.screens.actions.edit')}
-                  >
-                    <Edit size={16} />
-                    <span className="ml-1">
-                      {t('sections.screens.actions.edit')}
-                    </span>
-                  </Button>
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    onClick={() => handleDelete(screen)}
-                    className="text-red-600 hover:text-red-700 hover:bg-red-50 dark:hover:bg-red-900/20"
-                    title={t('sections.screens.actions.delete')}
-                  >
-                    <Trash2 size={16} />
-                  </Button>
-                </div>
               </div>
             </div>
           ))}

--- a/app/apps/client/src/i18n/locales/en/settings.json
+++ b/app/apps/client/src/i18n/locales/en/settings.json
@@ -713,26 +713,26 @@
       "addScreen": "Add Screen",
       "noScreens": "No screens configured",
       "window": {
-        "active": "Window Active",
-        "inactive": "Window Inactive",
-        "openTooltip": "Open display window",
-        "closeTooltip": "Close display window"
+        "active": "Show in a native window",
+        "inactive": "Show in a native window",
+        "openTooltip": "Open a native display window for this screen",
+        "closeTooltip": "Close the native display window for this screen"
       },
       "alwaysOnTop": {
-        "pin": "Enable always on top",
-        "unpin": "Disable always on top",
-        "enabled": "Always on Top",
-        "disabled": "Not on Top",
+        "pin": "Make this window stay on top of others",
+        "unpin": "Allow other windows to cover this one",
+        "enabled": "Always on top",
+        "disabled": "Normal stacking",
         "pinned": "Window set to always on top",
         "unpinned": "Window no longer always on top",
         "error": "Failed to update always on top setting"
       },
       "closeOnEscape": {
-        "tooltip": "Controls what happens to this screen's Tauri window when Escape is pressed. Content always clears (clock shows) — this toggle only affects the window itself. ON (default): window closes on Escape and auto-reopens on the next presentation. OFF: window stays open showing the clock.",
-        "on": "Close on Escape",
-        "off": "Keep on Escape",
-        "enabled": "Window will close on Escape",
-        "disabled": "Window will stay open on Escape",
+        "tooltip": "Controls whether this screen's native window closes when nothing is being displayed (after Escape / hide). The slide content always clears and the clock shows — this only controls the window itself. Default: window stays open.",
+        "on": "Close window when nothing is displayed",
+        "off": "Keep window open at all times",
+        "enabled": "Window will close when nothing is displayed",
+        "disabled": "Window will stay open at all times",
         "error": "Failed to update close-on-escape setting"
       },
       "actions": {

--- a/app/apps/client/src/i18n/locales/ro/settings.json
+++ b/app/apps/client/src/i18n/locales/ro/settings.json
@@ -714,26 +714,26 @@
       "addScreen": "Adaugă Ecran",
       "noScreens": "Niciun ecran configurat",
       "window": {
-        "active": "Fereastră Activă",
-        "inactive": "Fereastră Dezactivată",
-        "openTooltip": "Deschide fereastra de afișare",
-        "closeTooltip": "Închide fereastra de afișare"
+        "active": "Afișează într-o fereastră nativă",
+        "inactive": "Afișează într-o fereastră nativă",
+        "openTooltip": "Deschide o fereastră nativă pe acest ecran pentru a afișa conținutul",
+        "closeTooltip": "Închide fereastra nativă a acestui ecran"
       },
       "alwaysOnTop": {
-        "pin": "Activează mereu deasupra",
-        "unpin": "Dezactivează mereu deasupra",
-        "enabled": "Mereu Deasupra",
-        "disabled": "Normal",
+        "pin": "Ține această fereastră deasupra celorlalte",
+        "unpin": "Permite altor ferestre să o acopere",
+        "enabled": "Mereu deasupra",
+        "disabled": "Stivuire normală",
         "pinned": "Fereastra setată mereu deasupra",
         "unpinned": "Fereastra nu mai este mereu deasupra",
         "error": "Nu s-a putut actualiza setarea"
       },
       "closeOnEscape": {
-        "tooltip": "Controlează ce se întâmplă cu fereastra Tauri a acestui ecran la Escape. Conținutul se șterge mereu (apare ceasul) — toggle-ul afectează doar fereastra. ON (default): fereastra se închide la Escape și se redeschide automat la următoarea prezentare. OFF: fereastra rămâne deschisă cu ceasul.",
-        "on": "Se închide pe Escape",
-        "off": "Rămâne pe Escape",
-        "enabled": "Fereastra se va închide la Escape",
-        "disabled": "Fereastra va rămâne deschisă la Escape",
+        "tooltip": "Controlează dacă fereastra nativă a acestui ecran se închide când nu este afișat ceva (după Escape / hide). Conținutul se șterge mereu și apare ceasul — această opțiune controlează doar fereastra în sine. Implicit: fereastra rămâne deschisă.",
+        "on": "Închide fereastra când nu este afișat ceva",
+        "off": "Păstrează fereastra deschisă tot timpul",
+        "enabled": "Fereastra se va închide când nu este afișat ceva",
+        "disabled": "Fereastra va rămâne deschisă tot timpul",
         "error": "Nu s-a putut actualiza setarea"
       },
       "actions": {

--- a/app/apps/server/src/db/migrations/add-close-on-escape.ts
+++ b/app/apps/server/src/db/migrations/add-close-on-escape.ts
@@ -8,25 +8,32 @@ function log(level: 'debug' | 'info' | 'warning' | 'error', message: string) {
   console.log(`[add-close-on-escape:${level}] ${message}`)
 }
 
-const MIGRATION_KEY = 'add_close_on_escape_v1'
+const MIGRATION_KEY_V1 = 'add_close_on_escape_v1'
+const MIGRATION_KEY_V2 = 'add_close_on_escape_v2_default_off'
 
 /**
- * Add close_on_escape column to screens table (default true).
+ * Add close_on_escape column to screens table (default false).
  * When true, the screen's Tauri window closes on Escape and re-opens on the
- * next presentation. When false, the window stays open showing the clock.
+ * next presentation. When false (default), the window stays open showing
+ * the clock.
  *
- * Also migrates from the earlier `keep_visible_on_escape` column if present:
- * inverts the values (NOT keep_visible) and drops the legacy column.
+ * Migration history:
+ *  - v1: introduced close_on_escape with DEFAULT 1. Also migrated from the
+ *    earlier `keep_visible_on_escape` column (inverted semantics).
+ *  - v2: flipped the default to 0 (stay open). On databases where v1 was
+ *    already applied, all existing rows are reset to 0 to match the new
+ *    default behavior (the feature was brand new and not yet tuned per
+ *    screen).
  */
 export function addCloseOnEscape(db: Database): void {
-  const migrationApplied = db
+  const v2Applied = db
     .query<{ count: number }, [string]>(
       'SELECT COUNT(*) as count FROM app_settings WHERE key = ?',
     )
-    .get(MIGRATION_KEY)?.count
+    .get(MIGRATION_KEY_V2)?.count
 
-  if (migrationApplied && migrationApplied > 0) {
-    log('debug', 'Migration already applied, skipping')
+  if (v2Applied && v2Applied > 0) {
+    log('debug', 'Migration v2 already applied, skipping')
     return
   }
 
@@ -38,9 +45,9 @@ export function addCloseOnEscape(db: Database): void {
   const hasOld = columns.some((col) => col.name === 'keep_visible_on_escape')
 
   if (!hasNew) {
-    log('info', 'Adding "close_on_escape" column (default 1)...')
+    log('info', 'Adding "close_on_escape" column (default 0)...')
     db.run(
-      'ALTER TABLE screens ADD COLUMN close_on_escape INTEGER NOT NULL DEFAULT 1',
+      'ALTER TABLE screens ADD COLUMN close_on_escape INTEGER NOT NULL DEFAULT 0',
     )
   }
 
@@ -64,9 +71,27 @@ export function addCloseOnEscape(db: Database): void {
     }
   }
 
+  const v1Applied = db
+    .query<{ count: number }, [string]>(
+      'SELECT COUNT(*) as count FROM app_settings WHERE key = ?',
+    )
+    .get(MIGRATION_KEY_V1)?.count
+
+  if (v1Applied && v1Applied > 0) {
+    log(
+      'info',
+      'Resetting existing screens to close_on_escape = 0 (v2 default flip)...',
+    )
+    db.run('UPDATE screens SET close_on_escape = 0')
+  }
+
   db.run(
     'INSERT OR REPLACE INTO app_settings (key, value, created_at, updated_at) VALUES (?, ?, unixepoch(), unixepoch())',
-    [MIGRATION_KEY, JSON.stringify({ success: true })],
+    [MIGRATION_KEY_V1, JSON.stringify({ success: true })],
+  )
+  db.run(
+    'INSERT OR REPLACE INTO app_settings (key, value, created_at, updated_at) VALUES (?, ?, unixepoch(), unixepoch())',
+    [MIGRATION_KEY_V2, JSON.stringify({ success: true })],
   )
 
   log('info', 'close_on_escape migration complete')

--- a/app/apps/server/src/db/schema/presentation.ts
+++ b/app/apps/server/src/db/schema/presentation.ts
@@ -42,7 +42,7 @@ export const screens = sqliteTable(
       .default(false),
     closeOnEscape: integer('close_on_escape', { mode: 'boolean' })
       .notNull()
-      .default(true),
+      .default(false),
     width: integer('width').notNull().default(1920),
     height: integer('height').notNull().default(1080),
     globalSettings: text('global_settings').notNull().default('{}'),

--- a/app/apps/server/src/openapi/schemas/screens.ts
+++ b/app/apps/server/src/openapi/schemas/screens.ts
@@ -113,7 +113,7 @@ export const screenSchemas = {
       closeOnEscape: {
         type: 'boolean',
         description:
-          'If true (default), the screen Tauri window closes on Escape and re-opens on the next presentation. If false, the window stays open showing the clock.',
+          'If true, the screen Tauri window closes on Escape and re-opens on the next presentation. If false (default), the window stays open showing the clock.',
       },
       width: { type: 'integer', description: 'Screen width in pixels' },
       height: { type: 'integer', description: 'Screen height in pixels' },

--- a/app/apps/server/src/service/presentation/screens.ts
+++ b/app/apps/server/src/service/presentation/screens.ts
@@ -572,7 +572,7 @@ export function upsertScreen(input: UpsertScreenInput): Screen | null {
         openMode,
         isFullscreen: input.isFullscreen === true,
         alwaysOnTop: input.alwaysOnTop === true,
-        closeOnEscape: input.closeOnEscape !== false,
+        closeOnEscape: input.closeOnEscape === true,
         width,
         height,
         globalSettings: globalSettingsJson,


### PR DESCRIPTION
## Summary

Follow-up polish on the close-on-escape feature shipped in PR #9. Three coordinated changes in a single commit:

1. **Default flip:** `closeOnEscape` defaults to `false` (keep window open) instead of `true`. Field testing showed users were surprised that display windows closed on Escape — most setups want the window to persist across the worship flow. Migration v2 also resets every existing row's value to `0` since the feature was brand new in PR #9 and not yet tuned per screen.
2. **Panel layout:** `ScreenManager` rows split into an *identity row* (status dot + name + type + dimensions + Export / CopyUrl / Edit / Delete) and a *separate actions row* for the three main toggle buttons. No more wrap-on-mid-width.
3. **Toggle labels:** rewritten across en/ro. The labels now describe the visible effect rather than the mechanism — "Window Active" → "Show in a native window"; "Close on Escape" → "Close window when nothing is displayed". Eye/EyeOff icons replaced with DoorOpen/DoorClosed (a closed door reads as "window closes" more obviously than a crossed-out eye).

## What's in the PR

### 1. `feat(presentation/screens)` — Polish panel layout, rephrase toggle labels, default close-on-escape to OFF

- `ScreenManager.tsx` (+68 / -64): two-row layout, ghost action buttons moved next to the identity, primary toggles isolated below.
- `i18n/locales/{en,ro}/settings.json` (+13 / -13 each): rewritten window, alwaysOnTop, closeOnEscape labels & tooltips.
- `db/schema/presentation.ts`: `close_on_escape` default `true` → `false`.
- `db/migrations/add-close-on-escape.ts`: new v2 step `add_close_on_escape_v2_default_off` that flips the column default and resets existing rows to `0` on databases that already applied v1. Idempotent (early-return if v2 key already in `app_settings`).
- `openapi/schemas/screens.ts`: description rewritten to reflect the new default.
- `service/presentation/screens.ts`: upsert reads `input.closeOnEscape === true` instead of `!== false`, so an omitted field now resolves to `false` to match the new semantics.

[![screens-panel polish demo](https://github.com/radio-crestin/church-hub/releases/download/pr-demos-screens-panel-polish/c8b17764-screens-panel-polish.gif)](https://github.com/radio-crestin/church-hub/releases/download/pr-demos-screens-panel-polish/c8b17764-screens-panel-polish.webm)

## Test plan

- [ ] **Layout:** Settings → screens panel. Each row has identity (status dot + name + type + dimensions + Export/CopyUrl/Edit/Delete ghost buttons) on top and the three main toggle buttons (Window / AlwaysOnTop / CloseOnEscape) on a second row. Nothing wraps on a 1280px viewport.
- [ ] **Labels:** the Window toggle reads "Show in a native window" (en) / equivalent (ro); the CloseOnEscape toggle reads "Close window when nothing is displayed" or "Keep window open at all times" depending on its state.
- [ ] **Icons:** the CloseOnEscape toggle shows DoorClosed when ON and DoorOpen when OFF.
- [ ] **Default flip on fresh install:** new screens created via Settings → Add Screen have `closeOnEscape = false`. The toggle initially reads "Keep window open at all times".
- [ ] **Migration v2 reset:** existing databases that applied v1 (had `closeOnEscape = true` per-row) come up after this PR with every row at `closeOnEscape = false`. The `app_settings` table contains both `add_close_on_escape_v1` and `add_close_on_escape_v2_default_off` keys.
- [ ] **Re-run safety:** restarting the app does not reapply the v2 reset (idempotency check via `app_settings` key).
- [ ] **End-to-end behavior:** with toggle OFF (default), present a slide → press Escape → content clears to clock, window stays open. Toggle ON → press Escape → content clears AND window closes; click next slide → window reopens automatically (existing PR #9 auto-reopen still works).

## Files touched

7 files, **+134 / -105**. No removed features, no breaking API changes — `Screen` and `UpsertScreenInput` shapes unchanged, only the default value flipped.
