### PR TITLE
fix(songs/search): exact-title queries match + clitic contractions render inside highlight

### DIFF
--- a/app/apps/server/src/db/migrations/index.ts
+++ b/app/apps/server/src/db/migrations/index.ts
@@ -8,6 +8,7 @@ import { EMBEDDED_MIGRATIONS } from './embedded'
 import { extractKeylinesFromSlides } from './extract-keylines-from-slides'
 import { migrateMidiDeviceByName } from './migrate-midi-device-by-name'
 import { migrateShortcuts } from './migrate-shortcuts'
+import { rebuildFtsForSingleCharFix } from './rebuild-fts-single-char-fix'
 import { seedSystemRoles } from './seed'
 import { seedBibleTranslations } from './seed-bibles'
 import { seedSampleMusic } from './seed-music'
@@ -209,6 +210,14 @@ export function runMigrations(
   t = performance.now()
   seedSampleMusic(rawDb)
   logTiming('seed_sample_music', t)
+
+  // One-shot rebuild of the FTS index after single-char tokens were filtered
+  // out of normalizeForIndex (must run AFTER seed-songs so the rebuild has
+  // something to index). Skipped on subsequent boots via app_settings flag.
+  log('info', 'Running FTS single-char rebuild migration...')
+  t = performance.now()
+  rebuildFtsForSingleCharFix(rawDb)
+  logTiming('rebuild_fts_single_char_fix', t)
 
   return { ftsRecreated: ftsCreated }
 }

--- a/app/apps/server/src/db/migrations/rebuild-fts-single-char-fix.ts
+++ b/app/apps/server/src/db/migrations/rebuild-fts-single-char-fix.ts
@@ -1,0 +1,65 @@
+import type { Database } from 'bun:sqlite'
+
+import { rebuildSearchIndex } from '../../service/songs/search'
+
+const DEBUG = process.env.DEBUG === 'true'
+
+function log(level: 'debug' | 'info' | 'warning' | 'error', message: string) {
+  if (level === 'debug' && !DEBUG) return
+  // biome-ignore lint/suspicious/noConsole: migration logging
+  console.log(`[migrate-fts-single-char:${level}] ${message}`)
+}
+
+const MIGRATION_KEY = 'rebuild_fts_single_char_fix_v1'
+
+/**
+ * One-shot rebuild of the FTS index after normalizeForIndex was changed to
+ * drop single-character tokens.
+ *
+ * Existing rows in `songs_fts` were tokenized as e.g. "cand isus hristos m a
+ * mantuit" — the `m` and `a` between `Hristos` and `mantuit` made it
+ * impossible for `calculateTitleScoreNormalized` to detect the user's exact
+ * phrase "cand isus hristos mantuit". Rebuilding regenerates every row with
+ * the new tokenization.
+ *
+ * Safe to skip when no songs have been indexed yet (fresh install hitting
+ * seedSongs followed by initial index build will already use the fixed
+ * normalizer).
+ */
+export function rebuildFtsForSingleCharFix(db: Database): void {
+  const applied = db
+    .query<{ count: number }, [string]>(
+      'SELECT COUNT(*) as count FROM app_settings WHERE key = ?',
+    )
+    .get(MIGRATION_KEY)?.count
+
+  if (applied && applied > 0) {
+    log('debug', 'FTS single-char rebuild already applied, skipping')
+    return
+  }
+
+  const ftsRowCount = db
+    .query<{ count: number }, []>('SELECT COUNT(*) as count FROM songs_fts')
+    .get()?.count
+
+  if (!ftsRowCount || ftsRowCount === 0) {
+    log('info', 'FTS index empty, nothing to rebuild — marking complete')
+    markComplete(db, { rebuilt: false, reason: 'empty_index' })
+    return
+  }
+
+  log('info', `Rebuilding FTS index for ${ftsRowCount} song row(s)...`)
+  rebuildSearchIndex()
+  log('info', 'FTS rebuild complete')
+  markComplete(db, { rebuilt: true, rowCount: ftsRowCount })
+}
+
+function markComplete(
+  db: Database,
+  result: { rebuilt: boolean; rowCount?: number; reason?: string },
+): void {
+  db.run(
+    'INSERT OR REPLACE INTO app_settings (key, value, created_at, updated_at) VALUES (?, ?, unixepoch(), unixepoch())',
+    [MIGRATION_KEY, JSON.stringify(result)],
+  )
+}

--- a/app/apps/server/src/db/migrations/rebuild-fts-single-char-fix.ts
+++ b/app/apps/server/src/db/migrations/rebuild-fts-single-char-fix.ts
@@ -10,21 +10,19 @@ function log(level: 'debug' | 'info' | 'warning' | 'error', message: string) {
   console.log(`[migrate-fts-single-char:${level}] ${message}`)
 }
 
-const MIGRATION_KEY = 'rebuild_fts_single_char_fix_v1'
+// Bumped from v1 → v2 because the v1 rebuild dropped single-char tokens
+// from the index ("cand isus hristos m a mantuit" → "cand isus hristos
+// mantuit"), which lost linguistic signal for Romanian clitics. The v2
+// rebuild reinstates them — single chars now flow through normalizeForIndex
+// untouched and are filtered defensively only where they cause noise (the
+// broad-OR tier of buildSearchQuery + meaningful-term denominator in the
+// title score). Any dev DB that already ran v1 still needs this re-rebuild.
+const MIGRATION_KEY = 'rebuild_fts_clitic_aware_v2'
 
 /**
- * One-shot rebuild of the FTS index after normalizeForIndex was changed to
- * drop single-character tokens.
- *
- * Existing rows in `songs_fts` were tokenized as e.g. "cand isus hristos m a
- * mantuit" — the `m` and `a` between `Hristos` and `mantuit` made it
- * impossible for `calculateTitleScoreNormalized` to detect the user's exact
- * phrase "cand isus hristos mantuit". Rebuilding regenerates every row with
- * the new tokenization.
- *
- * Safe to skip when no songs have been indexed yet (fresh install hitting
- * seedSongs followed by initial index build will already use the fixed
- * normalizer).
+ * Re-runs rebuildSearchIndex once with the current normalizeForIndex so the
+ * FTS table reflects the source-of-truth tokenisation rules. Skipped on
+ * subsequent boots via the app_settings flag.
  */
 export function rebuildFtsForSingleCharFix(db: Database): void {
   const applied = db

--- a/app/apps/server/src/service/songs/search.test.ts
+++ b/app/apps/server/src/service/songs/search.test.ts
@@ -177,14 +177,12 @@ describe('highlightWithDiacritics - hyphenated word coverage', () => {
     // User-reported: searching "m-am departat de mantuitorul" only
     // highlighted "am departat de mantuitorul" — the "m-" prefix was
     // cut off because "m" is dropped from search tokens as noise.
-    // The highlighter should still cover the whole "m-am".
+    // The whole phrase (including the clitic prefix) lands in one mark.
     const out = highlightWithDiacritics(
       'M-am departat de Mantuitorul',
       ['am', 'departat', 'de', 'mantuitorul'],
     )
-    expect(out).toContain('<mark>M-am</mark>')
-    expect(out).toContain('<mark>departat</mark>')
-    expect(out).toContain('<mark>Mantuitorul</mark>')
+    expect(out).toBe('<mark>M-am departat de Mantuitorul</mark>')
     // Crucially the "M-" prefix is INSIDE the mark, not outside it
     expect(out).not.toMatch(/M-<mark>am<\/mark>/)
   })
@@ -206,21 +204,46 @@ describe('highlightWithDiacritics - hyphenated word coverage', () => {
     expect(out).toBe('<mark>Isus</mark> mantuitor')
   })
 
+  test('swallows a mid-phrase clitic ("m-a") into the merged mark', () => {
+    // User-reported: in "Cand Isus Hristos m-a mantuit", the "m-a"
+    // sits between two matched terms and was left un-marked even
+    // though it visibly belongs to the same phrase. With clitic-gap
+    // merging it should land inside the same <mark> as its neighbours.
+    const out = highlightWithDiacritics(
+      'Cand Isus Hristos m-a mantuit',
+      ['cand', 'isus', 'hristos', 'mantuit'],
+    )
+    expect(out).toContain('<mark>Cand Isus Hristos m-a mantuit</mark>')
+    // Sanity: only ONE pair of mark tags in the output
+    expect(out.match(/<mark>/g)?.length).toBe(1)
+  })
+
+  test('does not swallow plain words between matches ("a" without hyphen stays out)', () => {
+    // "a" is a Romanian particle, not a clitic contraction. The merger
+    // must only bridge across hyphenated connectors so we don't blob
+    // unrelated content together.
+    const out = highlightWithDiacritics('Isus a inviat din morti', [
+      'isus',
+      'inviat',
+    ])
+    expect(out).not.toContain('<mark>Isus a inviat</mark>')
+    expect(out).toContain('<mark>Isus</mark>')
+    expect(out).toContain('<mark>inviat</mark>')
+  })
+
   test('does not nest <mark> tags when a shorter term overlaps a longer one', () => {
     // Pre-existing artefact: searching "m-am departat de mantuitorul"
     // produced "<mark><mark>depărtat</mark></mark>" because the regex
     // for "de" greedily matched the whole "depărtat" already wrapped by
     // the "departat" term. The single-pass + merge implementation must
-    // collapse this.
+    // collapse this into one flat mark.
     const out = highlightWithDiacritics(
       'M-am depărtat de Mântuitorul',
       ['am', 'departat', 'de', 'mantuitorul'],
     )
     expect(out).not.toMatch(/<mark><mark>/)
     expect(out).not.toMatch(/<\/mark><\/mark>/)
-    expect(out).toContain('<mark>M-am</mark>')
-    expect(out).toContain('<mark>depărtat</mark>')
-    expect(out).toContain('<mark>Mântuitorul</mark>')
+    expect(out).toBe('<mark>M-am depărtat de Mântuitorul</mark>')
   })
 })
 

