### PR TITLE
ci(release): include version in download artifact names (-v-X.X.X)

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -136,6 +136,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: v${{ steps.version.outputs.version }}
+          VERSION: ${{ steps.version.outputs.version }}
         run: |
           # Build the release notes once into a temp file so the create
           # and edit branches share the same body — keeps the heredoc in
@@ -151,9 +152,9 @@ jobs:
 
           | Platform | Download |
           |----------|----------|
-          | **macOS** (Apple Silicon) | [Download .dmg](https://github.com/radio-crestin/church-hub/releases/latest/download/church-hub-macos-arm64.dmg) |
-          | **macOS** (Intel) | [Download .dmg](https://github.com/radio-crestin/church-hub/releases/latest/download/church-hub-macos-x64.dmg) |
-          | **Windows** (x64) | [Download .exe](https://github.com/radio-crestin/church-hub/releases/latest/download/church-hub-windows-x64.exe) |
+          | **macOS** (Apple Silicon) | [Download .dmg](https://github.com/radio-crestin/church-hub/releases/download/$TAG/church-hub-macos-arm64-v-$VERSION.dmg) |
+          | **macOS** (Intel) | [Download .dmg](https://github.com/radio-crestin/church-hub/releases/download/$TAG/church-hub-macos-x64-v-$VERSION.dmg) |
+          | **Windows** (x64) | [Download .exe](https://github.com/radio-crestin/church-hub/releases/download/$TAG/church-hub-windows-x64-v-$VERSION.exe) |
 
           ---
 
@@ -215,21 +216,24 @@ jobs:
             rust_target: aarch64-apple-darwin
             bun_target: bun-darwin-arm64
             sidecar_suffix: aarch64-apple-darwin
-            consistent_name: church-hub-macos-arm64.dmg
+            artifact_base: church-hub-macos-arm64
+            artifact_ext: dmg
 
           # macOS x64 (Intel) - cross-compiled from ARM64 runner
           - platform: macos-latest
             rust_target: x86_64-apple-darwin
             bun_target: bun-darwin-x64
             sidecar_suffix: x86_64-apple-darwin
-            consistent_name: church-hub-macos-x64.dmg
+            artifact_base: church-hub-macos-x64
+            artifact_ext: dmg
 
           # Windows x64
           - platform: windows-latest
             rust_target: x86_64-pc-windows-msvc
             bun_target: bun-windows-x64
             sidecar_suffix: x86_64-pc-windows-msvc.exe
-            consistent_name: church-hub-windows-x64.exe
+            artifact_base: church-hub-windows-x64
+            artifact_ext: exe
 
     runs-on: ${{ matrix.platform }}
 
@@ -245,9 +249,11 @@ jobs:
           # MSI requires numeric-only pre-release identifiers
           # Strip non-numeric pre-release (e.g., "0.1.46-beta.2" -> "0.1.46")
           TAURI_VERSION=$(echo "$VERSION" | sed 's/-[^0-9].*//')
+          ARTIFACT_NAME="${{ matrix.artifact_base }}-v-${VERSION}.${{ matrix.artifact_ext }}"
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "tauri_version=$TAURI_VERSION" >> $GITHUB_OUTPUT
-          echo "Building version: $VERSION (tauri: $TAURI_VERSION)"
+          echo "artifact_name=$ARTIFACT_NAME" >> $GITHUB_OUTPUT
+          echo "Building version: $VERSION (tauri: $TAURI_VERSION, artifact: $ARTIFACT_NAME)"
 
       - name: Update version in tauri.conf.json
         shell: bash
@@ -385,7 +391,7 @@ jobs:
           done
           echo "=== Done ==="
 
-      - name: Create consistently named artifact (macOS)
+      - name: Create versioned artifact (macOS)
         if: matrix.platform == 'macos-latest'
         shell: bash
         run: |
@@ -393,16 +399,16 @@ jobs:
           DMG_FILE=$(find app/tauri/target -name "*.dmg" -type f 2>/dev/null | head -1)
           echo "Found: $DMG_FILE"
           if [ -n "$DMG_FILE" ] && [ -f "$DMG_FILE" ]; then
-            cp "$DMG_FILE" "${{ matrix.consistent_name }}"
-            echo "Created: ${{ matrix.consistent_name }}"
-            ls -la "${{ matrix.consistent_name }}"
+            cp "$DMG_FILE" "${{ steps.version.outputs.artifact_name }}"
+            echo "Created: ${{ steps.version.outputs.artifact_name }}"
+            ls -la "${{ steps.version.outputs.artifact_name }}"
           else
             echo "No .dmg file found!"
             find app/tauri/target -type f -name "*" | grep -E '\.(dmg|app)' || echo "No dmg/app files found"
             exit 1
           fi
 
-      - name: Create consistently named artifact (Windows)
+      - name: Create versioned artifact (Windows)
         if: matrix.platform == 'windows-latest'
         shell: bash
         run: |
@@ -410,19 +416,19 @@ jobs:
           EXE_FILE=$(find app/tauri/target -name "*-setup.exe" -type f 2>/dev/null | head -1)
           echo "Found: $EXE_FILE"
           if [ -n "$EXE_FILE" ] && [ -f "$EXE_FILE" ]; then
-            cp "$EXE_FILE" "${{ matrix.consistent_name }}"
-            echo "Created: ${{ matrix.consistent_name }}"
-            ls -la "${{ matrix.consistent_name }}"
+            cp "$EXE_FILE" "${{ steps.version.outputs.artifact_name }}"
+            echo "Created: ${{ steps.version.outputs.artifact_name }}"
+            ls -la "${{ steps.version.outputs.artifact_name }}"
           else
             echo "No setup exe file found!"
             find app/tauri/target -type f -name "*.exe" || echo "No exe files found"
             exit 1
           fi
 
-      - name: Upload consistently named artifact to release
+      - name: Upload versioned artifact to release
         uses: softprops/action-gh-release@v2
         with:
-          files: ${{ matrix.consistent_name }}
+          files: ${{ steps.version.outputs.artifact_name }}
           tag_name: v${{ steps.version.outputs.version }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,8 +17,11 @@ on:
 
 permissions:
   contents: read
-  pull-requests: read
-  # The /test gate reacts to the triggering PR comment (issue-comment APIs)
+  # The /test gate reacts to the triggering PR comment. Reacting to a
+  # comment that belongs to a PR is authorized via the pull-requests
+  # permission — issues: write alone 403s with "Resource not accessible
+  # by integration" — so both need write.
+  pull-requests: write
   issues: write
   statuses: write
   checks: write

--- a/.gitignore
+++ b/.gitignore
@@ -107,3 +107,6 @@ app/apps/client/test-results/
 app/apps/client/playwright-report/
 app/apps/client/coverage/
 app/test-results/
+
+# Claude Code worktrees (scripts/release.sh requires a clean tree)
+.claude/worktrees/

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Built with modern web technologies and powered by Tauri, Church Hub runs as a na
 <table align="center">
   <tr>
     <td align="center">
-      <a href="https://github.com/radio-crestin/church-hub/releases/latest/download/church-hub-windows-x64.exe">
+      <a href="https://github.com/radio-crestin/church-hub/releases/latest">
         <img src="https://img.shields.io/badge/Windows-0078D6?style=for-the-badge&logo=windows&logoColor=white" alt="Windows"/>
         <br/>
         <sub><b>Windows (x64)</b></sub>
@@ -45,7 +45,7 @@ Built with modern web technologies and powered by Tauri, Church Hub runs as a na
       </a>
     </td>
     <td align="center">
-      <a href="https://github.com/radio-crestin/church-hub/releases/latest/download/church-hub-macos-arm64.dmg">
+      <a href="https://github.com/radio-crestin/church-hub/releases/latest">
         <img src="https://img.shields.io/badge/macOS-000000?style=for-the-badge&logo=apple&logoColor=white" alt="macOS"/>
         <br/>
         <sub><b>macOS (Apple Silicon)</b></sub>


### PR DESCRIPTION
## Summary

Release assets are now named with the version inside, e.g. `church-hub-macos-arm64-v-0.1.72.dmg` instead of `church-hub-macos-arm64.dmg`, so downloaded installers are distinguishable across versions.

## Changes

- **Build workflow** (`.github/workflows/build-release.yml`): the static `consistent_name` matrix values were split into `artifact_base` + `artifact_ext`; the final filename is composed from the release tag at build time (`<base>-v-<version>.<ext>`) and used for the copy + upload steps.
- **Release notes template**: the "Direct Downloads" table now links to the tag's own versioned assets (`releases/download/$TAG/...`) instead of `releases/latest/download/...`. Side fix: old releases' notes no longer silently serve a newer version's files.
- **README download buttons**: point to the latest release page (`releases/latest`), since GitHub's `latest/download/<file>` URL requires a stable filename, which no longer exists.
- **`/test` gate fix** (`.github/workflows/test.yml`): the gate 403'd adding the 🚀 reaction on every PR — reactions on a comment that belongs to a PR are authorized via `pull-requests` permission, so `issues: write` alone wasn't enough. Bumped `pull-requests` to `write`.
- **.gitignore**: ignore `.claude/worktrees/` so `scripts/release.sh`'s clean-tree check passes.

## Notes

- Takes effect on the next tagged release.
- Breaking for anything external that hardcodes the old stable asset URLs (bookmarks, scripts) — the un-versioned filenames are no longer uploaded.
- No code paths reference the old filenames (checked scripts, app code, configs); `actionlint` passes with no new issues.
- CI validated via `workflow_dispatch` on the branch (the comment-triggered gate reads `test.yml` from main, so it can't validate its own fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)