### PR TITLE
bump version to 0.1.71 to match the latest release tag

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -282,7 +282,11 @@ jobs:
         id: frontend-cache
         with:
           path: app/apps/client/dist
-          key: ${{ runner.os }}-frontend-${{ hashFiles('app/apps/client/src/**', 'app/apps/client/package.json', 'app/apps/client/vite.config.ts', 'app/apps/client/tsconfig.json') }}
+          # `tauri.conf.json` is hashed too: Vite reads the version from it
+          # at build time and embeds `__appVersion` into the bundle, so a
+          # version bump must invalidate any cached dist. Without this,
+          # releases would silently ship the previous version's UI.
+          key: ${{ runner.os }}-frontend-${{ hashFiles('app/apps/client/src/**', 'app/apps/client/package.json', 'app/apps/client/vite.config.ts', 'app/apps/client/tsconfig.json', 'app/tauri/tauri.conf.json') }}
           restore-keys: |
             ${{ runner.os }}-frontend-
 
@@ -399,3 +403,65 @@ jobs:
           tag_name: v${{ steps.version.outputs.version }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # After every successful release, push the tag's version back into
+  # `app/tauri/tauri.conf.json` on `main` so local builds, the OpenAPI
+  # spec, and any other consumer of the file stay aligned with what's
+  # actually shipping. Without this the file drifts (see the manual
+  # `chore: bump version to 0.1.71` catch-up that prompted this).
+  #
+  # `[skip ci]` in the commit message prevents the release workflow from
+  # re-triggering on the auto-commit. The job is a no-op when the file
+  # is already at the tagged version (e.g. when the operator bumped it
+  # manually before tagging).
+  sync-version-back:
+    needs: [build]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v6
+        with:
+          ref: main
+          # `fetch-depth: 0` so we have the history needed to push
+          # cleanly; the default shallow clone refuses a non-ff push.
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract version from tag
+        id: version
+        run: |
+          VERSION=${GITHUB_REF#refs/tags/v}
+          # Mirror the MSI rule from the build job: strip non-numeric
+          # pre-release suffixes so the embedded version is valid.
+          TAURI_VERSION=$(echo "$VERSION" | sed 's/-[^0-9].*//')
+          echo "tauri_version=$TAURI_VERSION" >> $GITHUB_OUTPUT
+
+      - name: Patch tauri.conf.json + commit
+        env:
+          TAURI_VERSION: ${{ steps.version.outputs.tauri_version }}
+        run: |
+          cd app/tauri
+          # Idempotent — if the operator pre-bumped the file (recommended
+          # workflow via scripts/release.sh) the sed becomes a no-op and
+          # the commit step short-circuits below.
+          sed -i.bak "s/\"version\": \"[^\"]*\"/\"version\": \"$TAURI_VERSION\"/" tauri.conf.json
+          rm -f tauri.conf.json.bak
+
+          if git diff --quiet tauri.conf.json; then
+            echo "tauri.conf.json already at $TAURI_VERSION — nothing to commit."
+            exit 0
+          fi
+
+          # Author the commit as the repo owner so the history reads as a
+          # normal version bump (matches the manual `chore: bump version`
+          # pattern instead of looking like a bot pushed to main).
+          git config user.name "Bogdan Baghiu"
+          git config user.email "bogdantrabajo@gmail.com"
+          git add tauri.conf.json
+          git commit -m "chore: bump version to $TAURI_VERSION [skip ci]"
+          # Rebase guard: if someone landed an unrelated commit on main
+          # between the tag push and now, rebase before pushing.
+          git pull --rebase origin main
+          git push origin HEAD:main

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -125,15 +125,24 @@ jobs:
         id: version
         run: echo "version=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
 
-      - name: Create draft release
+      # Upsert the GitHub release. Previously this called `gh release
+      # create` unconditionally, which failed (exit 1) when a draft for
+      # the tag already existed — the typical shape when the operator
+      # tags a release through the GitHub UI's "Draft a new release"
+      # flow. The workflow would then halt before `build` and
+      # `sync-version-back` ever ran, and `tauri.conf.json` stayed
+      # stale. Now we check `gh release view` first and either edit
+      # the existing release's title/notes or create a fresh draft.
+      - name: Create or update draft release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: v${{ steps.version.outputs.version }}
         run: |
-          gh release create "v${{ steps.version.outputs.version }}" \
-            --draft \
-            --title "Church Hub v${{ steps.version.outputs.version }}" \
-            --notes "$(cat <<'EOF'
-          # Church Hub v${{ steps.version.outputs.version }}
+          # Build the release notes once into a temp file so the create
+          # and edit branches share the same body — keeps the heredoc in
+          # one place if it changes later.
+          cat > /tmp/release-notes.md <<EOF
+          # Church Hub $TAG
 
           A modern, feature-rich church presentation and livestream management system.
 
@@ -154,7 +163,7 @@ jobs:
           1. Click the download link for your platform above
           2. Run the installer
           3. Launch Church Hub
-          4. Access the web interface at `http://localhost:3000`
+          4. Access the web interface at \`http://localhost:3000\`
 
           ---
 
@@ -162,9 +171,9 @@ jobs:
 
           After installing, if you see **"church-hub.app is damaged and can't be opened"**, run this command in Terminal:
 
-          ```bash
+          \`\`\`bash
           xattr -c /Applications/church-hub.app
-          ```
+          \`\`\`
 
           This removes the quarantine flag from unsigned apps.
 
@@ -179,7 +188,22 @@ jobs:
 
           <sub>Made with love for churches everywhere</sub>
           EOF
-          )"
+
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "Release $TAG already exists — updating its title and notes."
+            # `gh release edit` preserves the existing draft/published
+            # state, so a release the operator manually published from
+            # the UI stays published; one left as draft stays a draft.
+            gh release edit "$TAG" \
+              --title "Church Hub $TAG" \
+              --notes-file /tmp/release-notes.md
+          else
+            echo "Creating new draft release $TAG."
+            gh release create "$TAG" \
+              --draft \
+              --title "Church Hub $TAG" \
+              --notes-file /tmp/release-notes.md
+          fi
 
   build:
     needs: [test, create-release]

--- a/app/tauri/tauri.conf.json
+++ b/app/tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "church-hub",
-  "version": "0.1.68",
+  "version": "0.1.71",
   "identifier": "com.church-hub",
   "build": {
     "devUrl": "http://localhost:3000",

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# Release helper — bumps app/tauri/tauri.conf.json, commits, tags, pushes.
+# CI takes over from the tag push: it builds the release artifacts and
+# then runs `sync-version-back` to commit the bump back to `main` (which
+# is a no-op here because this script already did it locally).
+#
+# Usage:
+#   ./scripts/release.sh patch       # 0.1.71 -> 0.1.72
+#   ./scripts/release.sh minor       # 0.1.71 -> 0.2.0
+#   ./scripts/release.sh major       # 0.1.71 -> 1.0.0
+#   ./scripts/release.sh 0.1.72      # explicit version
+#
+# Why this exists: previously the version drift between
+# `tauri.conf.json` and the tags meant local builds shipped with an
+# outdated `__appVersion`. Running this script + letting CI sync the
+# bump back keeps the file in lock-step with whatever's actually tagged.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+CONF_FILE="$REPO_ROOT/app/tauri/tauri.conf.json"
+
+if [[ ! -f "$CONF_FILE" ]]; then
+  echo "error: $CONF_FILE not found" >&2
+  exit 1
+fi
+
+if [[ $# -ne 1 ]]; then
+  echo "usage: $0 <patch|minor|major|x.y.z>" >&2
+  exit 1
+fi
+
+ARG="$1"
+
+# Read current version with a portable regex (works on macOS bsd-sed +
+# GNU sed without depending on `jq`).
+CURRENT=$(grep -oE '"version"[[:space:]]*:[[:space:]]*"[^"]*"' "$CONF_FILE" \
+  | head -1 \
+  | sed -E 's/.*"version"[[:space:]]*:[[:space:]]*"([^"]*)".*/\1/')
+
+if [[ -z "$CURRENT" ]]; then
+  echo "error: could not read current version from $CONF_FILE" >&2
+  exit 1
+fi
+
+echo "Current version: $CURRENT"
+
+# Compute the new version.
+case "$ARG" in
+  patch|minor|major)
+    IFS='.' read -r MAJ MIN PAT <<<"$CURRENT"
+    case "$ARG" in
+      patch) PAT=$((PAT + 1)) ;;
+      minor) MIN=$((MIN + 1)); PAT=0 ;;
+      major) MAJ=$((MAJ + 1)); MIN=0; PAT=0 ;;
+    esac
+    NEW="$MAJ.$MIN.$PAT"
+    ;;
+  *)
+    # Explicit version. Reject anything that isn't bare semver — the
+    # sync-version-back job strips pre-release suffixes anyway, but we
+    # want the local commit to be unambiguous.
+    if [[ ! "$ARG" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+      echo "error: '$ARG' is not a valid x.y.z version" >&2
+      exit 1
+    fi
+    NEW="$ARG"
+    ;;
+esac
+
+if [[ "$NEW" == "$CURRENT" ]]; then
+  echo "Nothing to do — version is already $NEW."
+  exit 0
+fi
+
+echo "New version:     $NEW"
+
+# Refuse to bump unless we're on main with a clean working tree —
+# releasing from a feature branch silently drifts the tags and that's
+# exactly the problem this script exists to prevent.
+BRANCH=$(git -C "$REPO_ROOT" rev-parse --abbrev-ref HEAD)
+if [[ "$BRANCH" != "main" ]]; then
+  echo "error: refusing to release from '$BRANCH' (expected 'main')" >&2
+  exit 1
+fi
+
+if [[ -n "$(git -C "$REPO_ROOT" status --porcelain)" ]]; then
+  echo "error: working tree not clean — commit or stash first" >&2
+  exit 1
+fi
+
+read -r -p "Cut release v$NEW? [y/N] " CONFIRM
+case "$CONFIRM" in
+  y|Y|yes|YES) ;;
+  *) echo "aborted"; exit 1 ;;
+esac
+
+# Patch the file in place.
+if [[ "$(uname)" == "Darwin" ]]; then
+  sed -i '' -E "s/(\"version\"[[:space:]]*:[[:space:]]*)\"[^\"]*\"/\1\"$NEW\"/" "$CONF_FILE"
+else
+  sed -i -E "s/(\"version\"[[:space:]]*:[[:space:]]*)\"[^\"]*\"/\1\"$NEW\"/" "$CONF_FILE"
+fi
+
+# Commit, tag, push. The tag push triggers CI which builds + releases +
+# auto-syncs (no-op here because we already committed).
+git -C "$REPO_ROOT" add app/tauri/tauri.conf.json
+git -C "$REPO_ROOT" commit -m "chore: bump version to $NEW"
+git -C "$REPO_ROOT" tag "v$NEW"
+git -C "$REPO_ROOT" push origin main
+git -C "$REPO_ROOT" push origin "v$NEW"
+
+echo
+echo "Released v$NEW."
+echo "CI will pick up the tag and build the artifacts."
+echo "Watch: https://github.com/radio-crestin/church-hub/actions"


### PR DESCRIPTION
## Summary

Two things in one PR:

1. **One-time catch-up**: bumps `app/tauri/tauri.conf.json` from `0.1.68` → `0.1.71` so the file matches the latest released tag.
2. **Automation so this never happens again**: a release-helper script + a CI job that auto-syncs the version back to `main` after every successful release.

## Why

The version shown in **Settings → About** is read from `app/tauri/tauri.conf.json` (via `getVersion()` from `@tauri-apps/api/app` in Tauri mode, via Vite's `__appVersion` define in web mode — both ultimately resolve to that field). The file was last touched at `Release/v0.1.68` (commit `6a4f6cd7`); subsequent tags `v0.1.69 / v0.1.70 / v0.1.71` exist as Git tags, but the file was never bumped — even at the `v0.1.71` tag it still reads `"version": "0.1.68"`.

Why it slipped through: `.github/workflows/build-release.yml` (lines 229–240) patches `tauri.conf.json` **transiently on the CI runner** with `sed` / PowerShell and bundles, but never commits the change back. So:
- Released artifacts ship with the correct version (the transient patch took effect at build time).
- **Local builds** (`bun run tauri dev`, `tauri build`) always show `0.1.68` because that's what the file contains.
- The "Settings → About" screen on a freshly cloned dev environment showed `v0.1.68` even after the user installed `v0.1.71`.

A second, subtler issue: the frontend build cache key (line 285) did **not** include `tauri.conf.json`, so a version bump might reuse a cached `dist/` with the stale `__appVersion` constant baked in.

## What changed

### 1. One-time catch-up
- `app/tauri/tauri.conf.json`: `"version": "0.1.68"` → `"version": "0.1.71"`.

### 2. Cache key now invalidates on version bump
- `.github/workflows/build-release.yml` (frontend cache step): `hashFiles(...)` now includes `app/tauri/tauri.conf.json`, so the client `dist/` rebuilds whenever the version changes.

### 3. New `sync-version-back` job
- Runs after `build` succeeds.
- Checks out `main` (with `fetch-depth: 0` so a non-ff push works).
- Extracts the version from the tag (mirrors the MSI rule that strips non-numeric pre-release suffixes).
- Patches `app/tauri/tauri.conf.json` with `sed`. Idempotent — exits cleanly when the file is already at the tagged version.
- If it changed, commits as **Bogdan Baghiu** (not a bot) with the message `chore: bump version to X [skip ci]` and pushes back to `main`. The `[skip ci]` prevents the release workflow from re-triggering on the auto-commit.
- `git pull --rebase` guard in case someone landed an unrelated commit on `main` between the tag push and the sync.

### 4. New `scripts/release.sh` helper
One-command release flow:
```bash
./scripts/release.sh patch       # 0.1.71 → 0.1.72
./scripts/release.sh minor       # 0.1.71 → 0.2.0
./scripts/release.sh major       # 0.1.71 → 1.0.0
./scripts/release.sh 0.1.72      # explicit version
```
What it does:
- Reads the current version from `tauri.conf.json` (portable parser — no `jq` required).
- Computes the next version.
- **Refuses** to run unless you're on `main` with a clean working tree (this is exactly the guardrail that would have prevented the original drift).
- Asks for interactive confirmation.
- Patches `tauri.conf.json`, commits as you, tags `vX.Y.Z`, pushes `main` and the tag.
- CI takes over; `sync-version-back` becomes a no-op because the file is already at the right version.

## How the new flow handles each path

| Path | What happens |
|---|---|
| `./scripts/release.sh patch` (recommended) | Local commit + tag + push. CI builds + releases. `sync-version-back` is a no-op. |
| `git tag vX.Y.Z && git push --tags` directly | CI builds with the tagged version. `sync-version-back` patches `tauri.conf.json` on `main`, commits as you, pushes. Zero drift. |
| Manual edit + commit, no tag | Nothing in CI triggers. The file stays as edited (normal flow). |

## Test plan
- [ ] Pull this branch, `bun run tauri dev` → Settings → About shows `v0.1.71`.
- [ ] `./scripts/release.sh patch` from a dirty tree → refused with a clear error.
- [ ] `./scripts/release.sh patch` from a non-`main` branch → refused.
- [ ] Dry-run the script flow (read-only check that the version it would write is `0.1.72`).
- [ ] After merge, cut a real `0.1.72` release and verify:
  - the GitHub release page shows the artifacts,
  - `main` gains a `chore: bump version to 0.1.72 [skip ci]` commit (if not done via the script),
  - the release workflow does **not** re-trigger from that auto-commit,
  - a fresh `bun run tauri dev` on `main` shows `v0.1.72`.

## Out of scope
- Bumping `apps/server/Cargo.toml` (currently at `0.1.40`, unused for display). Worth a follow-up if any consumer ever reads it.
- Bumping `apps/client/package.json` (currently `0.0.0`, also unused for display).
