### PR TITLE
ci+app-update: drop sync-version-back; show dev-instance badge & suppress dev update checks

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -129,10 +129,9 @@ jobs:
       # create` unconditionally, which failed (exit 1) when a draft for
       # the tag already existed — the typical shape when the operator
       # tags a release through the GitHub UI's "Draft a new release"
-      # flow. The workflow would then halt before `build` and
-      # `sync-version-back` ever ran, and `tauri.conf.json` stayed
-      # stale. Now we check `gh release view` first and either edit
-      # the existing release's title/notes or create a fresh draft.
+      # flow. The workflow would then halt before `build` ever ran. Now
+      # we check `gh release view` first and either edit the existing
+      # release's title/notes or create a fresh draft.
       - name: Create or update draft release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -427,65 +426,3 @@ jobs:
           tag_name: v${{ steps.version.outputs.version }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-  # After every successful release, push the tag's version back into
-  # `app/tauri/tauri.conf.json` on `main` so local builds, the OpenAPI
-  # spec, and any other consumer of the file stay aligned with what's
-  # actually shipping. Without this the file drifts (see the manual
-  # `chore: bump version to 0.1.71` catch-up that prompted this).
-  #
-  # `[skip ci]` in the commit message prevents the release workflow from
-  # re-triggering on the auto-commit. The job is a no-op when the file
-  # is already at the tagged version (e.g. when the operator bumped it
-  # manually before tagging).
-  sync-version-back:
-    needs: [build]
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - name: Checkout main
-        uses: actions/checkout@v6
-        with:
-          ref: main
-          # `fetch-depth: 0` so we have the history needed to push
-          # cleanly; the default shallow clone refuses a non-ff push.
-          fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Extract version from tag
-        id: version
-        run: |
-          VERSION=${GITHUB_REF#refs/tags/v}
-          # Mirror the MSI rule from the build job: strip non-numeric
-          # pre-release suffixes so the embedded version is valid.
-          TAURI_VERSION=$(echo "$VERSION" | sed 's/-[^0-9].*//')
-          echo "tauri_version=$TAURI_VERSION" >> $GITHUB_OUTPUT
-
-      - name: Patch tauri.conf.json + commit
-        env:
-          TAURI_VERSION: ${{ steps.version.outputs.tauri_version }}
-        run: |
-          cd app/tauri
-          # Idempotent — if the operator pre-bumped the file (recommended
-          # workflow via scripts/release.sh) the sed becomes a no-op and
-          # the commit step short-circuits below.
-          sed -i.bak "s/\"version\": \"[^\"]*\"/\"version\": \"$TAURI_VERSION\"/" tauri.conf.json
-          rm -f tauri.conf.json.bak
-
-          if git diff --quiet tauri.conf.json; then
-            echo "tauri.conf.json already at $TAURI_VERSION — nothing to commit."
-            exit 0
-          fi
-
-          # Author the commit as the repo owner so the history reads as a
-          # normal version bump (matches the manual `chore: bump version`
-          # pattern instead of looking like a bot pushed to main).
-          git config user.name "Bogdan Baghiu"
-          git config user.email "bogdantrabajo@gmail.com"
-          git add tauri.conf.json
-          git commit -m "chore: bump version to $TAURI_VERSION [skip ci]"
-          # Rebase guard: if someone landed an unrelated commit on main
-          # between the tag push and now, rebase before pushing.
-          git pull --rebase origin main
-          git push origin HEAD:main

--- a/app/apps/client/src/features/app-update/components/AboutSection.tsx
+++ b/app/apps/client/src/features/app-update/components/AboutSection.tsx
@@ -5,8 +5,14 @@ import { useAppUpdate } from '../hooks/useAppUpdate'
 
 export function AboutSection() {
   const { t } = useTranslation('settings')
-  const { updateInfo, isLoading, isDownloading, checkNow, downloadUpdate } =
-    useAppUpdate()
+  const {
+    updateInfo,
+    isLoading,
+    isDownloading,
+    isDevInstance,
+    checkNow,
+    downloadUpdate,
+  } = useAppUpdate()
 
   return (
     <div className="flex-1 bg-white dark:bg-gray-900 rounded-lg p-6 border border-gray-200 dark:border-gray-800">
@@ -32,19 +38,33 @@ export function AboutSection() {
               v{updateInfo?.currentVersion || '...'}
             </p>
           </div>
-          <button
-            onClick={() => void checkNow()}
-            disabled={isLoading}
-            className="flex items-center gap-2 px-3 py-2 text-sm text-gray-600 dark:text-gray-400 hover:bg-gray-200 dark:hover:bg-gray-700 rounded-lg transition-colors disabled:opacity-50"
-            title={t('sections.about.checkForUpdates')}
-          >
-            <RefreshCw size={16} className={isLoading ? 'animate-spin' : ''} />
-            {t('sections.about.checkForUpdates')}
-          </button>
+          {!isDevInstance && (
+            <button
+              onClick={() => void checkNow()}
+              disabled={isLoading}
+              className="flex items-center gap-2 px-3 py-2 text-sm text-gray-600 dark:text-gray-400 hover:bg-gray-200 dark:hover:bg-gray-700 rounded-lg transition-colors disabled:opacity-50"
+              title={t('sections.about.checkForUpdates')}
+            >
+              <RefreshCw
+                size={16}
+                className={isLoading ? 'animate-spin' : ''}
+              />
+              {t('sections.about.checkForUpdates')}
+            </button>
+          )}
         </div>
 
-        {/* Latest Version / Update Available */}
-        {updateInfo?.hasUpdate ? (
+        {/* Dev instance note / Latest Version / Update Available */}
+        {isDevInstance ? (
+          <div className="p-4 bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 rounded-lg">
+            <p className="text-sm font-medium text-amber-800 dark:text-amber-200">
+              {t('sections.about.devInstance')}
+            </p>
+            <p className="text-xs text-amber-600 dark:text-amber-400 mt-1">
+              {t('sections.about.devInstanceDescription')}
+            </p>
+          </div>
+        ) : updateInfo?.hasUpdate ? (
           <div className="p-4 bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-800 rounded-lg">
             <div className="flex items-start justify-between gap-4">
               <div>

--- a/app/apps/client/src/features/app-update/components/UpdateNotification.tsx
+++ b/app/apps/client/src/features/app-update/components/UpdateNotification.tsx
@@ -14,12 +14,13 @@ export function UpdateNotification({ isCollapsed }: UpdateNotificationProps) {
     updateInfo,
     isDismissed,
     isDownloading,
+    isDevInstance,
     dismissUpdate,
     downloadUpdate,
   } = useAppUpdate()
 
-  // Only show inside Tauri desktop app
-  if (!isTauri() || !updateInfo?.hasUpdate || isDismissed) {
+  // Only show inside the packaged Tauri desktop app — never on a dev instance.
+  if (isDevInstance || !isTauri() || !updateInfo?.hasUpdate || isDismissed) {
     return null
   }
 

--- a/app/apps/client/src/features/app-update/components/VersionDisplay.tsx
+++ b/app/apps/client/src/features/app-update/components/VersionDisplay.tsx
@@ -9,7 +9,7 @@ interface VersionDisplayProps {
 
 export function VersionDisplay({ isCollapsed }: VersionDisplayProps) {
   const { t } = useTranslation('sidebar')
-  const { updateInfo, isLoading, checkNow } = useAppUpdate()
+  const { updateInfo, isLoading, isDevInstance, checkNow } = useAppUpdate()
 
   if (!updateInfo) {
     return null
@@ -27,13 +27,21 @@ export function VersionDisplay({ isCollapsed }: VersionDisplayProps) {
         className={`flex items-center gap-1 ${isCollapsed ? 'flex-col' : ''}`}
       >
         <span title={t('version.current')}>v{currentVersion}</span>
+        {isDevInstance && (
+          <span
+            className="rounded bg-amber-100 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-amber-700 dark:bg-amber-900/40 dark:text-amber-300"
+            title={t('version.devInstanceHint')}
+          >
+            {t('version.dev')}
+          </span>
+        )}
         {!isCollapsed && hasUpdate && (
           <span className="text-green-600 dark:text-green-400">
             → v{latestVersion}
           </span>
         )}
       </div>
-      {!isCollapsed && (
+      {!isCollapsed && !isDevInstance && (
         <button
           onClick={() => void checkNow()}
           disabled={isLoading}

--- a/app/apps/client/src/features/app-update/hooks/useAppUpdate.ts
+++ b/app/apps/client/src/features/app-update/hooks/useAppUpdate.ts
@@ -1,10 +1,20 @@
 import { useCallback, useEffect, useState } from 'react'
 
 import type { UpdateInfo } from '../services/versionService'
-import { checkForUpdates, openDownloadUrl } from '../services/versionService'
+import {
+  checkForUpdates,
+  getCurrentVersion,
+  openDownloadUrl,
+} from '../services/versionService'
 
 const UPDATE_DISMISSED_KEY = 'update-dismissed-version'
 const CHECK_INTERVAL = 1000 * 60 * 60 // Check every hour
+
+// A dev instance is anything served by Vite's dev server (`vite dev`, including
+// `tauri dev`) rather than a packaged release build. There's no shipped
+// artifact to compare against, so we never check for or prompt updates — and
+// surface a "dev instance" badge instead.
+const IS_DEV_INSTANCE = import.meta.env.DEV
 
 interface UseAppUpdateResult {
   updateInfo: UpdateInfo | null
@@ -12,6 +22,7 @@ interface UseAppUpdateResult {
   error: string | null
   isDismissed: boolean
   isDownloading: boolean
+  isDevInstance: boolean
   checkNow: () => Promise<void>
   dismissUpdate: () => void
   downloadUpdate: () => Promise<void>
@@ -25,6 +36,25 @@ export function useAppUpdate(): UseAppUpdateResult {
   const [isDownloading, setIsDownloading] = useState(false)
 
   const checkNow = useCallback(async () => {
+    // Dev instances never reach out to GitHub — that just logs noisy
+    // rate-limit errors and there's nothing to upgrade to. Surface the
+    // current version so the UI can still show it (with a dev badge).
+    if (IS_DEV_INSTANCE) {
+      const currentVersion = await getCurrentVersion()
+      setUpdateInfo({
+        currentVersion,
+        latestVersion: currentVersion,
+        hasUpdate: false,
+        releaseUrl: '',
+        releaseNotes: '',
+        downloadUrl: null,
+        publishedAt: '',
+      })
+      setError(null)
+      setIsLoading(false)
+      return
+    }
+
     setIsLoading(true)
     setError(null)
     try {
@@ -69,8 +99,9 @@ export function useAppUpdate(): UseAppUpdateResult {
     void checkNow()
   }, [checkNow])
 
-  // Periodic check
+  // Periodic check — skipped entirely on dev instances (nothing to poll).
   useEffect(() => {
+    if (IS_DEV_INSTANCE) return
     const intervalId = setInterval(() => {
       void checkNow()
     }, CHECK_INTERVAL)
@@ -82,6 +113,7 @@ export function useAppUpdate(): UseAppUpdateResult {
     updateInfo,
     isLoading,
     error,
+    isDevInstance: IS_DEV_INSTANCE,
     isDismissed,
     isDownloading,
     checkNow,

--- a/app/apps/client/src/i18n/locales/en/settings.json
+++ b/app/apps/client/src/i18n/locales/en/settings.json
@@ -941,7 +941,9 @@
       "downloadUpdate": "Download Update",
       "downloading": "Opening...",
       "upToDate": "You are running the latest version.",
-      "viewReleaseNotes": "View release notes on GitHub"
+      "viewReleaseNotes": "View release notes on GitHub",
+      "devInstance": "Development instance",
+      "devInstanceDescription": "You're running a dev build — update checks are disabled."
     }
   }
 }

--- a/app/apps/client/src/i18n/locales/en/sidebar.json
+++ b/app/apps/client/src/i18n/locales/en/sidebar.json
@@ -28,6 +28,8 @@
     "clickToDownload": "Click to download the latest version",
     "download": "Download Update",
     "downloading": "Opening...",
-    "dismiss": "Dismiss"
+    "dismiss": "Dismiss",
+    "dev": "Dev",
+    "devInstanceHint": "Running a dev instance — update checks are disabled"
   }
 }

--- a/app/apps/client/src/i18n/locales/ro/settings.json
+++ b/app/apps/client/src/i18n/locales/ro/settings.json
@@ -942,7 +942,9 @@
       "downloadUpdate": "Descarcă Actualizarea",
       "downloading": "Se deschide...",
       "upToDate": "Rulezi cea mai recentă versiune.",
-      "viewReleaseNotes": "Vezi notele versiunii pe GitHub"
+      "viewReleaseNotes": "Vezi notele versiunii pe GitHub",
+      "devInstance": "Instanță de dezvoltare",
+      "devInstanceDescription": "Rulezi o versiune de dezvoltare — verificarea actualizărilor este dezactivată."
     }
   }
 }

--- a/app/apps/client/src/i18n/locales/ro/sidebar.json
+++ b/app/apps/client/src/i18n/locales/ro/sidebar.json
@@ -28,6 +28,8 @@
     "clickToDownload": "Apasă pentru a descărca ultima versiune",
     "download": "Descarcă Actualizarea",
     "downloading": "Se deschide...",
-    "dismiss": "Închide"
+    "dismiss": "Închide",
+    "dev": "Dev",
+    "devInstanceHint": "Rulează o instanță de dezvoltare — verificarea actualizărilor este dezactivată"
   }
 }


### PR DESCRIPTION
Two related fixes from the v0.1.72 release:

- **ci(release):** remove the `sync-version-back` job — it pushed the version bump directly to `main`, which the protected-ref ruleset rejects (GH013), so it failed on every release. The shipped version comes from the tag; bump via the normal `chore: bump version` PR.
- **feat(app-update):** on a dev instance (`import.meta.env.DEV`), skip the GitHub update check + hourly poll (no more rate-limit console errors), never show the upgrade prompt, and surface a `Dev` badge in the sidebar + a 'development instance' note on the About page. EN + RO i18n.

Verified locally: client unit tests pass, biome clean, About page shows the dev note with the update check suppressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)