--- a/app/apps/server/src/service/songs/search.test.ts
+++ b/app/apps/server/src/service/songs/search.test.ts
@@ -2,8 +2,10 @@ import {
   buildSearchQuery,
   calculateBestPhraseScoreNormalized,
   calculateTitleScoreNormalized,
+  createFuzzyHighlightedSnippet,
   extractSearchTerms,
   getValidTerms,
+  highlightWithDiacritics,
   normalizeForIndex,
 } from './search'
 import { describe, expect, test } from 'bun:test'
@@ -167,6 +169,82 @@ describe('normalizeForIndex - HTML tag stripping', () => {
     // "A" (Romanian article) is dropped as a single-char noise token;
     // the rest of the second clause is preserved.
     expect(normalized).toContain('noastra nelegiuire')
+  })
+})
+
+describe('highlightWithDiacritics - hyphenated word coverage', () => {
+  test('extends highlight backward across a clitic prefix ("m-am")', () => {
+    // User-reported: searching "m-am departat de mantuitorul" only
+    // highlighted "am departat de mantuitorul" — the "m-" prefix was
+    // cut off because "m" is dropped from search tokens as noise.
+    // The highlighter should still cover the whole "m-am".
+    const out = highlightWithDiacritics(
+      'M-am departat de Mantuitorul',
+      ['am', 'departat', 'de', 'mantuitorul'],
+    )
+    expect(out).toContain('<mark>M-am</mark>')
+    expect(out).toContain('<mark>departat</mark>')
+    expect(out).toContain('<mark>Mantuitorul</mark>')
+    // Crucially the "M-" prefix is INSIDE the mark, not outside it
+    expect(out).not.toMatch(/M-<mark>am<\/mark>/)
+  })
+
+  test('extends across hyphen-joined chunks with diacritics ("te-aşteptăm")', () => {
+    const out = highlightWithDiacritics('Isus te-aşteptăm vino', ['asteptam'])
+    expect(out).toContain('<mark>te-aşteptăm</mark>')
+  })
+
+  test('extends forward across a trailing hyphen segment ("Te-aşteptăm" forward case)', () => {
+    // term "te" should sweep up the whole "Te-aşteptăm" forward
+    const out = highlightWithDiacritics('Te-aşteptăm Doamne', ['te'])
+    expect(out).toContain('<mark>Te-aşteptăm</mark>')
+  })
+
+  test('still highlights plain words without altering them', () => {
+    const out = highlightWithDiacritics('Isus mantuitor', ['isus'])
+    expect(out).toContain('<mark>Isus</mark>')
+    expect(out).toBe('<mark>Isus</mark> mantuitor')
+  })
+
+  test('does not nest <mark> tags when a shorter term overlaps a longer one', () => {
+    // Pre-existing artefact: searching "m-am departat de mantuitorul"
+    // produced "<mark><mark>depărtat</mark></mark>" because the regex
+    // for "de" greedily matched the whole "depărtat" already wrapped by
+    // the "departat" term. The single-pass + merge implementation must
+    // collapse this.
+    const out = highlightWithDiacritics(
+      'M-am depărtat de Mântuitorul',
+      ['am', 'departat', 'de', 'mantuitorul'],
+    )
+    expect(out).not.toMatch(/<mark><mark>/)
+    expect(out).not.toMatch(/<\/mark><\/mark>/)
+    expect(out).toContain('<mark>M-am</mark>')
+    expect(out).toContain('<mark>depărtat</mark>')
+    expect(out).toContain('<mark>Mântuitorul</mark>')
+  })
+})
+
+describe('createFuzzyHighlightedSnippet - hyphenated word coverage', () => {
+  test('snippet highlight covers the whole "m-am" chunk, not just "am"', () => {
+    const snippet = createFuzzyHighlightedSnippet(
+      'Cantam: m-am departat de Mantuitorul, dar acum revin.',
+      ['am', 'departat', 'mantuitorul'],
+    )
+    // The existing merge step fuses adjacent matches separated only by
+    // whitespace, so checking the exact "<mark>m-am</mark>" boundary is
+    // wrong here — what matters is that the "m-" prefix is INSIDE a mark.
+    expect(snippet).not.toMatch(/m-<mark>/)
+    // The clitic + adjacent matches should all land inside a single mark
+    expect(snippet).toContain('<mark>m-am departat</mark>')
+  })
+
+  test('snippet without merge: standalone "m-am" sweeps both letters', () => {
+    const snippet = createFuzzyHighlightedSnippet(
+      'Cuvinte m-am altele neutre.',
+      ['am'],
+    )
+    expect(snippet).toContain('<mark>m-am</mark>')
+    expect(snippet).not.toMatch(/m-<mark>am<\/mark>/)
   })
 })
 

--- a/app/apps/server/src/service/songs/search.test.ts
+++ b/app/apps/server/src/service/songs/search.test.ts
@@ -39,22 +39,25 @@ describe('extractSearchTerms', () => {
     expect(isusCount).toBe(1)
   })
 
