### PR TITLE
chore: bump version to 0.1.72

### DIFF
--- a/app/tauri/tauri.conf.json
+++ b/app/tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "church-hub",
-  "version": "0.1.71",
+  "version": "0.1.72",
   "identifier": "com.church-hub",
   "build": {
     "devUrl": "http://localhost:3000",
@@ -37,9 +37,7 @@
   "bundle": {
     "active": true,
     "targets": "all",
-    "externalBin": [
-      "bin/church-hub-sidecar"
-    ],
+    "externalBin": ["bin/church-hub-sidecar"],
     "resources": {
       "../apps/client/dist": "client-dist",
       "resources/midi-native": "midi-native",


### PR DESCRIPTION
Sync `main`'s `tauri.conf.json` to the released **v0.1.72** tag. The release CI's `sync-version-back` step can't push directly to `main` (protected-ref ruleset), so this mirrors that bump via the normal PR + admin flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)