-  test('drops single-character tokens (numeric prefix + "m-a" splits)', () => {
-    // Regression: user-reported query "1. Cand Isus Hristos m-a mantuit"
-    // used to tokenize as ["1","cand","isus","hristos","m","a","mantuit"],
-    // and those single chars then polluted both the FTS query (prefix
-    // expansions like "m"*) and the title-order scoring. Only meaningful
-    // tokens should remain.
+  test('strips leading hymn-number-style prefix but keeps clitic single chars', () => {
+    // User-reported regression: "1. Cand Isus Hristos m-a mantuit" must
+    // still match the song titled "Cand Isus Hristos m-a mantuit". The
+    // leading "1." is a hymn number that the user remembers — drop it
+    // from the query. The "m" and "a" from "m-a", however, are clitic
+    // tokens that need to survive so the title phrase still matches.
     expect(
       extractSearchTerms('1. Cand Isus Hristos m-a mantuit'),
-    ).toEqual(['cand', 'isus', 'hristos', 'mantuit'])
+    ).toEqual(['cand', 'isus', 'hristos', 'm', 'a', 'mantuit'])
   })
 
-  test('returns empty for input that boils down to single chars only', () => {
-    // Calling code in buildSearchQuery already short-circuits on empty
-    // term lists; this just pins the behaviour.
-    expect(extractSearchTerms('a o')).toEqual([])
-    expect(extractSearchTerms('1 2 3')).toEqual([])
+  test('strips hymn-number prefixes with various separators', () => {
+    expect(extractSearchTerms('265. Cantarea')).toEqual(['cantarea'])
+    expect(extractSearchTerms('34 - Cantarea')).toEqual(['cantarea'])
+    expect(extractSearchTerms('  001  Cantarea')).toEqual(['cantarea'])
+  })
+
+  test('does NOT strip internal numbers', () => {
+    expect(extractSearchTerms('Psalmul 23 si Isus')).toContain('23')
   })
 })
 
@@ -91,51 +94,53 @@ describe('normalizeForIndex', () => {
     expect(normalized).not.toContain(';')
   })
 
-  test('drops single-character tokens so title phrase matching survives "m-a"', () => {
-    // Regression: title "Cand Isus Hristos m-a mantuit" used to tokenize as
-    // "cand isus hristos m a mantuit". A user query for the same title then
-    // could never see the exact phrase in the normalized index because of
-    // the stray "m" and "a" tokens between "hristos" and "mantuit".
+  test('keeps the clitic single-letter tokens so "m-a" becomes "m a" in the index', () => {
+    // Single-character tokens stay in the index alongside meaningful
+    // words. With the matching query (after extractSearchTerms strips
+    // its hymn-number prefix) preserving those same tokens, FTS phrase
+    // matching can land directly on the title.
     const normalized = normalizeForIndex('Cand Isus Hristos m-a mantuit')
-    expect(normalized).toBe('Cand Isus Hristos mantuit')
-    expect(normalized.toLowerCase()).toContain('cand isus hristos mantuit')
+    expect(normalized).toBe('Cand Isus Hristos m a mantuit')
   })
 })
 
 describe('buildSearchQuery', () => {
-  test('reported regression: "1. Cand Isus Hristos m-a mantuit" emits a title-restricted phrase tier so the song can outrank synonym noise', () => {
-    // The TODO.md "Căutarea nu găsește …" bug. After normalizeForIndex and
-    // extractSearchTerms drop single chars, the joined phrase becomes
-    // "cand isus hristos mantuit" — and that exact phrase needs to appear
-    // restricted to the `title` column so BM25 lifts the matching song
-    // even when synonym expansion (hristos → cristos) widens the broad OR
-    // tier to 20k+ candidates.
+  test('reported regression: "1. Cand Isus Hristos m-a mantuit" emits a title-restricted phrase with the clitic tokens preserved', () => {
+    // The TODO.md "Căutarea nu găsește …" bug. extractSearchTerms strips
+    // the leading hymn-number prefix ("1.") but keeps the clitic tokens
+    // (m / a from "m-a"), so the title clause exactly matches the indexed
+    // title "cand isus hristos m a mantuit".
     const q = buildSearchQuery('1. Cand Isus Hristos m-a mantuit')
-    expect(q).toContain('title:"cand isus hristos mantuit"')
-    // Other tiers still present for fuzzy / content matches
+    expect(q).toContain('title:"cand isus hristos m a mantuit"')
+    // Single-character clitic tokens stay in the phrase + NEAR tiers …
+    expect(q).toContain('("cand isus hristos m a mantuit")')
     expect(q).toContain('NEAR(')
+    // … but are excluded from the prefix-broad OR (no "m"* / "a"*).
     expect(q).toContain('"cand"*')
+    expect(q).not.toMatch(/"m"\*/)
+    expect(q).not.toMatch(/"a"\*/)
   })
 
-  test('synonym-expanded query keeps the title-restricted clause on the original terms only', () => {
+  test('synonym-expanded query keeps the title clause on the original terms only', () => {
     // Caller appends a synonym (e.g. cristos) to queryText, but passes the
     // pre-expansion terms via the originalTerms arg so the title clause
     // doesn't require the synonym word to appear in the title.
-    const q = buildSearchQuery('cand isus hristos mantuit cristos', [
+    const q = buildSearchQuery('cand isus hristos m a mantuit cristos', [
       'cand',
       'isus',
       'hristos',
+      'm',
+      'a',
       'mantuit',
     ])
-    expect(q).toContain('title:"cand isus hristos mantuit"')
-    expect(q).not.toContain('title:"cand isus hristos mantuit cristos"')
-    // Broad / phrase tiers still use the full expanded set
+    expect(q).toContain('title:"cand isus hristos m a mantuit"')
+    expect(q).not.toContain('title:"cand isus hristos m a mantuit cristos"')
+    // Broad-OR tier still uses the expanded set (sans single chars)
     expect(q).toContain('"cristos"*')
   })
 
   test('omits title-restricted clause when only one meaningful term', () => {
     const q = buildSearchQuery('Isus')
-    // single-term path returns just a prefix match, no need for title clause
     expect(q).toBe('"isus"*')
   })
 })
@@ -166,108 +171,121 @@ describe('normalizeForIndex - HTML tag stripping', () => {
     // Should not contain "p" tokens from <p> tags
     expect(normalized).not.toMatch(/\bp\b/)
     expect(normalized).toContain('Sa ne speli de orice pacat')
-    // "A" (Romanian article) is dropped as a single-char noise token;
-    // the rest of the second clause is preserved.
-    expect(normalized).toContain('noastra nelegiuire')
+    // The Romanian article "A" survives — single-char tokens are kept in
+    // the index (they carry phrase signal for clitic contractions).
+    expect(normalized).toContain('A noastra nelegiuire')
   })
 })
 
-describe('highlightWithDiacritics - hyphenated word coverage', () => {
-  test('extends highlight backward across a clitic prefix ("m-am")', () => {
-    // User-reported: searching "m-am departat de mantuitorul" only
-    // highlighted "am departat de mantuitorul" — the "m-" prefix was
-    // cut off because "m" is dropped from search tokens as noise.
-    // The whole phrase (including the clitic prefix) lands in one mark.
-    const out = highlightWithDiacritics(
-      'M-am departat de Mantuitorul',
-      ['am', 'departat', 'de', 'mantuitorul'],
+describe('highlightWithDiacritics - literal-substring path (rawQuery)', () => {
+  test('marks exactly the typed phrase as the user incrementally types', () => {
+    // The user's mental model: yellow highlight = literal substring of
+    // what I typed. Title and content snippets must agree on this.
+    const title = 'Cand Isus Hristos m-a mantuit'
+    // …Cand Isus Hristos m
+    expect(highlightWithDiacritics(title, [], 'Cand Isus Hristos m')).toBe(
+      '<mark>Cand Isus Hristos m</mark>-a mantuit',
     )
-    expect(out).toBe('<mark>M-am departat de Mantuitorul</mark>')
-    // Crucially the "M-" prefix is INSIDE the mark, not outside it
-    expect(out).not.toMatch(/M-<mark>am<\/mark>/)
+    // …Cand Isus Hristos m-
+    expect(highlightWithDiacritics(title, [], 'Cand Isus Hristos m-')).toBe(
+      '<mark>Cand Isus Hristos m-</mark>a mantuit',
+    )
+    // …Cand Isus Hristos m-a
+    expect(highlightWithDiacritics(title, [], 'Cand Isus Hristos m-a')).toBe(
+      '<mark>Cand Isus Hristos m-a</mark> mantuit',
+    )
+    // …Cand Isus Hristos m-a mantuit (full phrase)
+    expect(
+      highlightWithDiacritics(title, [], 'Cand Isus Hristos m-a mantuit'),
+    ).toBe('<mark>Cand Isus Hristos m-a mantuit</mark>')
   })
 
-  test('extends across hyphen-joined chunks with diacritics ("te-aşteptăm")', () => {
-    const out = highlightWithDiacritics('Isus te-aşteptăm vino', ['asteptam'])
-    expect(out).toContain('<mark>te-aşteptăm</mark>')
+  test('literal substring is diacritic-insensitive and strips the leading hymn-number prefix', () => {
+    const title = 'Când Isus Hristos m-a mântuit'
+    // Stripped diacritics in the query still pick up the title diacritics
+    expect(highlightWithDiacritics(title, [], 'cand isus hristos m-a')).toBe(
+      '<mark>Când Isus Hristos m-a</mark> mântuit',
+    )
+    // Leading hymn-number prefix is dropped for the highlight too
+    expect(
+      highlightWithDiacritics(title, [], '1. cand isus hristos m-a'),
+    ).toBe('<mark>Când Isus Hristos m-a</mark> mântuit')
   })
 
-  test('extends forward across a trailing hyphen segment ("Te-aşteptăm" forward case)', () => {
-    // term "te" should sweep up the whole "Te-aşteptăm" forward
-    const out = highlightWithDiacritics('Te-aşteptăm Doamne', ['te'])
-    expect(out).toContain('<mark>Te-aşteptăm</mark>')
+  test('"m-am departat de Mântuitorul" marks exactly that phrase', () => {
+    const title = 'M-am depărtat de Mântuitorul ce m-a salvat'
+    const out = highlightWithDiacritics(title, [], 'm-am departat de mantuitorul')
+    // M- prefix is included; trailing "ce m-a salvat" is not touched.
+    expect(out).toBe('<mark>M-am depărtat de Mântuitorul</mark> ce m-a salvat')
   })
+})
 
-  test('still highlights plain words without altering them', () => {
-    const out = highlightWithDiacritics('Isus mantuitor', ['isus'])
-    expect(out).toContain('<mark>Isus</mark>')
-    expect(out).toBe('<mark>Isus</mark> mantuitor')
-  })
-
-  test('swallows a mid-phrase clitic ("m-a") into the merged mark', () => {
-    // User-reported: in "Cand Isus Hristos m-a mantuit", the "m-a"
-    // sits between two matched terms and was left un-marked even
-    // though it visibly belongs to the same phrase. With clitic-gap
-    // merging it should land inside the same <mark> as its neighbours.
+describe('highlightWithDiacritics - per-term fallback', () => {
+  test('falls back to per-term when the typed phrase is not a literal substring', () => {
+    // "isus mantuit" is not contiguous in the title, so per-term marks
+    // each term independently (no clitic gap to bridge across "hristos m-a").
     const out = highlightWithDiacritics(
       'Cand Isus Hristos m-a mantuit',
-      ['cand', 'isus', 'hristos', 'mantuit'],
+      ['isus', 'mantuit'],
+      'isus mantuit',
     )
-    expect(out).toContain('<mark>Cand Isus Hristos m-a mantuit</mark>')
-    // Sanity: only ONE pair of mark tags in the output
-    expect(out.match(/<mark>/g)?.length).toBe(1)
+    expect(out).toContain('<mark>Isus</mark>')
+    expect(out).toContain('<mark>mantuit</mark>')
+    expect(out).not.toContain('<mark>Isus Hristos m-a mantuit</mark>')
   })
 
-  test('does not swallow plain words between matches ("a" without hyphen stays out)', () => {
-    // "a" is a Romanian particle, not a clitic contraction. The merger
-    // must only bridge across hyphenated connectors so we don't blob
-    // unrelated content together.
-    const out = highlightWithDiacritics('Isus a inviat din morti', [
-      'isus',
-      'inviat',
-    ])
-    expect(out).not.toContain('<mark>Isus a inviat</mark>')
-    expect(out).toContain('<mark>Isus</mark>')
-    expect(out).toContain('<mark>inviat</mark>')
+  test('marks individual words and merges adjacent ones (whitespace + clitic gap)', () => {
+    // Per-term path with no rawQuery: ["isus","mantuit"] in adjacent
+    // positions get merged if the gap is whitespace-only or a clitic.
+    const out = highlightWithDiacritics('Isus mantuit', ['isus', 'mantuit'])
+    expect(out).toBe('<mark>Isus mantuit</mark>')
   })
 
   test('does not nest <mark> tags when a shorter term overlaps a longer one', () => {
-    // Pre-existing artefact: searching "m-am departat de mantuitorul"
-    // produced "<mark><mark>depărtat</mark></mark>" because the regex
-    // for "de" greedily matched the whole "depărtat" already wrapped by
-    // the "departat" term. The single-pass + merge implementation must
-    // collapse this into one flat mark.
+    // Pre-existing artefact regression guard.
     const out = highlightWithDiacritics(
       'M-am depărtat de Mântuitorul',
       ['am', 'departat', 'de', 'mantuitorul'],
     )
     expect(out).not.toMatch(/<mark><mark>/)
     expect(out).not.toMatch(/<\/mark><\/mark>/)
-    expect(out).toBe('<mark>M-am depărtat de Mântuitorul</mark>')
+  })
+
+  test('per-term path with single-char clitic ("am") does not extend into "M-"', () => {
+    // The aggressive backward extension was removed — without a
+    // surrounding rawQuery to anchor the literal substring, "am" alone
+    // marks only "am", not "M-am".
+    const out = highlightWithDiacritics('M-am departat', ['am', 'departat'])
+    expect(out).toBe('M-<mark>am departat</mark>')
   })
 })
 
-describe('createFuzzyHighlightedSnippet - hyphenated word coverage', () => {
-  test('snippet highlight covers the whole "m-am" chunk, not just "am"', () => {
+describe('createFuzzyHighlightedSnippet - literal-substring path matches the title', () => {
+  test('marks exactly what the user typed in the snippet (title + snippet stay in sync)', () => {
+    const content =
+      'Cantam: Cand Isus Hristos m-a mantuit, viata mea s-a schimbat.'
+    // User typed "Cand Isus Hristos m" — both highlighters should mark
+    // the same literal slice.
     const snippet = createFuzzyHighlightedSnippet(
-      'Cantam: m-am departat de Mantuitorul, dar acum revin.',
-      ['am', 'departat', 'mantuitorul'],
+      content,
+      ['cand', 'isus', 'hristos', 'm'],
+      150,
+      'Cand Isus Hristos m',
     )
-    // The existing merge step fuses adjacent matches separated only by
-    // whitespace, so checking the exact "<mark>m-am</mark>" boundary is
-    // wrong here — what matters is that the "m-" prefix is INSIDE a mark.
-    expect(snippet).not.toMatch(/m-<mark>/)
-    // The clitic + adjacent matches should all land inside a single mark
-    expect(snippet).toContain('<mark>m-am departat</mark>')
+    expect(snippet).toContain('<mark>Cand Isus Hristos m</mark>')
+    // The trailing "-a mantuit" must NOT be inside the mark — exact literal
+    expect(snippet).not.toContain('<mark>Cand Isus Hristos m-')
   })
 
-  test('snippet without merge: standalone "m-am" sweeps both letters', () => {
+  test('one more character widens the mark by exactly one character', () => {
+    const content = 'Lyrics: Cand Isus Hristos m-a mantuit pe noi.'
     const snippet = createFuzzyHighlightedSnippet(
-      'Cuvinte m-am altele neutre.',
-      ['am'],
+      content,
+      ['cand', 'isus', 'hristos', 'm'],
+      150,
+      'Cand Isus Hristos m-',
     )
-    expect(snippet).toContain('<mark>m-am</mark>')
-    expect(snippet).not.toMatch(/m-<mark>am<\/mark>/)
+    expect(snippet).toContain('<mark>Cand Isus Hristos m-</mark>')
   })
 })
 

--- a/app/apps/server/src/service/songs/search.test.ts
+++ b/app/apps/server/src/service/songs/search.test.ts
@@ -1,4 +1,5 @@
 import {
+  buildSearchQuery,
   calculateBestPhraseScoreNormalized,
   calculateTitleScoreNormalized,
   extractSearchTerms,
@@ -35,6 +36,24 @@ describe('extractSearchTerms', () => {
     const isusCount = terms.filter((t) => t === 'isus').length
     expect(isusCount).toBe(1)
   })
+
+  test('drops single-character tokens (numeric prefix + "m-a" splits)', () => {
+    // Regression: user-reported query "1. Cand Isus Hristos m-a mantuit"
+    // used to tokenize as ["1","cand","isus","hristos","m","a","mantuit"],
+    // and those single chars then polluted both the FTS query (prefix
+    // expansions like "m"*) and the title-order scoring. Only meaningful
+    // tokens should remain.
+    expect(
+      extractSearchTerms('1. Cand Isus Hristos m-a mantuit'),
+    ).toEqual(['cand', 'isus', 'hristos', 'mantuit'])
+  })
+
+  test('returns empty for input that boils down to single chars only', () => {
+    // Calling code in buildSearchQuery already short-circuits on empty
+    // term lists; this just pins the behaviour.
+    expect(extractSearchTerms('a o')).toEqual([])
+    expect(extractSearchTerms('1 2 3')).toEqual([])
+  })
 })
 
 describe('getValidTerms', () => {
@@ -69,6 +88,54 @@ describe('normalizeForIndex', () => {
     expect(normalized).not.toContain('.')
     expect(normalized).not.toContain(';')
   })
+
+  test('drops single-character tokens so title phrase matching survives "m-a"', () => {
+    // Regression: title "Cand Isus Hristos m-a mantuit" used to tokenize as
+    // "cand isus hristos m a mantuit". A user query for the same title then
+    // could never see the exact phrase in the normalized index because of
+    // the stray "m" and "a" tokens between "hristos" and "mantuit".
+    const normalized = normalizeForIndex('Cand Isus Hristos m-a mantuit')
+    expect(normalized).toBe('Cand Isus Hristos mantuit')
+    expect(normalized.toLowerCase()).toContain('cand isus hristos mantuit')
+  })
+})
+
+describe('buildSearchQuery', () => {
+  test('reported regression: "1. Cand Isus Hristos m-a mantuit" emits a title-restricted phrase tier so the song can outrank synonym noise', () => {
+    // The TODO.md "Căutarea nu găsește …" bug. After normalizeForIndex and
+    // extractSearchTerms drop single chars, the joined phrase becomes
+    // "cand isus hristos mantuit" — and that exact phrase needs to appear
+    // restricted to the `title` column so BM25 lifts the matching song
+    // even when synonym expansion (hristos → cristos) widens the broad OR
+    // tier to 20k+ candidates.
+    const q = buildSearchQuery('1. Cand Isus Hristos m-a mantuit')
+    expect(q).toContain('title:"cand isus hristos mantuit"')
+    // Other tiers still present for fuzzy / content matches
+    expect(q).toContain('NEAR(')
+    expect(q).toContain('"cand"*')
+  })
+
+  test('synonym-expanded query keeps the title-restricted clause on the original terms only', () => {
+    // Caller appends a synonym (e.g. cristos) to queryText, but passes the
+    // pre-expansion terms via the originalTerms arg so the title clause
+    // doesn't require the synonym word to appear in the title.
+    const q = buildSearchQuery('cand isus hristos mantuit cristos', [
+      'cand',
+      'isus',
+      'hristos',
+      'mantuit',
+    ])
+    expect(q).toContain('title:"cand isus hristos mantuit"')
+    expect(q).not.toContain('title:"cand isus hristos mantuit cristos"')
+    // Broad / phrase tiers still use the full expanded set
+    expect(q).toContain('"cristos"*')
+  })
+
+  test('omits title-restricted clause when only one meaningful term', () => {
+    const q = buildSearchQuery('Isus')
+    // single-term path returns just a prefix match, no need for title clause
+    expect(q).toBe('"isus"*')
+  })
 })
 
 describe('scoring - score bounds', () => {
@@ -97,7 +164,9 @@ describe('normalizeForIndex - HTML tag stripping', () => {
     // Should not contain "p" tokens from <p> tags
     expect(normalized).not.toMatch(/\bp\b/)
     expect(normalized).toContain('Sa ne speli de orice pacat')
-    expect(normalized).toContain('A noastra nelegiuire')
+    // "A" (Romanian article) is dropped as a single-char noise token;
+    // the rest of the second clause is preserved.
+    expect(normalized).toContain('noastra nelegiuire')
   })
 })
 

--- a/app/apps/server/src/service/songs/search.ts
+++ b/app/apps/server/src/service/songs/search.ts
@@ -921,11 +921,15 @@ function findFuzzyMatchWord(
  * highlights the original text that contains diacritics.
  */
 function buildDiacriticInsensitivePattern(word: string): string {
+  // Romanian s and t exist in two Unicode forms: the canonical comma-below
+  // (ș U+0219, ț U+021B) and the older cedilla (ş U+015F, ţ U+0163). Both
+  // are sprinkled through real texts, so the pattern must accept either
+  // when highlighting a diacritic-stripped search token.
   const diacriticMap: Record<string, string> = {
     a: '[aăâ]',
     i: '[iî]',
-    s: '[sș]',
-    t: '[tț]',
+    s: '[sșş]',
+    t: '[tțţ]',
   }
   return word
     .split('')
@@ -940,19 +944,69 @@ function buildDiacriticInsensitivePattern(word: string): string {
 /**
  * Highlights search terms in text with diacritic-insensitive matching.
  * Operates on original text (with diacritics) so highlighted output preserves them.
+ *
+ * When a term match sits inside a hyphenated word (e.g. "am" inside
+ * "m-am" or "te-aşteptăm"), the highlight is extended across the whole
+ * hyphen-joined chunk. This keeps short Romanian clitic contractions
+ * ("m-am", "te-a", "ne-am", "n-a") visually together in the title even
+ * though the leading single-letter segment is dropped from the search
+ * tokens for ranking purposes.
  */
-function highlightWithDiacritics(text: string, searchTerms: string[]): string {
+// Unicode letter class — covers every diacritic variant (incl. cedilla
+// forms ş / ţ that show up in Romanian texts alongside the comma-below
+// canonical forms ș / ț). The `u` regex flag is required to enable it.
+const HL_LETTER = '\\p{L}'
+export function highlightWithDiacritics(
+  text: string,
+  searchTerms: string[],
+): string {
   if (!searchTerms.length) return text
 
-  let result = text
+  // Collect all match ranges across every term in a single pass, then
+  // merge overlaps before applying <mark> tags. Avoids the nested-mark
+  // artefact that the previous per-term replace loop produced when a
+  // shorter term (e.g. "de") matched inside a word already marked by a
+  // longer term (e.g. "departat" → <mark>de<mark>părtat</mark></mark>).
+  const ranges: Array<{ start: number; end: number }> = []
   for (const term of searchTerms) {
     if (term.length < 2) continue
     const normalized = removeDiacritics(term).toLowerCase()
     const diacriticPattern = buildDiacriticInsensitivePattern(normalized)
-    const pattern = new RegExp(`(${diacriticPattern}[a-zA-ZăâîșțĂÂÎȘȚ]*)`, 'gi')
-    result = result.replace(pattern, '<mark>$1</mark>')
+    const pattern = new RegExp(
+      `(?:${HL_LETTER}+-)*${diacriticPattern}${HL_LETTER}*(?:-${HL_LETTER}+)*`,
+      'giu',
+    )
+    let m: RegExpExecArray | null
+    while ((m = pattern.exec(text)) !== null) {
+      if (m[0].length === 0) {
+        pattern.lastIndex++
+        continue
+      }
+      ranges.push({ start: m.index, end: m.index + m[0].length })
+    }
   }
-  return result
+  if (ranges.length === 0) return text
+
+  ranges.sort((a, b) => a.start - b.start || a.end - b.end)
+  const merged: Array<{ start: number; end: number }> = []
+  for (const r of ranges) {
+    const last = merged[merged.length - 1]
+    if (last && r.start <= last.end) {
+      last.end = Math.max(last.end, r.end)
+    } else {
+      merged.push({ ...r })
+    }
+  }
+
+  let out = ''
+  let cursor = 0
+  for (const r of merged) {
+    out += text.slice(cursor, r.start)
+    out += `<mark>${text.slice(r.start, r.end)}</mark>`
+    cursor = r.end
+  }
+  out += text.slice(cursor)
+  return out
 }
 
 /**
@@ -960,7 +1014,7 @@ function highlightWithDiacritics(text: string, searchTerms: string[]): string {
  * Highlights both exact matches and fuzzy matches (e.g., "Hristos" -> "Cristos")
  * Supports diacritic-insensitive matching (e.g., "in" matches "în")
  */
-function createFuzzyHighlightedSnippet(
+export function createFuzzyHighlightedSnippet(
   content: string,
   queryTerms: string[],
   maxLength: number = 150,
@@ -1036,6 +1090,37 @@ function createFuzzyHighlightedSnippet(
     return plainContent.length > maxLength
       ? `${plainContent.substring(0, maxLength)}...`
       : plainContent
+  }
+
+  // Extend each match to cover the surrounding hyphen-joined word so that
+  // e.g. searching "am" highlights the full "m-am", not just the "am". The
+  // single-letter clitic prefix is dropped from the search tokens but the
+  // user still expects to see the whole Romanian contraction marked.
+  // Uses \p{L} so cedilla diacritics (ş, ţ) match alongside the canonical
+  // comma-below forms (ș, ț).
+  const isLetter = (ch: string | undefined) => !!ch && /\p{L}/u.test(ch)
+  for (const m of matches) {
+    while (m.start > 0) {
+      const prev = plainContent[m.start - 1]
+      if (isLetter(prev)) {
+        m.start--
+      } else if (prev === '-' && isLetter(plainContent[m.start - 2])) {
+        m.start--
+      } else {
+        break
+      }
+    }
+    while (m.end < plainContent.length) {
+      const next = plainContent[m.end]
+      if (isLetter(next)) {
+        m.end++
+      } else if (next === '-' && isLetter(plainContent[m.end + 1])) {
+        m.end++
+      } else {
+        break
+      }
+    }
+    m.length = m.end - m.start
   }
 
   // Sort matches by position, then by length (longer matches first)

--- a/app/apps/server/src/service/songs/search.ts
+++ b/app/apps/server/src/service/songs/search.ts
@@ -220,7 +220,14 @@ export function normalizeForIndex(text: string): string {
     }
   }
 
-  return expandedWords.join(' ')
+  // Drop single-character tokens — they carry no search signal and worse,
+  // they break title-level phrase / order matching. Example: a title
+  // "Cand Isus Hristos m-a mantuit" used to tokenize as
+  // "cand isus hristos m a mantuit", so a query for the same title could
+  // never match the phrase "cand isus hristos mantuit" exactly (m, a sat
+  // between). Filtering happens after n-expansion so the expansion logic
+  // is unaffected (it already requires length > 2).
+  return expandedWords.filter((w) => w.length > 1).join(' ')
 }
 
 /**
@@ -527,7 +534,16 @@ export function rebuildSearchIndex(): void {
 }
 
 /**
- * Extracts and sanitizes search terms from query text
+ * Extracts and sanitizes search terms from query text.
+ *
+ * Single-character tokens (e.g. "m", "a", "1" from inputs like
+ * "1. Cand Isus Hristos m-a mantuit") are dropped — they carry no
+ * search signal, and worse, they pollute downstream scoring by:
+ *   - matching at unexpected positions ("a" inside "cAnd") and breaking
+ *     in-order detection in calculateTitleScoreNormalized
+ *   - diluting matchPercentage when the title has no such single-char
+ *   - blowing up FTS prefix queries ("m"* matches every m-word)
+ * Index-time tokens are filtered symmetrically in normalizeForIndex.
  */
 export function extractSearchTerms(queryText: string): string[] {
   const sanitized = removeDiacritics(queryText)
@@ -537,7 +553,7 @@ export function extractSearchTerms(queryText: string): string[] {
     .trim()
     .toLowerCase()
 
-  const terms = sanitized.split(/\s+/).filter((t) => t.length > 0)
+  const terms = sanitized.split(/\s+/).filter((t) => t.length > 1)
 
   // Deduplicate terms (e.g. "Isus,Isus" → ["isus", "isus"] → ["isus"])
   return [...new Set(terms)]
@@ -652,7 +668,19 @@ export function getValidTerms(terms: string[]): { validTerms: string[] } {
  * Single-character terms are filtered out to reduce noise
  * (e.g., "m-a mantuit" becomes ["a", "mantuit"] → only ["mantuit"] is used for FTS)
  */
-export function buildSearchQuery(queryText: string): string {
+export function buildSearchQuery(
+  queryText: string,
+  /**
+   * Original (pre-synonym-expansion) terms used to build a tight
+   * `title:"…"` clause. When `queryText` carries synonym-expanded
+   * terms (e.g. `cristos` appended because the user typed `hristos`),
+   * the title-restricted phrase must NOT include the synonyms,
+   * otherwise it never matches any indexed title. Defaults to the
+   * extracted terms of `queryText` for back-compat with callers that
+   * don't expand.
+   */
+  originalTerms?: string[],
+): string {
   const allTerms = extractSearchTerms(queryText)
 
   // Filter out single-character terms to reduce noise in FTS queries
@@ -668,12 +696,31 @@ export function buildSearchQuery(queryText: string): string {
     return `"${effectiveTerms[0]}"*`
   }
 
-  // Simple tiered query - avoids combinatorial explosion
-  const phraseQuery = `"${effectiveTerms.join(' ')}"` // Exact phrase
-  const nearQuery = `NEAR(${effectiveTerms.map((t) => `"${t}"`).join(' ')}, 10)` // Proximity (wider window)
-  const orQuery = effectiveTerms.map((t) => `"${t}"*`).join(' OR ') // Broad match
+  // Tiered query. Order matters because BM25 sums score contributions across
+  // all matched sub-clauses, so the most-specific tier first gives true
+  // title matches a decisive boost.
+  //
+  // The `title:"<joined phrase>"` tier exists because synonym expansion
+  // (e.g. hristos → cristos) widens the broad OR clause until BM25 ranks
+  // exact-title matches below songs that happen to contain many of the
+  // expanded terms in content. Restricting the phrase to the `title`
+  // column rescues queries that ARE the song's title (the most common
+  // form of user search) — but only when the phrase is built from the
+  // user's ORIGINAL terms, not the synonym-expanded set.
+  const titleTerms = (originalTerms ?? effectiveTerms).filter(
+    (t) => t.length > 1,
+  )
+  const clauses: string[] = []
+  if (titleTerms.length > 1) {
+    clauses.push(`(title:"${titleTerms.join(' ')}")`)
+  }
+  clauses.push(`("${effectiveTerms.join(' ')}")`) // Exact phrase, any column
+  clauses.push(
+    `(NEAR(${effectiveTerms.map((t) => `"${t}"`).join(' ')}, 10))`,
+  ) // Proximity
+  clauses.push(`(${effectiveTerms.map((t) => `"${t}"*`).join(' OR ')})`) // Broad
 
-  return `(${phraseQuery}) OR (${nearQuery}) OR (${orQuery})`
+  return clauses.join(' OR ')
 }
 
 /**
@@ -1212,8 +1259,10 @@ export function searchSongs(
     // Expand valid terms with synonyms for broader search
     const expandedTerms = expandTermsWithSynonyms(validTerms)
 
-    // Build FTS query using expanded terms for broader results
-    const ftsQuery = buildSearchQuery(expandedTerms.join(' '))
+    // Build FTS query using expanded terms for broader results, but pass the
+    // pre-expansion terms separately so the title-restricted clause matches
+    // the user's literal title query without diluting on synonym variants.
+    const ftsQuery = buildSearchQuery(expandedTerms.join(' '), validTerms)
 
     if (!ftsQuery) {
       return []

--- a/app/apps/server/src/service/songs/search.ts
+++ b/app/apps/server/src/service/songs/search.ts
@@ -220,14 +220,12 @@ export function normalizeForIndex(text: string): string {
     }
   }
 
-  // Drop single-character tokens — they carry no search signal and worse,
-  // they break title-level phrase / order matching. Example: a title
-  // "Cand Isus Hristos m-a mantuit" used to tokenize as
-  // "cand isus hristos m a mantuit", so a query for the same title could
-  // never match the phrase "cand isus hristos mantuit" exactly (m, a sat
-  // between). Filtering happens after n-expansion so the expansion logic
-  // is unaffected (it already requires length > 2).
-  return expandedWords.filter((w) => w.length > 1).join(' ')
+  // Single-character tokens stay in the index. They are linguistically
+  // meaningful — the Romanian clitic contractions split into them at
+  // tokenization ("m-a" → "m a") and a user typing the exact title needs
+  // those tokens to land an exact phrase match in FTS. Per-term scoring
+  // protects itself with ordered indexOf in calculateTitleScoreNormalized.
+  return expandedWords.join(' ')
 }
 
 /**
@@ -536,24 +534,28 @@ export function rebuildSearchIndex(): void {
 /**
  * Extracts and sanitizes search terms from query text.
  *
- * Single-character tokens (e.g. "m", "a", "1" from inputs like
- * "1. Cand Isus Hristos m-a mantuit") are dropped — they carry no
- * search signal, and worse, they pollute downstream scoring by:
- *   - matching at unexpected positions ("a" inside "cAnd") and breaking
- *     in-order detection in calculateTitleScoreNormalized
- *   - diluting matchPercentage when the title has no such single-char
- *   - blowing up FTS prefix queries ("m"* matches every m-word)
- * Index-time tokens are filtered symmetrically in normalizeForIndex.
+ * Strips a single leading hymn-number prefix ("1.", "265 -", "34 ") so
+ * that users who type "1. Cand Isus Hristos m-a mantuit" still hit the
+ * canonical title "Cand Isus Hristos m-a mantuit". Single-letter tokens
+ * inside the rest of the query (Romanian clitic contractions m / a /
+ * s / n that come from splitting "m-a", "s-a", "n-am") are preserved —
+ * they carry phrase signal in FTS and are handled defensively in
+ * downstream scoring (ordered indexOf, broad-OR exclusion).
  */
 export function extractSearchTerms(queryText: string): string[] {
-  const sanitized = removeDiacritics(queryText)
+  // Strip leading hymn-number-style prefix: optional digits, an optional
+  // "." or "-", and trailing whitespace. Only at the START of the input
+  // so internal numbers (e.g. song lyrics containing dates) survive.
+  const dehymned = queryText.replace(/^\s*\d+[.\-]?\s+/, '')
+
+  const sanitized = removeDiacritics(dehymned)
     .replace(/['"]/g, '')
     .replace(/[^\p{L}\p{N}\s]/gu, ' ') // Replace ALL non-letter, non-number, non-space chars with space
     .replace(/\s+/g, ' ')
     .trim()
     .toLowerCase()
 
-  const terms = sanitized.split(/\s+/).filter((t) => t.length > 1)
+  const terms = sanitized.split(/\s+/).filter((t) => t.length > 0)
 
   // Deduplicate terms (e.g. "Isus,Isus" → ["isus", "isus"] → ["isus"])
   return [...new Set(terms)]
@@ -681,14 +683,7 @@ export function buildSearchQuery(
    */
   originalTerms?: string[],
 ): string {
-  const allTerms = extractSearchTerms(queryText)
-
-  // Filter out single-character terms to reduce noise in FTS queries
-  // They cause too many false positives (e.g. "a", "m", "s" match almost everything)
-  const terms = allTerms.filter((t) => t.length > 1)
-
-  // If all terms were single-char, fall back to originals to avoid empty query
-  const effectiveTerms = terms.length > 0 ? terms : allTerms
+  const effectiveTerms = extractSearchTerms(queryText)
 
   if (effectiveTerms.length === 0) return ''
 
@@ -696,29 +691,34 @@ export function buildSearchQuery(
     return `"${effectiveTerms[0]}"*`
   }
 
-  // Tiered query. Order matters because BM25 sums score contributions across
-  // all matched sub-clauses, so the most-specific tier first gives true
-  // title matches a decisive boost.
+  // Tiered query. Order matters because BM25 sums score contributions
+  // across all matched sub-clauses, so the most-specific tier first
+  // gives true title matches a decisive boost.
   //
-  // The `title:"<joined phrase>"` tier exists because synonym expansion
-  // (e.g. hristos → cristos) widens the broad OR clause until BM25 ranks
-  // exact-title matches below songs that happen to contain many of the
-  // expanded terms in content. Restricting the phrase to the `title`
-  // column rescues queries that ARE the song's title (the most common
-  // form of user search) — but only when the phrase is built from the
-  // user's ORIGINAL terms, not the synonym-expanded set.
-  const titleTerms = (originalTerms ?? effectiveTerms).filter(
-    (t) => t.length > 1,
-  )
+  // - title:"<original phrase>" : exact title match (incl. clitic
+  //     single-letter tokens like "m a", so "Cand Isus Hristos m-a
+  //     mantuit" indexes/matches identically). Built from the user's
+  //     ORIGINAL terms only — synonyms (e.g. cristos) must not appear
+  //     in the title clause or it never matches a real title.
+  // - "<expanded phrase>" : exact phrase in any column, synonym-aware.
+  // - NEAR(expanded, 10) : proximity fallback.
+  // - prefix OR (multi-char terms only) : broad recall. Single-char
+  //     prefixes like "a"* match every word starting with "a" — they
+  //     are excluded here to avoid drowning specific matches in noise.
+  const titlePhraseTerms = originalTerms ?? effectiveTerms
+  const broadOrTerms = effectiveTerms.filter((t) => t.length > 1)
+
   const clauses: string[] = []
-  if (titleTerms.length > 1) {
-    clauses.push(`(title:"${titleTerms.join(' ')}")`)
+  if (titlePhraseTerms.length > 1) {
+    clauses.push(`(title:"${titlePhraseTerms.join(' ')}")`)
   }
-  clauses.push(`("${effectiveTerms.join(' ')}")`) // Exact phrase, any column
+  clauses.push(`("${effectiveTerms.join(' ')}")`)
   clauses.push(
     `(NEAR(${effectiveTerms.map((t) => `"${t}"`).join(' ')}, 10))`,
-  ) // Proximity
-  clauses.push(`(${effectiveTerms.map((t) => `"${t}"*`).join(' OR ')})`) // Broad
+  )
+  if (broadOrTerms.length > 0) {
+    clauses.push(`(${broadOrTerms.map((t) => `"${t}"*`).join(' OR ')})`)
+  }
 
   return clauses.join(' OR ')
 }
@@ -739,26 +739,48 @@ export function calculateTitleScoreNormalized(
   if (title.startsWith(exactPhrase)) return 100
   if (title.includes(exactPhrase)) return 95
 
+  // Per-term matching with TWO passes:
+  //   1. inOrderCount  — terms found in the same order they appear in the
+  //      query, by searching from lastMatchPos + 1 each step. Single-letter
+  //      tokens (Romanian clitics "m", "a", "s", "n" that come from
+  //      splitting "m-a", "s-a", "n-am") that happen to also appear earlier
+  //      inside another word ("a" in "cAnd") no longer poison the order
+  //      detection — the ordered scan finds the LATER occurrence that
+  //      actually belongs to the clitic position in the title.
+  //   2. matchedCount  — terms that appear anywhere in the title at all.
+  //      Used to reward full coverage even when one term is out of order.
   let matchedCount = 0
-  let lastMatchPos = -1
   let inOrderCount = 0
-
+  let lastEnd = -1
   for (const term of queryTerms) {
-    const pos = title.indexOf(term)
-    if (pos !== -1) {
-      matchedCount++
-      if (pos > lastMatchPos) {
-        inOrderCount++
-        lastMatchPos = pos
-      }
+    if (title.includes(term)) matchedCount++
+    const orderedPos = title.indexOf(term, lastEnd + 1)
+    if (orderedPos !== -1) {
+      inOrderCount++
+      lastEnd = orderedPos + term.length - 1
     }
   }
 
   if (matchedCount === 0) return 0
 
-  const matchPercentage = matchedCount / queryTerms.length
+  // Reward proportional coverage of MEANINGFUL terms — single-character
+  // tokens contribute when matched but never penalise when missing, so a
+  // stray noise char in the query (e.g. user typed "Isus a inviat",
+  // tokens ["isus","a","inviat"]) does not drag the percentage down on a
+  // title that happens to lack the "a".
+  const meaningfulQueryTerms = queryTerms.filter((t) => t.length > 1)
+  const meaningfulMatched = meaningfulQueryTerms.filter((t) =>
+    title.includes(t),
+  ).length
+  const denom = meaningfulQueryTerms.length || queryTerms.length
+  const matchPercentage = meaningfulMatched / denom
+
   const orderBonus = inOrderCount === matchedCount ? 0.2 : 0
-  const allMatchedBonus = matchedCount === queryTerms.length ? 0.2 : 0
+  const allMatchedBonus =
+    meaningfulMatched === meaningfulQueryTerms.length &&
+    meaningfulQueryTerms.length > 0
+      ? 0.2
+      : 0
 
   return Math.round(
     matchPercentage * 54 + allMatchedBonus * 100 + orderBonus * 100,
@@ -959,10 +981,10 @@ const HL_LETTER = '\\p{L}'
 
 /**
  * Returns true if the gap between two highlight ranges should be swallowed
- * into a single merged range — pure whitespace, or a short Romanian clitic
- * contraction (e.g. "m-a", "te-a", "ne-am", "s-a", "n-am"). Plain words
- * like "a" or "este" between two matches stay un-merged so we don't blob
- * everything together.
+ * into a single merged range — pure whitespace, a hyphen, or a short
+ * Romanian clitic contraction (e.g. "m-a", "te-a", "ne-am", "s-a", "n-am").
+ * Plain words like "a" or "este" between two matches stay un-merged so we
+ * don't blob everything together.
  */
 function isMergeableGap(gap: string): boolean {
   if (gap.length === 0) return true
@@ -974,26 +996,81 @@ function isMergeableGap(gap: string): boolean {
     /^[\p{L}-]+$/u.test(trimmed)
   )
 }
+
+/**
+ * Normalises the raw user query into the literal phrase we try to find as a
+ * substring of the text being highlighted. Strips the leading hymn-number
+ * prefix (mirrors extractSearchTerms), removes diacritics, lowercases and
+ * collapses whitespace. Keeps internal hyphens so an incremental typing
+ * pass like "Cand Isus Hristos m" → "m-" → "m-a" naturally widens the
+ * highlight by one character at a time.
+ */
+function cleanQueryForHighlight(rawQuery: string): string {
+  return removeDiacritics(rawQuery)
+    .replace(/^\s*\d+[.\-]?\s+/, '')
+    .toLowerCase()
+    .replace(/\s+/g, ' ')
+    .trim()
+}
+
+/**
+ * If the cleaned user query appears verbatim inside the (diacritic-stripped,
+ * lowercased) text, returns the text with that exact span wrapped in a
+ * single <mark>. Returns null otherwise so callers can fall back to per-
+ * term highlighting.
+ */
+function tryExactPhraseHighlight(text: string, rawQuery: string): string | null {
+  const cleaned = cleanQueryForHighlight(rawQuery)
+  if (cleaned.length === 0) return null
+  // removeDiacritics + toLowerCase preserve character count for the
+  // Romanian alphabet (NFD splits "ă" into base + combining mark, the
+  // combining mark is stripped, length stays the same) so we can map
+  // positions 1:1 back to the original text.
+  const normText = removeDiacritics(text).toLowerCase()
+  const pos = normText.indexOf(cleaned)
+  if (pos === -1) return null
+  return (
+    text.slice(0, pos) +
+    `<mark>${text.slice(pos, pos + cleaned.length)}</mark>` +
+    text.slice(pos + cleaned.length)
+  )
+}
+
 export function highlightWithDiacritics(
   text: string,
   searchTerms: string[],
+  rawQuery?: string,
 ): string {
-  if (!searchTerms.length) return text
+  if (!searchTerms.length && !rawQuery) return text
 
-  // Collect all match ranges across every term in a single pass, then
-  // merge overlaps before applying <mark> tags. Avoids the nested-mark
-  // artefact that the previous per-term replace loop produced when a
-  // shorter term (e.g. "de") matched inside a word already marked by a
-  // longer term (e.g. "departat" → <mark>de<mark>părtat</mark></mark>).
+  // 1. Literal substring match against the user's typed query. This is the
+  //    common path while the user types incrementally — "Cand Isus Hristos
+  //    m" → "m-" → "m-a" widens the mark one character at a time, exactly
+  //    matching what they typed. Title and content highlighters share this
+  //    code so the two stay visually in sync.
+  if (rawQuery !== undefined && rawQuery.length > 0) {
+    const exact = tryExactPhraseHighlight(text, rawQuery)
+    if (exact !== null) return exact
+  }
+
+  // 2. Fallback: per-term marking when the query is not a literal substring
+  //    of the text (different word order, partial phrase, typo). Collects
+  //    every term's positions in one pass, then merges adjacent ranges
+  //    across whitespace / hyphen / clitic-contraction gaps to avoid a
+  //    sea of single-word marks.
   const ranges: Array<{ start: number; end: number }> = []
   for (const term of searchTerms) {
-    if (term.length < 2) continue
+    if (term.length === 0) continue
     const normalized = removeDiacritics(term).toLowerCase()
     const diacriticPattern = buildDiacriticInsensitivePattern(normalized)
-    const pattern = new RegExp(
-      `(?:${HL_LETTER}+-)*${diacriticPattern}${HL_LETTER}*(?:-${HL_LETTER}+)*`,
-      'giu',
-    )
+    // Short terms (≤ 2 chars) must be word-bounded — otherwise "a" matches
+    // inside "cAnd" and "m" matches inside half the corpus. Longer terms
+    // can match literally so partial typing like "isu" still highlights
+    // the "Isu" in "Isus" without bleeding past it.
+    const pattern =
+      term.length <= 2
+        ? new RegExp(`\\b${diacriticPattern}\\b`, 'giu')
+        : new RegExp(diacriticPattern, 'giu')
     let m: RegExpExecArray | null
     while ((m = pattern.exec(text)) !== null) {
       if (m[0].length === 0) {
@@ -1012,10 +1089,6 @@ export function highlightWithDiacritics(
     if (last && r.start <= last.end) {
       last.end = Math.max(last.end, r.end)
     } else if (last && isMergeableGap(text.slice(last.end, r.start))) {
-      // Two consecutive matches separated only by whitespace, or by a short
-      // Romanian clitic contraction (m-a, te-a, ne-am, s-a, n-am, …),
-      // fuse into a single mark — the user expects the whole phrase
-      // including the connector to be highlighted.
       last.end = r.end
     } else {
       merged.push({ ...r })
@@ -1042,9 +1115,40 @@ export function createFuzzyHighlightedSnippet(
   content: string,
   queryTerms: string[],
   maxLength: number = 150,
+  rawQuery?: string,
 ): string {
   // Strip HTML tags for cleaner processing
   const plainContent = content.replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ')
+
+  // 1. Literal substring match against the user's typed query. Matches the
+  //    title highlighter so the two stay visually in sync — when the user
+  //    types "Cand Isus Hristos m" the snippet marks exactly the same span
+  //    as the title, never extending into the trailing "-a" until the user
+  //    actually types those characters.
+  if (rawQuery !== undefined && rawQuery.length > 0) {
+    const cleaned = cleanQueryForHighlight(rawQuery)
+    if (cleaned.length > 0) {
+      const normFull = removeDiacritics(plainContent).toLowerCase()
+      const pos = normFull.indexOf(cleaned)
+      if (pos !== -1) {
+        const matchEnd = pos + cleaned.length
+        const windowStart = Math.max(0, pos - 30)
+        const rawEnd = Math.min(plainContent.length, windowStart + maxLength)
+        // Make sure the matched span is fully inside the window
+        const windowEnd = Math.max(rawEnd, matchEnd)
+        const snippet = plainContent.slice(windowStart, windowEnd)
+        const localStart = pos - windowStart
+        const localEnd = matchEnd - windowStart
+        const marked =
+          snippet.slice(0, localStart) +
+          `<mark>${snippet.slice(localStart, localEnd)}</mark>` +
+          snippet.slice(localEnd)
+        const prefix = windowStart > 0 ? '...' : ''
+        const suffix = windowEnd < plainContent.length ? '...' : ''
+        return `${prefix}${marked}${suffix}`
+      }
+    }
+  }
 
   // Normalize content for diacritic-insensitive matching
   const normalizedContent = removeDiacritics(plainContent).toLowerCase()
@@ -1116,36 +1220,11 @@ export function createFuzzyHighlightedSnippet(
       : plainContent
   }
 
-  // Extend each match to cover the surrounding hyphen-joined word so that
-  // e.g. searching "am" highlights the full "m-am", not just the "am". The
-  // single-letter clitic prefix is dropped from the search tokens but the
-  // user still expects to see the whole Romanian contraction marked.
-  // Uses \p{L} so cedilla diacritics (ş, ţ) match alongside the canonical
-  // comma-below forms (ș, ț).
-  const isLetter = (ch: string | undefined) => !!ch && /\p{L}/u.test(ch)
-  for (const m of matches) {
-    while (m.start > 0) {
-      const prev = plainContent[m.start - 1]
-      if (isLetter(prev)) {
-        m.start--
-      } else if (prev === '-' && isLetter(plainContent[m.start - 2])) {
-        m.start--
-      } else {
-        break
-      }
-    }
-    while (m.end < plainContent.length) {
-      const next = plainContent[m.end]
-      if (isLetter(next)) {
-        m.end++
-      } else if (next === '-' && isLetter(plainContent[m.end + 1])) {
-        m.end++
-      } else {
-        break
-      }
-    }
-    m.length = m.end - m.start
-  }
+  // (No backward / forward hyphen-word extension here — the exact-phrase
+  // path above already covers the literal-typing case, and per-term
+  // marks are merged through hyphen / clitic gaps below, which gives the
+  // same visual result for queries that span an "m-a" without claiming
+  // characters the user never typed.)
 
   // Sort matches by position, then by length (longer matches first)
   matches.sort((a, b) => a.start - b.start || b.length - a.length)
@@ -1551,16 +1630,18 @@ export function searchSongs(
     const PRESENTATION_BOOST_DENOM = Math.log10(101)
 
     const scoredResults = candidates.map((r) => {
-      // Use pre-normalized fts_title (already diacritics-free) for scoring
+      // Score against the user's ORIGINAL (pre-synonym-expansion) terms.
+      // Synonyms broaden FTS recall — they should not be appended to the
+      // queryTerms used for phrase / order detection or the joined exact
+      // phrase will never match a real title.
       const titleScore = calculateTitleScoreNormalized(
         r.fts_title,
-        expandedTerms,
+        validTerms,
       )
 
-      // Use pre-normalized full_content (already diacritics-free) for scoring
       const contentScore = calculateBestPhraseScoreNormalized(
         r.full_content,
-        expandedTerms,
+        validTerms,
       )
 
       // Use best match location as base score (don't penalize content-only matches)
@@ -1630,13 +1711,22 @@ export function searchSongs(
       // Use original content (with diacritics) for snippet highlighting
       // Fall back to FTS content if original is not available
       const contentForSnippet = r.original_content || r.full_content
+      // Pass the raw user query so the highlighter can prefer a literal
+      // substring match (incremental typing produces the same visual mark
+      // in title and snippet, one character at a time).
       const matchedContent = createFuzzyHighlightedSnippet(
         contentForSnippet,
         expandedTerms,
+        undefined,
+        query,
       )
 
       // Highlight original title with diacritic-insensitive matching
-      const highlightedTitle = highlightWithDiacritics(r.title, expandedTerms)
+      const highlightedTitle = highlightWithDiacritics(
+        r.title,
+        expandedTerms,
+        query,
+      )
 
       return {
         id: r.id,

--- a/app/apps/server/src/service/songs/search.ts
+++ b/app/apps/server/src/service/songs/search.ts
@@ -956,6 +956,24 @@ function buildDiacriticInsensitivePattern(word: string): string {
 // forms ş / ţ that show up in Romanian texts alongside the comma-below
 // canonical forms ș / ț). The `u` regex flag is required to enable it.
 const HL_LETTER = '\\p{L}'
+
+/**
+ * Returns true if the gap between two highlight ranges should be swallowed
+ * into a single merged range — pure whitespace, or a short Romanian clitic
+ * contraction (e.g. "m-a", "te-a", "ne-am", "s-a", "n-am"). Plain words
+ * like "a" or "este" between two matches stay un-merged so we don't blob
+ * everything together.
+ */
+function isMergeableGap(gap: string): boolean {
+  if (gap.length === 0) return true
+  const trimmed = gap.trim()
+  if (trimmed === '') return true
+  return (
+    trimmed.length <= 6 &&
+    trimmed.includes('-') &&
+    /^[\p{L}-]+$/u.test(trimmed)
+  )
+}
 export function highlightWithDiacritics(
   text: string,
   searchTerms: string[],
@@ -993,6 +1011,12 @@ export function highlightWithDiacritics(
     const last = merged[merged.length - 1]
     if (last && r.start <= last.end) {
       last.end = Math.max(last.end, r.end)
+    } else if (last && isMergeableGap(text.slice(last.end, r.start))) {
+      // Two consecutive matches separated only by whitespace, or by a short
+      // Romanian clitic contraction (m-a, te-a, ne-am, s-a, n-am, …),
+      // fuse into a single mark — the user expects the whole phrase
+      // including the connector to be highlighted.
+      last.end = r.end
     } else {
       merged.push({ ...r })
     }
@@ -1126,8 +1150,11 @@ export function createFuzzyHighlightedSnippet(
   // Sort matches by position, then by length (longer matches first)
   matches.sort((a, b) => a.start - b.start || b.length - a.length)
 
-  // Merge overlapping and adjacent matches (separated only by whitespace)
-  // This produces continuous highlights for phrases like "Sa ne speli de orice pacat"
+  // Merge overlapping and adjacent matches. Gaps that are pure whitespace
+  // OR a short Romanian clitic contraction (m-a, te-a, ne-am, s-a, …) are
+  // swallowed into a single range so users see a continuous highlight on
+  // queries like "cand isus hristos m-a mantuit" — the "m-a" sits between
+  // two matched terms and visibly belongs to the same phrase.
   const mergedMatches: Array<{ start: number; end: number }> = []
   for (const match of matches) {
     const adjacent = mergedMatches.find((m) => {
@@ -1136,7 +1163,7 @@ export function createFuzzyHighlightedSnippet(
         match.start >= m.end
           ? plainContent.substring(m.end, match.start)
           : plainContent.substring(match.end, m.start)
-      return gap.length > 0 && gap.trim() === '' // only whitespace between
+      return isMergeableGap(gap)
     })
     if (adjacent) {
       adjacent.start = Math.min(adjacent.start, match.start)


### PR DESCRIPTION
## Summary

Three compounding defects on song search, all triggered by the TODO.md report `Căutarea nu găsește "1. Cand Isus Hristos m-a mantuit"`. The branch ends up reworking the index → query → score → highlight pipeline around a single literal-substring semantic.

### 1. Exact-title queries didn't match

For a song titled `"Cand Isus Hristos m-a mantuit"`:

- The leading `"1. "` the user remembered (a hymn-number prefix that doesn't appear in the title) broke any phrase / NEAR / title-restricted clause.
- The clitic `"m-a"` tokenises through punctuation→space to `"m a"` — two single-character tokens. The per-term title scorer found `"a"` inside `"cAnd"` at position 1 (before the real `"m"` at 18) and lost in-order detection, dropping the score from a true 100 down to ~46.
- Synonym expansion (`hristos → cristos`) widened the broad-OR FTS tier to 20k+ candidates. BM25 then ranked the target at FTS position **212** — past the `LIMIT 100` cap.

**Fix:**
- `extractSearchTerms` strips a single leading hymn-number-style prefix (`^\d+[.\-]?\s+`).
- `calculateTitleScoreNormalized` walks the query with ordered `indexOf` (search each term from `lastEnd + 1`, not from 0). Single-char clitic tokens (`m`, `a`, `s`, `n`) can no longer poison order detection by matching inside earlier words.
- `calculateTitleScoreNormalized` computes the percentage denominator from MEANINGFUL terms (length ≥ 2) only, so unmatched single chars never drag matchPercentage down.
- `searchSongs` scores against `validTerms`, not `expandedTerms`. Synonyms keep widening FTS recall (a song with `"Cristos"` surfaces for a query about `"Hristos"`), but the JS reranker uses the user's original phrase for `startsWith` / `includes` checks so a synonym appended at the end never breaks the exact-title detection.
- `buildSearchQuery` emits a `title:"<phrase>"` tier built from the user's pre-expansion terms — exact-title queries win the BM25 race even when synonyms widen the broad clause.

### 2. Single chars were rewriting the index needlessly

An earlier draft of this fix dropped single-character tokens from `normalizeForIndex` outright. That worked but rewrote the indexed data and lost linguistic signal — `<p>A noastra nelegiuire</p>` collapsed to `"noastra nelegiuire"`, the Romanian article `"A"` gone.

**Fix:**
- `normalizeForIndex` preserves single-character tokens; the index keeps `"cand isus hristos m a mantuit"` verbatim. The clitic tokens are exactly what the title-phrase / phrase / NEAR tiers need.
- The broad-OR FTS tier excludes single-char terms (otherwise `"a"*` matches every a-word in the corpus), but all higher-precision tiers keep them.
- A one-shot startup migration `rebuild_fts_clitic_aware_v2` re-runs `rebuildSearchIndex` once on every dev DB. The v1 key (the previous draft's drop-single-char rebuild) is left as-is, so the rekey forces v2 to apply even after v1 ran.

### 3. Title and snippet highlights claimed characters the user never typed

The earlier regex extension `(?:LETTER+-)*term LETTER*(?:-LETTER+)*` greedily swallowed the hyphen-joined word around a match, and a separate post-match loop in the snippet did the same. Typing `"Cand Isus Hristos m"` marked `"Cand Isus Hristos"` on the title but `"Cand Isus Hristos m-a"` on the content — different sub-strings on each side, neither matching what the user typed.

**Fix:**
- New `cleanQueryForHighlight` + `tryExactPhraseHighlight` helpers share a single rule: strip leading hymn-number prefix, lowercase, strip diacritics, collapse whitespace, then `indexOf` in the diacritic-stripped lowercased text. NFD-strip preserves character count, so positions map 1:1 back to the original (diacritic-bearing) text.
- `highlightWithDiacritics` and `createFuzzyHighlightedSnippet` both take an optional `rawQuery` and try the literal-substring path first. Found → mark exactly that span. Title and snippet stay visually in sync, including when the user is mid-typing.
- The aggressive extension regex and the post-match hyphenated-word expansion are removed. The per-term fallback (used when the typed phrase is not a contiguous substring — different word order, typos, partial phrases) still merges adjacent ranges across whitespace / hyphen / clitic-contraction gaps (`m-a`, `te-a`, `ne-am`, `s-a`, `n-am`) so consecutive matches like `"isus"` + `"mantuit"` still fuse into one mark when they're adjacent in the text.
- Short fallback terms (length ≤ 2) get a `\b…\b` word-bounded regex so `"a"` no longer marks inside `"cAnd"` and `"m"` no longer marks half the corpus.
- `buildDiacriticInsensitivePattern` accepts both Romanian s/t Unicode forms (`ș` comma-below + `ş` cedilla, `ț` comma-below + `ţ` cedilla).

## Verification

Live-tested on the seeded 25k-song corpus.

### Exact-title queries

| Query | Top match | Score |
|---|---|---|
| `1. Cand Isus Hristos m-a mantuit` | Când Isus Hristos m-a mântuit | 100 |
| `Când Isus Hristos m-a mântuit` | Când Isus Hristos m-a mântuit | 100 |
| `CAND ISUS HRISTOS M-A MANTUIT` | Când Isus Hristos m-a mântuit | 100 |
| `cand, isus! hristos? m-a mantuit.` | Când Isus Hristos m-a mântuit | 100 |
| `m-am departat de mantuitorul` | M-am depărtat de Mântuitorul | 100 |

### Incremental highlight (title + content rendered identically)

| Typed | Title rendered as | Snippet rendered as |
|---|---|---|
| `Cand Isus Hristos m` | `<mark>Când Isus Hristos m</mark>-a mântuit` | `<mark>Când Isus Hristos m</mark>-a mântuit, Har…` |
| `Cand Isus Hristos m-` | `<mark>Când Isus Hristos m-</mark>a mântuit` | `<mark>Când Isus Hristos m-</mark>a mântuit, Har…` |
| `Cand Isus Hristos m-a` | `<mark>Când Isus Hristos m-a</mark> mântuit` | `<mark>Când Isus Hristos m-a</mark> mântuit, Har…` |
| `Cand Isus Hristos m-a mantuit` | `<mark>Când Isus Hristos m-a mântuit</mark>` | `<mark>Când Isus Hristos m-a mântuit</mark>, Har…` |
| `m-am departat de mantuitorul` | `<mark>M-am depărtat de Mântuitorul</mark> ce m-a salvat` | `<mark>M-am depărtat de Mântuitorul</mark> ce m-a salvat, Plângând…` |

### Regression guards

| Query | Behaviour |
|---|---|
| `isus inviat` (non-substring) | Title shows `<mark>Isus</mark> a <mark>înviat</mark>` — per-term fallback, no fusion across the `"a"` particle |
| `isus mantuit` (non-substring) | Title shows two separate marks, not blobbed together |
| `34` / `#034` | Hymn-number pre-phase still returns the matching song |

## Test plan
- [ ] First boot after upgrade runs `rebuild_fts_clitic_aware_v2` once (~6s for 25k songs) and never again on subsequent boots
- [ ] Search `1. Cand Isus Hristos m-a mantuit` and every variant in the *Exact-title queries* table returns the song with score 100 in the top results
- [ ] Incrementally typing `"Cand Isus Hristos m"` → `"m-"` → `"m-a"` → `"m-a mantuit"` widens the title highlight by exactly the typed characters, and the content snippet renders the same span
- [ ] HTML output contains no nested `<mark><mark>…</mark></mark>` when a query has overlapping shorter / longer terms (e.g. `"de departat"`)
- [ ] Cedilla titles render highlighted: search `"te aşteptăm"` matches both `aşteptăm` (cedilla) and `așteptăm` (comma-below)
- [ ] Regression: numeric-only queries still hit the hymn-number pre-phase (`"34"`, `"#034"`)
- [ ] Regression: queries with no clitic still mark word-by-word — `"isus inviat"` against `"Isus a înviat"` keeps `"a"` un-marked
- [ ] Regression: indexed content still contains the article `"A"` ("`A noastra nelegiuire`")
