### PR TITLE
feat: logs viewer & activity logging, song category visibility, presenter remote, and configurable song slide layouts

### DIFF
--- a/.claude/skills/detailed-pr/SKILL.md
+++ b/.claude/skills/detailed-pr/SKILL.md
@@ -1,0 +1,193 @@
+---
+name: detailed-pr
+description: Generate an extremely detailed, professional "Staff Engineer final review" Pull Request description (13-section Markdown — Summary, Why, What changed, Technical details, API changes, Database changes, Permissions/Authorization, UI/UX, Migration/Backfill, Commit breakdown, Test plan, Risks, Out of scope) grounded in the branch's REAL commits and diff, then create or update the GitHub PR with it. Use WHENEVER the user asks to create, open, make, write, refresh, or update a PR or a PR description — e.g. "fă un PR", "fă-mi un PR", "deschide un PR", "update la PR", "actualizează descrierea PR-ului", "create/open/update a PR". This is the lightweight text-only counterpart to `documented-pr` (which records GIF demos); prefer THIS one unless the user explicitly wants demo videos.
+---
+
+# detailed-pr
+
+Produce a Pull Request description so thorough that any reviewer understands the
+problem, why it mattered, the solution, the design decisions, and every
+permission / migration / API / UI change — then open or update the PR with it.
+
+The description must read as if written by the feature's **principal author**.
+**Everything is grounded in the actual branch diff — never invent endpoints,
+permissions, migrations, or behaviour the diff doesn't contain.**
+
+This skill is text-only (no GIF recording). For the GIF-demo variant the user
+invokes `/documented-pr` explicitly.
+
+---
+
+## Step 0 — Language
+
+Default to **English content with the English section headers below** (matches
+this repo's existing commits/PRs). If the user explicitly asks for Romanian,
+write the prose in Romanian but **keep the English section headers**. When
+unsure, check existing PRs: `gh pr list --state all --limit 5 --json title`.
+
+---
+
+## Step 1 — Gather the facts (run these; base them, not memory)
+
+```bash
+# Branch + base
+BRANCH=$(git rev-parse --abbrev-ref HEAD)
+BASE=$(gh pr view --json baseRefName -q .baseRefName 2>/dev/null || echo main)
+git fetch origin "$BASE" --quiet
+
+# Commits, stat, files (use three-dot for "since divergence")
+git log --pretty='%h %s' "origin/$BASE..HEAD"
+git diff --shortstat "origin/$BASE...HEAD"
+git diff --name-only "origin/$BASE...HEAD"
+```
+
+Then detect the high-signal areas the format requires a dedicated section for:
+
+```bash
+# Database: migrations + schema changes
+git diff --name-only "origin/$BASE...HEAD" | grep -iE 'migration|db/schema' || true
+#   → read each migration file fully (what it ALTERs/INSERTs, idempotency guard)
+
+# Permissions: new permission keys, and whether they are NEW vs pre-existing
+git diff "origin/$BASE...HEAD" | grep -E '^\+' | grep -oE "'[a-z_]+\.[a-z_]+'" | sort -u
+#   for each candidate, confirm whether it already existed on the base:
+#   git show "origin/$BASE:<permission-catalog-file>" | grep -c '<key>'   (>0 = pre-existing, only newly ENFORCED)
+
+# API: new/changed endpoints (routes, handlers, openapi paths)
+git diff "origin/$BASE...HEAD" | grep -E '^\+' | grep -iE "app\.(get|post|put|delete|patch)|url\.pathname ===|/api/" | head -40
+
+# UI surfaces, new components/hooks/services
+git diff --name-only "origin/$BASE...HEAD" | grep -iE 'components|hooks|service|routes' | head
+```
+
+Read the bodies of anything flagged (migrations especially). If the diff touches
+**permissions, authorization, migrations, or data**, prioritise depth over
+brevity in those sections — they are the highest-risk parts of any review.
+
+If the branch is behind the base, say so; offer to merge `origin/$BASE` first
+(a conflict-laden description is misleading).
+
+---
+
+## Step 2 — Generate the description (this EXACT 13-section format)
+
+Write to `/tmp/pr-body.md`. Fill every section that applies; omit a section only
+when the diff genuinely has nothing for it (e.g. no DB change → write
+"No database changes." rather than fabricating one). Use tables where they add
+clarity, hierarchical lists, and concrete examples. Group commits by theme and
+cite their short hashes.
+
+```markdown
+# <PR title>
+
+### 1. Summary
+Natural-language explanation of what this PR brings. If the branch contains
+multiple themes/directions, enumerate them.
+
+### 2. Why
+The original problems. For EACH problem, in subsections when needed:
+- the previous behaviour
+- why it was wrong/problematic
+- a concrete example
+- the affected user flow(s)
+- the impact on product / users / operations
+
+### 3. What changed
+Split by functional area (Bug fixes, Backend, Frontend, Permissions, API,
+Database, Migrations, Refactors, Naming, UX). For each area: intent →
+implementation → relevant side effects → backward compatibility. Reference the
+relevant commit hashes, grouped by theme.
+
+### 4. Technical details
+Implementation context where useful: new services, helpers, hooks, endpoints,
+queries, models, components, guards, middlewares, jobs, events, permissions,
+feature flags. Use tables (e.g. | Kind | Name | Purpose |).
+
+### 5. API changes
+New endpoints, changed endpoints, request/response changes, required
+permissions. Use code blocks (```http …```).
+
+### 6. Database changes
+New tables/columns/indexes/constraints/foreign-keys/backfills/migrations.
+Explain compatibility and the rollback strategy clearly.
+
+### 7. Permissions / Authorization
+What permissions exist, what they grant, how they interact with existing ones,
+and the migration/backward-compat strategy. Present as tables. Mark each
+permission NEW vs EXISTING (newly enforced).
+
+### 8. UI / UX changes
+User-visible changes, new buttons, empty states, view cases, edit cases,
+naming/label changes.
+
+### 9. Migration / Backfill strategy
+For each migration: exactly what it does, why it is safe, why it is idempotent,
+and what happens if it runs again.
+
+### 10. Commit breakdown
+Themed groups, each with `<hash> <subject>`:
+#### <Theme>
+- `abc1234` …
+
+### 11. Test plan
+Detailed manual-validation checklist with Markdown checkboxes, covering: happy
+paths, edge cases, regression, permission matrix, API validation, database
+validation, migration validation, UI validation. Mark anything that can't be
+reproduced in the dev/browser environment (e.g. packaged-app/WebView behaviour)
+explicitly.
+
+### 12. Risks
+Potential risks across: data, permissions, performance, compatibility, UX —
+each with a mitigation.
+
+### 13. Out of scope
+Explicitly list everything this PR does NOT do.
+```
+
+### Quality requirements (non-negotiable)
+- No vague summaries. Deduce the architectural intent from the implemented changes.
+- Explain the reasoning behind each decision.
+- Tables where they increase clarity; hierarchical lists; concrete examples.
+- A migration or a permission change gets a full dedicated section.
+- If the PR touches permissions, authorization, or data → depth over brevity.
+- Produce a description **ready to copy-paste into GitHub with no further edits**.
+
+---
+
+## Step 3 — Push, then create or update the PR
+
+The branch must be on origin before the PR can reference its commits. Pushing
+and PR create/edit are part of this skill's contract — **the project-wide "ask
+before pushing" rule is suspended the moment the user invokes this skill**; do
+not ask for confirmation.
+
+```bash
+git push -u origin "$BRANCH"
+
+if gh pr view --json number -q .number >/dev/null 2>&1; then
+  gh pr edit "$(gh pr view --json number -q .number)" --body-file /tmp/pr-body.md
+  # update the title too only if the user asked or it's clearly stale:
+  # gh pr edit <num> --title "<title>"
+else
+  gh pr create --base "$BASE" --head "$BRANCH" --title "<title>" --body-file /tmp/pr-body.md
+fi
+gh pr view --json url -q .url   # show the user the link
+```
+
+Title style: `<scope or domain>: <short summary>` — compact, conventional.
+
+---
+
+## Constraints
+
+- **Sole author.** This user requires being the sole author. Do NOT add a
+  `Co-Authored-By: Claude` trailer to any commit, and do NOT add a
+  "Generated with Claude Code" footer to the PR body.
+- **Grounded only.** Every claim (endpoint, permission, migration, column, file
+  count) must come from the actual diff/commits. When something is uncertain,
+  inspect it; do not guess.
+- **Create vs update.** If a PR already exists for the branch, UPDATE it
+  (`gh pr edit`); otherwise CREATE it. Never open a duplicate.
+- **Push every time** before `gh pr create` / `gh pr edit`.
+- **Don't pad.** Omit a section with a one-line "N/A" rather than inventing
+  content to fill the template.

--- a/app/apps/client/e2e/presenter-remote.spec.ts
+++ b/app/apps/client/e2e/presenter-remote.spec.ts
@@ -37,16 +37,16 @@ test.describe('Presenter remote', () => {
     return (await res.json()).data.id as number
   }
 
-  test('F5 presents focused; forward advances and closes past last; black closes', async ({
+  test('F5 presents focused; forward advances and hides past last; black hides like Escape', async ({
     page,
     request,
   }) => {
     const songId = await makeSong(request, `E2E Remote ${Date.now()}`, 2)
 
+    const rawState = async () =>
+      (await (await request.get('/api/presentation/state')).json()).data
     const songTemp = async (): Promise<SongTemp | null> => {
-      const { data } = await (
-        await request.get('/api/presentation/state')
-      ).json()
+      const data = await rawState()
       const tc = data?.temporaryContent
       return tc?.type === 'song' && tc.data.songId === songId ? tc.data : null
     }
@@ -71,12 +71,13 @@ test.describe('Presenter remote', () => {
       await page.keyboard.press('PageDown')
       await expect.poll(slideIndex, { timeout: 10000 }).toBe(1)
 
-      // Forward past the last slide → presentation CLOSES.
+      // Forward past the last slide → presentation is hidden (content cleared).
       await page.keyboard.press('PageDown')
       await expect.poll(songTemp, { timeout: 10000 }).toBeNull()
       await page.waitForTimeout(1500)
 
-      // Present again, then the black button ("b") closes it.
+      // Present again, then the black button ("b") hides it like Escape:
+      // isHidden becomes true but the temporary content is kept (restorable).
       await page.evaluate(() =>
         (document.activeElement as HTMLElement | null)?.blur(),
       )
@@ -85,7 +86,11 @@ test.describe('Presenter remote', () => {
       await page.waitForTimeout(1500)
 
       await page.keyboard.press('b')
-      await expect.poll(songTemp, { timeout: 10000 }).toBeNull()
+      await expect
+        .poll(async () => (await rawState())?.isHidden, { timeout: 10000 })
+        .toBe(true)
+      // Content is kept (Escape-style blank, not a full close).
+      expect(await songTemp()).not.toBeNull()
     } finally {
       await request.delete(`/api/songs/${songId}`).catch(() => {})
     }

--- a/app/apps/client/e2e/presenter-remote.spec.ts
+++ b/app/apps/client/e2e/presenter-remote.spec.ts
@@ -1,0 +1,134 @@
+import { expect, test } from '@playwright/test'
+
+/**
+ * Presenter-remote (clicker) flow. Remotes emit plain keyboard events:
+ *   F5 = present/start, PageDown = forward, PageUp = back, "b"/"." = black.
+ *
+ * Desired behaviour:
+ *  - Not presenting + F5 → present the currently-focused slide.
+ *  - Forward advances; advancing past the last slide CLOSES the presentation.
+ *  - Back goes to the first slide and never closes (even if pressed again).
+ *  - The black button CLOSES the presentation.
+ *
+ * Presentation state is a server singleton, so we assert against
+ * /api/presentation/state filtered by our song id.
+ */
+
+interface SongTemp {
+  songId: number
+  currentSlideIndex: number
+}
+
+test.describe('Presenter remote', () => {
+  // Presentation state is global on the server — keep these serial.
+  test.describe.configure({ mode: 'serial' })
+
+  async function makeSong(
+    request: import('@playwright/test').APIRequestContext,
+    title: string,
+    slideCount: number,
+  ): Promise<number> {
+    const slides = Array.from({ length: slideCount }, (_, i) => ({
+      content: `${title} slide ${i + 1}`,
+      type: i === 0 ? 'verse' : 'chorus',
+    }))
+    const res = await request.post('/api/songs', { data: { title, slides } })
+    expect([201, 409]).toContain(res.status())
+    return (await res.json()).data.id as number
+  }
+
+  test('F5 presents focused; forward advances and closes past last; black closes', async ({
+    page,
+    request,
+  }) => {
+    const songId = await makeSong(request, `E2E Remote ${Date.now()}`, 2)
+
+    const songTemp = async (): Promise<SongTemp | null> => {
+      const { data } = await (
+        await request.get('/api/presentation/state')
+      ).json()
+      const tc = data?.temporaryContent
+      return tc?.type === 'song' && tc.data.songId === songId ? tc.data : null
+    }
+    const slideIndex = async () => (await songTemp())?.currentSlideIndex ?? -1
+
+    try {
+      await page.goto(`/songs/${songId}`)
+      await page.waitForLoadState('networkidle')
+      // Ensure no input holds focus so keys reach the global handler.
+      await page.evaluate(() =>
+        (document.activeElement as HTMLElement | null)?.blur(),
+      )
+
+      // Present button (F5) → present the focused slide (index 0).
+      await page.keyboard.press('F5')
+      await expect.poll(slideIndex, { timeout: 10000 }).toBe(0)
+      // Let the client's presentation state catch up (websocket round-trip) so
+      // the next key acts on a live presentation.
+      await page.waitForTimeout(1500)
+
+      // Forward (PageDown) → next slide.
+      await page.keyboard.press('PageDown')
+      await expect.poll(slideIndex, { timeout: 10000 }).toBe(1)
+
+      // Forward past the last slide → presentation CLOSES.
+      await page.keyboard.press('PageDown')
+      await expect.poll(songTemp, { timeout: 10000 }).toBeNull()
+      await page.waitForTimeout(1500)
+
+      // Present again, then the black button ("b") closes it.
+      await page.evaluate(() =>
+        (document.activeElement as HTMLElement | null)?.blur(),
+      )
+      await page.keyboard.press('F5')
+      await expect.poll(slideIndex, { timeout: 10000 }).toBe(0)
+      await page.waitForTimeout(1500)
+
+      await page.keyboard.press('b')
+      await expect.poll(songTemp, { timeout: 10000 }).toBeNull()
+    } finally {
+      await request.delete(`/api/songs/${songId}`).catch(() => {})
+    }
+  })
+
+  test('back stops at the first slide and never closes', async ({
+    page,
+    request,
+  }) => {
+    const songId = await makeSong(request, `E2E Remote Back ${Date.now()}`, 2)
+
+    const songTemp = async (): Promise<SongTemp | null> => {
+      const { data } = await (
+        await request.get('/api/presentation/state')
+      ).json()
+      const tc = data?.temporaryContent
+      return tc?.type === 'song' && tc.data.songId === songId ? tc.data : null
+    }
+    const slideIndex = async () => (await songTemp())?.currentSlideIndex ?? -1
+
+    try {
+      await page.goto(`/songs/${songId}`)
+      await page.waitForLoadState('networkidle')
+      await page.evaluate(() =>
+        (document.activeElement as HTMLElement | null)?.blur(),
+      )
+
+      await page.keyboard.press('F5')
+      await expect.poll(slideIndex, { timeout: 10000 }).toBe(0)
+      await page.waitForTimeout(1500)
+      await page.keyboard.press('PageDown')
+      await expect.poll(slideIndex, { timeout: 10000 }).toBe(1)
+
+      // Back → first slide.
+      await page.keyboard.press('PageUp')
+      await expect.poll(slideIndex, { timeout: 10000 }).toBe(0)
+
+      // Back again at the first slide → stays at 0, does NOT close.
+      await page.keyboard.press('PageUp')
+      await page.waitForTimeout(1000)
+      expect(await slideIndex()).toBe(0)
+    } finally {
+      await request.delete(`/api/songs/${songId}`).catch(() => {})
+    }
+  })
+})

--- a/app/apps/client/e2e/settings-logs.spec.ts
+++ b/app/apps/client/e2e/settings-logs.spec.ts
@@ -1,0 +1,183 @@
+import { type APIRequestContext, expect, test } from '@playwright/test'
+
+/**
+ * Verifies the in-app Logs feature end to end:
+ *  - GET /api/logs/content is gated by `logs.view`,
+ *  - POST /api/logs/clear is gated (independently) by `logs.clear`,
+ *  - the two permissions can be granted independently to a user,
+ *  - the activity ingestion endpoint accepts client events,
+ *  - and the super admin sees the Logs settings section in the UI.
+ *
+ * The default `request` fixture carries the super-admin session (auth.setup.ts).
+ * For the limited-user checks we spin up clean contexts with their own session.
+ */
+
+const PASSWORD = 'e2e-secret-123'
+
+test.describe('Settings · Logs', () => {
+  // One test truncates the shared log dir; run serially so the auth-log
+  // assertion isn't wiped by a concurrent clear.
+  test.describe.configure({ mode: 'serial' })
+
+  test('super admin can read log content', async ({ request }) => {
+    const res = await request.get('/api/logs/content')
+    expect(res.ok()).toBeTruthy()
+    const { data } = await res.json()
+    expect(typeof data.logsDir).toBe('string')
+    expect(typeof data.serverTail).toBe('string')
+    expect(typeof data.tauriTail).toBe('string')
+  })
+
+  test('super admin can clear logs', async ({ request }) => {
+    const res = await request.post('/api/logs/clear')
+    expect(res.ok()).toBeTruthy()
+    const { data } = await res.json()
+    expect(typeof data.cleared).toBe('number')
+  })
+
+  test('a user WITHOUT logs perms is denied content + clear', async ({
+    request,
+    playwright,
+  }, testInfo) => {
+    const baseURL = testInfo.project.use.baseURL as string
+    const create = await request.post('/api/users', {
+      data: {
+        name: `E2E NoLogs ${Date.now()}`,
+        permissions: ['songs.view'],
+        password: PASSWORD,
+      },
+    })
+    expect([200, 201]).toContain(create.status())
+    const userId = (await create.json()).data.user.id as number
+
+    const guest: APIRequestContext = await playwright.request.newContext({
+      baseURL,
+    })
+    try {
+      const login = await guest.post('/api/auth/login', {
+        data: { userId, password: PASSWORD },
+      })
+      expect(login.ok()).toBeTruthy()
+
+      expect((await guest.get('/api/logs/content')).status()).toBe(403)
+      expect((await guest.post('/api/logs/clear')).status()).toBe(403)
+    } finally {
+      await guest.dispose()
+      await request.delete(`/api/users/${userId}`)
+    }
+  })
+
+  test('logs.view grants read but NOT clear (independent perms)', async ({
+    request,
+    playwright,
+  }, testInfo) => {
+    const baseURL = testInfo.project.use.baseURL as string
+    const create = await request.post('/api/users', {
+      data: {
+        name: `E2E LogsView ${Date.now()}`,
+        permissions: ['logs.view'],
+        password: PASSWORD,
+      },
+    })
+    expect([200, 201]).toContain(create.status())
+    const userId = (await create.json()).data.user.id as number
+
+    const guest: APIRequestContext = await playwright.request.newContext({
+      baseURL,
+    })
+    try {
+      const login = await guest.post('/api/auth/login', {
+        data: { userId, password: PASSWORD },
+      })
+      expect(login.ok()).toBeTruthy()
+
+      // /api/auth/me reflects the single granted permission.
+      const me = await (await guest.get('/api/auth/me')).json()
+      expect(me.data.permissions).toContain('logs.view')
+      expect(me.data.permissions).not.toContain('logs.clear')
+
+      // Can read logs…
+      expect((await guest.get('/api/logs/content')).ok()).toBeTruthy()
+      // …but cannot clear them.
+      expect((await guest.post('/api/logs/clear')).status()).toBe(403)
+    } finally {
+      await guest.dispose()
+      await request.delete(`/api/users/${userId}`)
+    }
+  })
+
+  test('client activity ingestion accepts events (public)', async ({
+    playwright,
+  }, testInfo) => {
+    const baseURL = testInfo.project.use.baseURL as string
+    // Pre-auth on purpose — activity (e.g. the login screen) happens before a
+    // session exists, so a no-cookie context must be accepted.
+    const guest = await playwright.request.newContext({ baseURL })
+    try {
+      const res = await guest.post('/api/client-activity', {
+        data: {
+          events: [
+            { action: 'navigate', source: 'e2e', context: { path: '/songs' } },
+            { action: 'login', source: 'e2e' },
+          ],
+        },
+      })
+      expect(res.ok()).toBeTruthy()
+      const { data } = await res.json()
+      expect(data.received).toBe(2)
+    } finally {
+      await guest.dispose()
+    }
+  })
+
+  test('auth events are written to the log', async ({
+    request,
+    playwright,
+  }, testInfo) => {
+    const baseURL = testInfo.project.use.baseURL as string
+    const name = `E2E AuthLog ${Date.now()}`
+    const create = await request.post('/api/users', {
+      data: { name, permissions: ['songs.view'], password: PASSWORD },
+    })
+    const userId = (await create.json()).data.user.id as number
+
+    const guest = await playwright.request.newContext({ baseURL })
+    try {
+      // A login writes an [auth] "Login success" line to the server log.
+      const login = await guest.post('/api/auth/login', {
+        data: { userId, password: PASSWORD },
+      })
+      expect(login.ok()).toBeTruthy()
+
+      // The super admin can read the log content and should see the auth trail.
+      // Widen the tail so a busy parallel run doesn't push the line out.
+      const { data } = await (
+        await request.get('/api/logs/content?maxBytes=1048576&days=1')
+      ).json()
+      expect(data.serverTail).toContain('[auth]')
+      expect(data.serverTail).toContain('Login success')
+    } finally {
+      await guest.dispose()
+      await request.delete(`/api/users/${userId}`)
+    }
+  })
+
+  test('super admin sees the Logs settings section', async ({ page }) => {
+    await page.goto('/settings/logs')
+    await page.waitForLoadState('networkidle')
+
+    // Section heading (settings namespace: sections.logs.title) — the section
+    // card renders it as the <h2>.
+    await expect(
+      page.getByRole('heading', {
+        level: 2,
+        name: /application logs|jurnale aplica/i,
+      }),
+    ).toBeVisible({ timeout: 10000 })
+
+    // The viewer's server-logs block is present.
+    await expect(
+      page.getByText(/server logs|jurnale server/i).first(),
+    ).toBeVisible()
+  })
+})

--- a/app/apps/client/e2e/settings-logs.spec.ts
+++ b/app/apps/client/e2e/settings-logs.spec.ts
@@ -179,5 +179,22 @@ test.describe('Settings · Logs', () => {
     await expect(
       page.getByText(/server logs|jurnale server/i).first(),
     ).toBeVisible()
+
+    // Level filter chips and the search box are present.
+    await expect(
+      page.getByRole('button', { name: /errors|erori/i }),
+    ).toBeVisible()
+    await expect(
+      page.getByRole('button', { name: /warnings|avertismente/i }),
+    ).toBeVisible()
+    await expect(
+      page.getByPlaceholder(/search logs|caută în jurnale/i),
+    ).toBeVisible()
+
+    // Toggling a level off updates its pressed state (filter is interactive).
+    const errorsChip = page.getByRole('button', { name: /errors|erori/i })
+    await expect(errorsChip).toHaveAttribute('aria-pressed', 'true')
+    await errorsChip.click()
+    await expect(errorsChip).toHaveAttribute('aria-pressed', 'false')
   })
 })

--- a/app/apps/client/e2e/song-category-hidden.spec.ts
+++ b/app/apps/client/e2e/song-category-hidden.spec.ts
@@ -88,4 +88,63 @@ test.describe('Song category hide/show', () => {
       await request.delete(`/api/categories/${catId}`).catch(() => {})
     }
   })
+
+  test('a hidden category song is excluded from version "possible matches"', async ({
+    request,
+  }) => {
+    const stamp = `${Date.now()}`
+    // Identical lyrics + near-identical titles so the candidate scores as a
+    // strong version match. The candidate lives in the category we will hide.
+    const lyrics = [
+      { content: `Slava Domnului in veci match ${stamp}`, type: 'verse' },
+      { content: `Cantam impreuna o cantare noua ${stamp}`, type: 'chorus' },
+    ]
+
+    const catRes = await request.post('/api/categories', {
+      data: { name: `E2E Match Cat ${stamp}`, priority: 1 },
+    })
+    const catId = (await catRes.json()).data.id as number
+
+    const subjectRes = await request.post('/api/songs', {
+      data: { title: `E2E Match Alpha ${stamp}`, slides: lyrics },
+    })
+    const subjectId = (await subjectRes.json()).data.id as number
+
+    const candidateRes = await request.post('/api/songs', {
+      data: {
+        title: `E2E Match Beta ${stamp}`,
+        categoryId: catId,
+        slides: lyrics,
+      },
+    })
+    const candidateId = (await candidateRes.json()).data.id as number
+
+    const similarHasCandidate = async (): Promise<boolean> => {
+      const r = await request.get(`/api/songs/${subjectId}/similar?limit=20`)
+      const { data } = await r.json()
+      return data.some((s: { songId: number }) => s.songId === candidateId)
+    }
+
+    try {
+      // Precondition: the candidate is suggested as a possible match.
+      expect(await similarHasCandidate()).toBe(true)
+
+      // Hiding the candidate's category drops it from the suggestions.
+      const hideRes = await request.post('/api/categories', {
+        data: { id: catId, name: `E2E Match Cat ${stamp}`, isHidden: 1 },
+      })
+      expect(hideRes.ok()).toBeTruthy()
+      expect(await similarHasCandidate()).toBe(false)
+
+      // Showing it again brings the match back.
+      await request.post('/api/categories', {
+        data: { id: catId, name: `E2E Match Cat ${stamp}`, isHidden: 0 },
+      })
+      expect(await similarHasCandidate()).toBe(true)
+    } finally {
+      await request.delete(`/api/songs/${subjectId}`).catch(() => {})
+      await request.delete(`/api/songs/${candidateId}`).catch(() => {})
+      await request.delete(`/api/categories/${catId}`).catch(() => {})
+    }
+  })
 })

--- a/app/apps/client/e2e/song-category-hidden.spec.ts
+++ b/app/apps/client/e2e/song-category-hidden.spec.ts
@@ -1,0 +1,91 @@
+import { expect, test } from '@playwright/test'
+
+/**
+ * Verifies the song-category "hide/show" feature:
+ *  - hiding a category removes its songs from the song list AND search,
+ *  - the category itself is still returned to admins (with isHidden=1) so it
+ *    can be re-shown,
+ *  - showing it again restores its songs.
+ *
+ * Nothing is deleted — the song row survives the whole cycle.
+ */
+
+test.describe('Song category hide/show', () => {
+  test('hiding a category hides its songs (list + search); showing restores them', async ({
+    request,
+  }) => {
+    const stamp = `${Date.now()}`
+    const catName = `E2E Hide Cat ${stamp}`
+    const songTitle = `E2E HiddenSong ${stamp}`
+
+    const catRes = await request.post('/api/categories', {
+      data: { name: catName, priority: 1 },
+    })
+    expect([200, 201]).toContain(catRes.status())
+    const category = (await catRes.json()).data
+    expect(category.isHidden).toBe(0)
+    const catId = category.id as number
+
+    const songRes = await request.post('/api/songs', {
+      data: {
+        title: songTitle,
+        categoryId: catId,
+        slides: [{ content: 'a hidden verse', type: 'verse' }],
+      },
+    })
+    expect([201, 409]).toContain(songRes.status())
+    const songId = (await songRes.json()).data.id as number
+
+    // Scope the list to this category (the seeded test DB has many songs, so an
+    // unscoped page could miss ours). When the category is hidden, the server's
+    // exclusion makes even this category-scoped query return nothing.
+    const listHasSong = async (): Promise<boolean> => {
+      const r = await request.get(
+        `/api/songs?categoryIds=${catId}&limit=500&offset=0`,
+      )
+      const { data } = await r.json()
+      return data.songs.some((s: { id: number }) => s.id === songId)
+    }
+    const searchHasSong = async (): Promise<boolean> => {
+      const r = await request.get(
+        `/api/songs/search?q=${encodeURIComponent('HiddenSong')}`,
+      )
+      const { data } = await r.json()
+      return data.some((s: { id: number }) => s.id === songId)
+    }
+
+    try {
+      // Visible initially (list + search).
+      expect(await listHasSong()).toBe(true)
+      expect(await searchHasSong()).toBe(true)
+
+      // Hide the category.
+      const hideRes = await request.post('/api/categories', {
+        data: { id: catId, name: catName, isHidden: 1 },
+      })
+      expect(hideRes.ok()).toBeTruthy()
+      expect((await hideRes.json()).data.isHidden).toBe(1)
+
+      // The song is gone from both the list and search…
+      expect(await listHasSong()).toBe(false)
+      expect(await searchHasSong()).toBe(false)
+
+      // …but the category still exists for admins (flagged hidden).
+      const cats = (await (await request.get('/api/categories')).json())
+        .data as Array<{ id: number; isHidden: number }>
+      const stillThere = cats.find((c) => c.id === catId)
+      expect(stillThere?.isHidden).toBe(1)
+
+      // Show it again → the song reappears (nothing was deleted).
+      const showRes = await request.post('/api/categories', {
+        data: { id: catId, name: catName, isHidden: 0 },
+      })
+      expect(showRes.ok()).toBeTruthy()
+      expect(await listHasSong()).toBe(true)
+      expect(await searchHasSong()).toBe(true)
+    } finally {
+      await request.delete(`/api/songs/${songId}`).catch(() => {})
+      await request.delete(`/api/categories/${catId}`).catch(() => {})
+    }
+  })
+})

--- a/app/apps/client/e2e/song-create-permission.spec.ts
+++ b/app/apps/client/e2e/song-create-permission.spec.ts
@@ -1,0 +1,62 @@
+import { expect, test } from '@playwright/test'
+
+/**
+ * The "New Song" button on the songs page is gated by `songs.create`:
+ * a user without that permission can't see it (and the /songs/new route + the
+ * POST /api/songs endpoint reject creation server-side too).
+ */
+
+const NEW_SONG = /new song|cântare nouă/i
+
+test.describe('Song create permission', () => {
+  test('super admin sees the New Song button', async ({ page }) => {
+    await page.goto('/songs')
+    await page.waitForLoadState('networkidle')
+    await expect(page.getByRole('button', { name: NEW_SONG })).toBeVisible({
+      timeout: 10000,
+    })
+  })
+
+  test('a songs.view user without songs.create cannot see or use create', async ({
+    browser,
+    request,
+  }, testInfo) => {
+    const baseURL = testInfo.project.use.baseURL as string
+    const create = await request.post('/api/users', {
+      data: {
+        name: `E2E NoCreate ${Date.now()}`,
+        permissions: ['songs.view'],
+      },
+    })
+    const userId = (await create.json()).data.user.id as number
+
+    const ctx = await browser.newContext({
+      baseURL,
+      storageState: { cookies: [], origins: [] },
+    })
+    const page = await ctx.newPage()
+
+    try {
+      // Sign in as the limited user (passwordless, allowed from localhost).
+      const ok = await page.request.post('/api/auth/login', {
+        data: { userId },
+      })
+      expect(ok.ok()).toBeTruthy()
+
+      await page.goto('/songs')
+      await page.waitForLoadState('networkidle')
+
+      // The songs page loads (songs.view) but the New Song button is hidden.
+      await expect(page.getByRole('button', { name: NEW_SONG })).toHaveCount(0)
+
+      // The server also rejects creation for this user.
+      const denied = await page.request.post('/api/songs', {
+        data: { title: `E2E Denied ${Date.now()}`, slides: [] },
+      })
+      expect(denied.status()).toBe(403)
+    } finally {
+      await ctx.close()
+      await request.delete(`/api/users/${userId}`)
+    }
+  })
+})

--- a/app/apps/client/e2e/song-screen-elements.spec.ts
+++ b/app/apps/client/e2e/song-screen-elements.spec.ts
@@ -184,9 +184,10 @@ test.describe('Song last slide layout (strofa + amin)', () => {
       ).json()
       const cfg = data.contentConfigs.song_last_slide
 
-      // Operator repositions/styles + hides the amen for the last slide.
+      // Operator repositions/styles the amen and sets a custom amin label.
       cfg.amen.style.color = '#654321'
       cfg.amen.constraints.top.value = 90
+      cfg.amen.text = 'Slăvit să fie El!'
       cfg.mainText.style.color = '#fedcba'
 
       const put = await request.put(
@@ -200,6 +201,7 @@ test.describe('Song last slide layout (strofa + amin)', () => {
       ).data.contentConfigs
       expect(reread.song_last_slide.amen.style.color).toBe('#654321')
       expect(reread.song_last_slide.amen.constraints.top.value).toBe(90)
+      expect(reread.song_last_slide.amen.text).toBe('Slăvit să fie El!')
       expect(reread.song_last_slide.mainText.style.color).toBe('#fedcba')
       // The plain `song` config is untouched by the last-slide edit.
       expect(reread.song.mainText.style.color).not.toBe('#fedcba')

--- a/app/apps/client/e2e/song-screen-elements.spec.ts
+++ b/app/apps/client/e2e/song-screen-elements.spec.ts
@@ -1,0 +1,76 @@
+import { expect, test } from '@playwright/test'
+
+/**
+ * Settings → Screens → Edit now exposes two configurable song elements,
+ * mirroring the Bible verse/reference config:
+ *  - "songKey" (gama) shown on the first slide,
+ *  - "amen" (amin) shown on the last slide,
+ * each with position/size/style. They default into every screen's song config
+ * (merged on read) and round-trip through the config API.
+ */
+
+async function createScreen(
+  request: import('@playwright/test').APIRequestContext,
+): Promise<number> {
+  const res = await request.post('/api/screens', {
+    data: { name: `E2E SongElems ${Date.now()}`, type: 'primary' },
+  })
+  expect([200, 201]).toContain(res.status())
+  return (await res.json()).data.id as number
+}
+
+test.describe('Song screen elements (songKey + amen)', () => {
+  test('a new screen song config includes songKey + amen defaults', async ({
+    request,
+  }) => {
+    const screenId = await createScreen(request)
+    try {
+      const { data } = await (
+        await request.get(`/api/screens/${screenId}`)
+      ).json()
+      const song = data.contentConfigs.song
+      for (const key of ['songKey', 'amen'] as const) {
+        expect(song[key], `${key} default present`).toBeTruthy()
+        expect(song[key]).toHaveProperty('constraints')
+        expect(song[key]).toHaveProperty('size')
+        expect(song[key].style).toHaveProperty('color')
+        expect(song[key].style).toHaveProperty('fontFamily')
+      }
+    } finally {
+      await request.delete(`/api/screens/${screenId}`)
+    }
+  })
+
+  test('songKey/amen position + style round-trip through the config API', async ({
+    request,
+  }) => {
+    const screenId = await createScreen(request)
+    try {
+      const { data } = await (
+        await request.get(`/api/screens/${screenId}`)
+      ).json()
+      const song = data.contentConfigs.song
+
+      // Operator repositions/styles + hides the amen element.
+      song.songKey.style.color = '#ff0000'
+      song.songKey.style.bold = true
+      song.amen.hidden = true
+      song.amen.style.color = '#00ff00'
+
+      const put = await request.put(`/api/screens/${screenId}/config/song`, {
+        data: { config: song },
+      })
+      expect(put.status()).toBe(200)
+
+      const reread = (
+        await (await request.get(`/api/screens/${screenId}`)).json()
+      ).data.contentConfigs.song
+      expect(reread.songKey.style.color).toBe('#ff0000')
+      expect(reread.songKey.style.bold).toBe(true)
+      expect(reread.amen.hidden).toBe(true)
+      expect(reread.amen.style.color).toBe('#00ff00')
+    } finally {
+      await request.delete(`/api/screens/${screenId}`)
+    }
+  })
+})

--- a/app/apps/client/e2e/song-screen-elements.spec.ts
+++ b/app/apps/client/e2e/song-screen-elements.spec.ts
@@ -76,7 +76,7 @@ test.describe('Song screen elements (songKey + amen)', () => {
 })
 
 /**
- * "Gama - Strofă" (song_first_slide) is a dedicated content type whose config
+ * "Cântec - Primul Slide" (song_first_slide) is a dedicated content type whose config
  * applies only to a song's FIRST slide: two separately positionable elements —
  * the song key (gama) and the slide lyrics (strofa) — like the Bible
  * reference/verse pair. It defaults into every screen and round-trips through
@@ -143,7 +143,7 @@ test.describe('Song first slide layout (gama + strofa)', () => {
 })
 
 /**
- * "Strofă - Amin" (song_last_slide) is a dedicated content type whose config
+ * "Cântec - Ultimul Slide" (song_last_slide) is a dedicated content type whose config
  * applies only to a song's LAST slide: two separately positionable elements —
  * the slide lyrics (strofa) and the "Amin" — like the Bible reference/verse
  * pair. It defaults into every screen and round-trips through the config API

--- a/app/apps/client/e2e/song-screen-elements.spec.ts
+++ b/app/apps/client/e2e/song-screen-elements.spec.ts
@@ -141,3 +141,70 @@ test.describe('Song first slide layout (gama + strofa)', () => {
     }
   })
 })
+
+/**
+ * "Strofă - Amin" (song_last_slide) is a dedicated content type whose config
+ * applies only to a song's LAST slide: two separately positionable elements —
+ * the slide lyrics (strofa) and the "Amin" — like the Bible reference/verse
+ * pair. It defaults into every screen and round-trips through the config API
+ * independently from the `song` config.
+ */
+test.describe('Song last slide layout (strofa + amin)', () => {
+  test('a new screen includes a song_last_slide config with mainText + amen defaults', async ({
+    request,
+  }) => {
+    const screenId = await createScreen(request)
+    try {
+      const { data } = await (
+        await request.get(`/api/screens/${screenId}`)
+      ).json()
+      const cfg = data.contentConfigs.song_last_slide
+      expect(cfg, 'song_last_slide config present').toBeTruthy()
+      for (const key of ['mainText', 'amen'] as const) {
+        expect(cfg[key], `${key} default present`).toBeTruthy()
+        expect(cfg[key]).toHaveProperty('constraints')
+        expect(cfg[key]).toHaveProperty('size')
+        expect(cfg[key].style).toHaveProperty('color')
+        expect(cfg[key].style).toHaveProperty('fontFamily')
+      }
+      // No songKey (gama) on the last slide.
+      expect(cfg.songKey).toBeUndefined()
+    } finally {
+      await request.delete(`/api/screens/${screenId}`)
+    }
+  })
+
+  test('song_last_slide position + style round-trips independently of song', async ({
+    request,
+  }) => {
+    const screenId = await createScreen(request)
+    try {
+      const { data } = await (
+        await request.get(`/api/screens/${screenId}`)
+      ).json()
+      const cfg = data.contentConfigs.song_last_slide
+
+      // Operator repositions/styles + hides the amen for the last slide.
+      cfg.amen.style.color = '#654321'
+      cfg.amen.constraints.top.value = 90
+      cfg.mainText.style.color = '#fedcba'
+
+      const put = await request.put(
+        `/api/screens/${screenId}/config/song_last_slide`,
+        { data: { config: cfg } },
+      )
+      expect(put.status()).toBe(200)
+
+      const reread = (
+        await (await request.get(`/api/screens/${screenId}`)).json()
+      ).data.contentConfigs
+      expect(reread.song_last_slide.amen.style.color).toBe('#654321')
+      expect(reread.song_last_slide.amen.constraints.top.value).toBe(90)
+      expect(reread.song_last_slide.mainText.style.color).toBe('#fedcba')
+      // The plain `song` config is untouched by the last-slide edit.
+      expect(reread.song.mainText.style.color).not.toBe('#fedcba')
+    } finally {
+      await request.delete(`/api/screens/${screenId}`)
+    }
+  })
+})

--- a/app/apps/client/e2e/song-screen-elements.spec.ts
+++ b/app/apps/client/e2e/song-screen-elements.spec.ts
@@ -74,3 +74,70 @@ test.describe('Song screen elements (songKey + amen)', () => {
     }
   })
 })
+
+/**
+ * "Gama - Strofă" (song_first_slide) is a dedicated content type whose config
+ * applies only to a song's FIRST slide: two separately positionable elements —
+ * the song key (gama) and the slide lyrics (strofa) — like the Bible
+ * reference/verse pair. It defaults into every screen and round-trips through
+ * the config API independently from the `song` config.
+ */
+test.describe('Song first slide layout (gama + strofa)', () => {
+  test('a new screen includes a song_first_slide config with mainText + songKey defaults', async ({
+    request,
+  }) => {
+    const screenId = await createScreen(request)
+    try {
+      const { data } = await (
+        await request.get(`/api/screens/${screenId}`)
+      ).json()
+      const cfg = data.contentConfigs.song_first_slide
+      expect(cfg, 'song_first_slide config present').toBeTruthy()
+      for (const key of ['mainText', 'songKey'] as const) {
+        expect(cfg[key], `${key} default present`).toBeTruthy()
+        expect(cfg[key]).toHaveProperty('constraints')
+        expect(cfg[key]).toHaveProperty('size')
+        expect(cfg[key].style).toHaveProperty('color')
+        expect(cfg[key].style).toHaveProperty('fontFamily')
+      }
+      // No amen on the first slide.
+      expect(cfg.amen).toBeUndefined()
+    } finally {
+      await request.delete(`/api/screens/${screenId}`)
+    }
+  })
+
+  test('song_first_slide position + style round-trips independently of song', async ({
+    request,
+  }) => {
+    const screenId = await createScreen(request)
+    try {
+      const { data } = await (
+        await request.get(`/api/screens/${screenId}`)
+      ).json()
+      const cfg = data.contentConfigs.song_first_slide
+
+      // Operator repositions/styles the gama + strofa for the first slide.
+      cfg.songKey.style.color = '#123456'
+      cfg.songKey.constraints.top.value = 7
+      cfg.mainText.style.color = '#abcdef'
+
+      const put = await request.put(
+        `/api/screens/${screenId}/config/song_first_slide`,
+        { data: { config: cfg } },
+      )
+      expect(put.status()).toBe(200)
+
+      const reread = (
+        await (await request.get(`/api/screens/${screenId}`)).json()
+      ).data.contentConfigs
+      expect(reread.song_first_slide.songKey.style.color).toBe('#123456')
+      expect(reread.song_first_slide.songKey.constraints.top.value).toBe(7)
+      expect(reread.song_first_slide.mainText.style.color).toBe('#abcdef')
+      // The plain `song` config is untouched by the first-slide edit.
+      expect(reread.song.mainText.style.color).not.toBe('#abcdef')
+    } finally {
+      await request.delete(`/api/screens/${screenId}`)
+    }
+  })
+})

--- a/app/apps/client/src/features/auth/components/AccountSection.tsx
+++ b/app/apps/client/src/features/auth/components/AccountSection.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next'
 import { getLogoutRedirectUrl } from '~/features/users/service'
 import { PERMISSION_GROUPS, type PermissionGroup } from '~/features/users/types'
 import { usePermissions } from '~/provider/permissions-provider'
+import { captureActivity } from '~/utils/activity-logger'
 import { UserAvatar } from './UserAvatar'
 
 const GROUP_ORDER: PermissionGroup[] = [
@@ -14,6 +15,7 @@ const GROUP_ORDER: PermissionGroup[] = [
   'queue',
   'song_key',
   'settings',
+  'logs',
   'displays',
   'users',
 ]
@@ -32,6 +34,7 @@ export function AccountSection() {
   const displayName = userName ?? t('profile.user')
 
   const handleLogout = () => {
+    captureActivity('logout', { source: 'settings-account' })
     window.location.href = getLogoutRedirectUrl()
   }
 

--- a/app/apps/client/src/features/auth/components/AccountSection.tsx
+++ b/app/apps/client/src/features/auth/components/AccountSection.tsx
@@ -1,7 +1,8 @@
+import { useQueryClient } from '@tanstack/react-query'
 import { Check, LogOut, ShieldCheck } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 
-import { getLogoutRedirectUrl } from '~/features/users/service'
+import { performLogout } from '~/features/users/service'
 import { PERMISSION_GROUPS, type PermissionGroup } from '~/features/users/types'
 import { usePermissions } from '~/provider/permissions-provider'
 import { captureActivity } from '~/utils/activity-logger'
@@ -28,14 +29,19 @@ const GROUP_ORDER: PermissionGroup[] = [
  */
 export function AccountSection() {
   const { t } = useTranslation(['users', 'settings'])
-  const { userName, permissions, isApp, isAdmin } = usePermissions()
+  const { userName, permissions, isApp, isAdmin, refresh } = usePermissions()
+  const queryClient = useQueryClient()
 
   const hasFullAccess = isApp || isAdmin
   const displayName = userName ?? t('profile.user')
 
-  const handleLogout = () => {
+  // Logout via fetch + context refresh (no page navigation, which is
+  // unreliable in the packaged desktop webview).
+  const handleLogout = async () => {
     captureActivity('logout', { source: 'settings-account' })
-    window.location.href = getLogoutRedirectUrl()
+    await performLogout()
+    queryClient.clear()
+    await refresh()
   }
 
   return (

--- a/app/apps/client/src/features/auth/components/CurrentUserButton.tsx
+++ b/app/apps/client/src/features/auth/components/CurrentUserButton.tsx
@@ -19,6 +19,7 @@ import {
 } from '~/features/users/service'
 import type { LocalUser } from '~/features/users/types'
 import { usePermissions } from '~/provider/permissions-provider'
+import { captureActivity } from '~/utils/activity-logger'
 import { UserAvatar } from './UserAvatar'
 
 interface CurrentUserButtonProps {
@@ -134,6 +135,7 @@ export function CurrentUserButton({ isCollapsed }: CurrentUserButtonProps) {
   const roleLabel = isApp ? t('superAdmin') : t('profile.user')
 
   function handleLogout() {
+    captureActivity('logout', { source: 'sidebar-account-menu', userId })
     window.location.href = getLogoutRedirectUrl()
   }
 
@@ -144,6 +146,10 @@ export function CurrentUserButton({ isCollapsed }: CurrentUserButtonProps) {
     setError(false)
     try {
       const result = await login(user.id, pw)
+      captureActivity('account-switch', {
+        source: 'sidebar-account-menu',
+        toUserId: user.id,
+      })
       window.location.href = getLoginRedirectUrl(result.ticket)
     } catch {
       setError(true)

--- a/app/apps/client/src/features/auth/components/CurrentUserButton.tsx
+++ b/app/apps/client/src/features/auth/components/CurrentUserButton.tsx
@@ -1,3 +1,4 @@
+import { useQueryClient } from '@tanstack/react-query'
 import {
   AlertCircle,
   ChevronsUpDown,
@@ -11,12 +12,7 @@ import { useEffect, useLayoutEffect, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { useTranslation } from 'react-i18next'
 
-import {
-  getLocalUsers,
-  getLoginRedirectUrl,
-  getLogoutRedirectUrl,
-  login,
-} from '~/features/users/service'
+import { getLocalUsers, login, performLogout } from '~/features/users/service'
 import type { LocalUser } from '~/features/users/types'
 import { usePermissions } from '~/provider/permissions-provider'
 import { captureActivity } from '~/utils/activity-logger'
@@ -46,7 +42,8 @@ const PANEL_GAP = 8 // space between the trigger and the panel
  */
 export function CurrentUserButton({ isCollapsed }: CurrentUserButtonProps) {
   const { t } = useTranslation('users')
-  const { userId, userName, isApp, isAuthenticated } = usePermissions()
+  const { userId, userName, isApp, isAuthenticated, refresh } = usePermissions()
+  const queryClient = useQueryClient()
   const [open, setOpen] = useState(false)
   const triggerRef = useRef<HTMLButtonElement>(null)
   const panelRef = useRef<HTMLDivElement>(null)
@@ -134,23 +131,33 @@ export function CurrentUserButton({ isCollapsed }: CurrentUserButtonProps) {
   const displayName = userName ?? t('profile.user')
   const roleLabel = isApp ? t('superAdmin') : t('profile.user')
 
-  function handleLogout() {
+  // Logout via fetch + a context refresh (re-read /api/auth/me) rather than a
+  // top-level navigation to the sidecar, which the packaged desktop webview
+  // blocks (app on `tauri.localhost`, API on `localhost`) — that's what made
+  // the old redirect-based logout do nothing.
+  async function handleLogout() {
     captureActivity('logout', { source: 'sidebar-account-menu', userId })
-    window.location.href = getLogoutRedirectUrl()
+    await performLogout()
+    queryClient.clear()
+    await refresh()
+    setOpen(false)
   }
 
-  // Finalize a switch with a top-level navigation — the 302 reliably sets the
-  // session cookie in the desktop webview and reloads the app as the new user.
+  // Switch account via fetch + context refresh — `login()` already set the
+  // session cookie via its fetch response, so a plain `refresh()` renders the
+  // app as the new user. No page navigation/reload (unreliable on desktop).
   async function switchTo(user: LocalUser, pw?: string) {
     setSubmitting(true)
     setError(false)
     try {
-      const result = await login(user.id, pw)
+      await login(user.id, pw)
       captureActivity('account-switch', {
         source: 'sidebar-account-menu',
         toUserId: user.id,
       })
-      window.location.href = getLoginRedirectUrl(result.ticket)
+      queryClient.clear()
+      await refresh()
+      setOpen(false)
     } catch {
       setError(true)
       setSubmitting(false)

--- a/app/apps/client/src/features/auth/components/LoginGate.tsx
+++ b/app/apps/client/src/features/auth/components/LoginGate.tsx
@@ -2,12 +2,7 @@ import { type ReactNode, useCallback, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { isMobile } from '~/config'
-import {
-  getLocalUsers,
-  getLoginRedirectUrl,
-  type LoginResult,
-  login,
-} from '~/features/users/service'
+import { getLocalUsers, LOGGED_OUT_FLAG, login } from '~/features/users/service'
 import type { LocalUser } from '~/features/users/types'
 import { usePermissions } from '~/provider/permissions-provider'
 import { LoginScreen } from './LoginScreen'
@@ -61,6 +56,11 @@ export function LoginGate({ children }: { children: ReactNode }) {
   const [users, setUsers] = useState<LocalUser[] | null>(null)
   const [autoLoginTried, setAutoLoginTried] = useState(false)
   const [autoLoggingIn, setAutoLoggingIn] = useState(false)
+  // Set when a deliberate logout is detected (LOGGED_OUT_FLAG), so we show the
+  // picker instead of instantly auto-signing a sole passwordless account back
+  // in. Checked at runtime in the auto-login effect (logout refreshes the
+  // context rather than reloading, so a mount-time read would miss it).
+  const [skipSoleAutoLogin, setSkipSoleAutoLogin] = useState(false)
 
   // Only fetch the user list when we actually need it (picker or sole
   // auto-login). When a session is already valid we skip straight to the app.
@@ -82,13 +82,25 @@ export function LoginGate({ children }: { children: ReactNode }) {
     }
   }, [needsList, users])
 
-  // A single passwordless account requires no choice.
-  const soleAutoLogin = !!users && users.length === 1 && !users[0].hasPassword
+  // A single passwordless account requires no choice — unless the user just
+  // logged out on purpose, in which case we show the picker so they stay out.
+  const soleAutoLogin =
+    !!users && users.length === 1 && !users[0].hasPassword && !skipSoleAutoLogin
 
   // Auto-login that single passwordless account (fresh install).
   useEffect(() => {
     if (!needsList || !users || autoLoginTried) return
     if (soleAutoLogin) {
+      // A deliberate logout suppresses this one auto-login so the user stays out.
+      try {
+        if (sessionStorage.getItem(LOGGED_OUT_FLAG) === '1') {
+          sessionStorage.removeItem(LOGGED_OUT_FLAG)
+          setSkipSoleAutoLogin(true)
+          return
+        }
+      } catch {
+        // sessionStorage unavailable — fall through to normal auto-login.
+      }
       setAutoLoginTried(true)
       setAutoLoggingIn(true)
       login(users[0].id)
@@ -97,12 +109,14 @@ export function LoginGate({ children }: { children: ReactNode }) {
     }
   }, [needsList, users, autoLoginTried, soleAutoLogin, refresh])
 
-  // Finalize the chosen account via a top-level navigation — reliably sets the
-  // session cookie in the desktop webview. The cookie persists for a year, so
-  // the next launch auto-loads the app as this user (no picker).
-  const handleSelected = useCallback((result: LoginResult) => {
-    window.location.href = getLoginRedirectUrl(result.ticket)
-  }, [])
+  // LoginScreen already called `login()`, which set the session cookie via its
+  // fetch response (it round-trips cross-site in the desktop webview). A pure
+  // context `refresh()` re-reads /api/auth/me and renders the app as the chosen
+  // user — no page navigation/reload, which is unreliable in the packaged
+  // desktop webview (app on `tauri.localhost`, sidecar on `localhost`).
+  const handleSelected = useCallback(() => {
+    void refresh()
+  }, [refresh])
 
   if (isMobile()) return <>{children}</>
   if (isLoading) return <FullScreenSpinner />

--- a/app/apps/client/src/features/auth/components/LoginScreen.tsx
+++ b/app/apps/client/src/features/auth/components/LoginScreen.tsx
@@ -11,6 +11,7 @@ import { useTranslation } from 'react-i18next'
 
 import { type LoginResult, login } from '~/features/users/service'
 import type { LocalUser } from '~/features/users/types'
+import { captureActivity } from '~/utils/activity-logger'
 import { UserAvatar } from './UserAvatar'
 
 interface LoginScreenProps {
@@ -79,6 +80,7 @@ export function LoginScreen({ users, onLoggedIn }: LoginScreenProps) {
     setError(false)
     try {
       const result = await login(user.id, pw)
+      captureActivity('login', { source: 'login-screen', userId: user.id })
       await onLoggedIn(result)
     } catch {
       setError(true)

--- a/app/apps/client/src/features/logs/components/ClearLogs.tsx
+++ b/app/apps/client/src/features/logs/components/ClearLogs.tsx
@@ -1,0 +1,129 @@
+import { AlertTriangle, Trash2 } from 'lucide-react'
+import { useCallback, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+
+import { usePermissions } from '~/provider/permissions-provider'
+import { useToast } from '~/ui/toast'
+import { captureActivity } from '~/utils/activity-logger'
+import { clearLogs } from '../service'
+
+interface ClearLogsProps {
+  /** Called after a successful clear so the viewer can refetch. */
+  onCleared: () => void
+}
+
+/**
+ * Destructive "clear logs" action, gated by the `logs.clear` permission and
+ * guarded behind a confirmation dialog.
+ */
+export function ClearLogs({ onCleared }: ClearLogsProps) {
+  const { t } = useTranslation('settings')
+  const { hasPermission } = usePermissions()
+  const { showToast } = useToast()
+  const [showConfirm, setShowConfirm] = useState(false)
+  const [isPending, setIsPending] = useState(false)
+
+  const handleClear = useCallback(async () => {
+    setShowConfirm(false)
+    setIsPending(true)
+    captureActivity('logs.clear', { source: 'settings:logs' })
+    try {
+      const result = await clearLogs()
+      if (result.success) {
+        showToast(t('sections.logs.toast.cleared'), 'success')
+        onCleared()
+      } else {
+        showToast(
+          t('sections.logs.toast.clearFailed', {
+            error: result.error ?? 'unknown',
+          }),
+          'error',
+        )
+      }
+    } catch (error) {
+      showToast(
+        t('sections.logs.toast.clearFailed', {
+          error: error instanceof Error ? error.message : String(error),
+        }),
+        'error',
+      )
+    } finally {
+      setIsPending(false)
+    }
+  }, [onCleared, showToast, t])
+
+  if (!hasPermission('logs.clear')) return null
+
+  return (
+    <div className="rounded-lg bg-gray-50 p-4 dark:bg-gray-800">
+      <div className="flex items-start gap-3">
+        <div className="rounded-lg bg-red-100 p-2 dark:bg-red-900/30">
+          <Trash2 className="h-5 w-5 text-red-600 dark:text-red-400" />
+        </div>
+        <div className="min-w-0 flex-1">
+          <h4 className="text-sm font-medium text-gray-900 dark:text-white">
+            {t('sections.logs.clear.card.title')}
+          </h4>
+          <p className="mt-0.5 text-xs text-gray-500 dark:text-gray-400">
+            {t('sections.logs.clear.card.description')}
+          </p>
+          <button
+            type="button"
+            onClick={() => setShowConfirm(true)}
+            disabled={isPending}
+            className="mt-3 inline-flex items-center gap-2 rounded-md bg-red-600 px-3 py-1.5 text-sm text-white hover:bg-red-700 disabled:opacity-50"
+          >
+            <Trash2 className="h-4 w-4" />
+            {isPending
+              ? t('sections.logs.clear.button.clearing')
+              : t('sections.logs.clear.button.clear')}
+          </button>
+        </div>
+      </div>
+
+      {showConfirm && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center">
+          <div
+            className="absolute inset-0 bg-black/50"
+            onClick={() => setShowConfirm(false)}
+            onKeyDown={(e) => e.key === 'Escape' && setShowConfirm(false)}
+          />
+          <div className="relative mx-4 w-full max-w-md rounded-lg bg-white p-6 shadow-xl dark:bg-gray-800">
+            <div className="flex items-start gap-4">
+              <div className="rounded-full bg-red-100 p-2 dark:bg-red-900/30">
+                <AlertTriangle className="h-6 w-6 text-red-600 dark:text-red-400" />
+              </div>
+              <div className="flex-1">
+                <h3 className="text-lg font-semibold text-gray-900 dark:text-white">
+                  {t('sections.logs.clear.confirm.title')}
+                </h3>
+                <p className="mt-2 text-sm text-gray-600 dark:text-gray-400">
+                  {t('sections.logs.clear.confirm.message')}
+                </p>
+                <p className="mt-2 text-sm font-medium text-red-600 dark:text-red-400">
+                  {t('sections.logs.clear.confirm.warning')}
+                </p>
+              </div>
+            </div>
+            <div className="mt-6 flex justify-end gap-3">
+              <button
+                type="button"
+                onClick={() => setShowConfirm(false)}
+                className="rounded-md px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-700"
+              >
+                {t('sections.logs.clear.confirm.cancel')}
+              </button>
+              <button
+                type="button"
+                onClick={handleClear}
+                className="rounded-md bg-red-600 px-4 py-2 text-sm text-white hover:bg-red-700"
+              >
+                {t('sections.logs.clear.confirm.confirm')}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/app/apps/client/src/features/logs/components/LogsPanel.tsx
+++ b/app/apps/client/src/features/logs/components/LogsPanel.tsx
@@ -1,0 +1,32 @@
+import { isLocalhost } from '~/config'
+import { ClearLogs } from './ClearLogs'
+import { LogsViewer } from './LogsViewer'
+import { OpenLogsFolder } from './OpenLogsFolder'
+import { useLogsContent } from '../hooks/useLogsContent'
+
+/**
+ * The full Logs settings panel: a read-only viewer of the recent log tails,
+ * plus actions to open the logs folder (host machine only) and clear the logs
+ * (gated by `logs.clear`). The surrounding route gates the whole panel behind
+ * `logs.view`.
+ */
+export function LogsPanel() {
+  const { data, isLoading, error, refresh } = useLogsContent()
+
+  return (
+    <div className="space-y-6">
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+        {/* Opening a folder only makes sense on the machine running the app. */}
+        {isLocalhost() && <OpenLogsFolder />}
+        <ClearLogs onCleared={refresh} />
+      </div>
+
+      <LogsViewer
+        data={data}
+        isLoading={isLoading}
+        error={error}
+        onRefresh={refresh}
+      />
+    </div>
+  )
+}

--- a/app/apps/client/src/features/logs/components/LogsViewer.tsx
+++ b/app/apps/client/src/features/logs/components/LogsViewer.tsx
@@ -1,0 +1,77 @@
+import { AlertCircle, RefreshCw } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+
+import type { LogsContent } from '../service'
+
+interface LogsViewerProps {
+  data: LogsContent | null
+  isLoading: boolean
+  error: string | null
+  onRefresh: () => void
+}
+
+function LogBlock({ heading, content }: { heading: string; content: string }) {
+  const { t } = useTranslation('settings')
+  return (
+    <div className="min-w-0">
+      <h4 className="mb-1.5 text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
+        {heading}
+      </h4>
+      <pre className="max-h-72 overflow-auto whitespace-pre-wrap break-words rounded-lg border border-gray-200 bg-gray-50 p-3 font-mono text-xs leading-relaxed text-gray-800 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-200">
+        {content.trim() ? content : t('sections.logs.viewer.empty')}
+      </pre>
+    </div>
+  )
+}
+
+/** Read-only viewer for the recent server + Tauri log tails. */
+export function LogsViewer({
+  data,
+  isLoading,
+  error,
+  onRefresh,
+}: LogsViewerProps) {
+  const { t } = useTranslation('settings')
+
+  return (
+    <div className="space-y-3">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <p className="min-w-0 break-all font-mono text-xs text-gray-500 dark:text-gray-400">
+          {data?.logsDir}
+        </p>
+        <button
+          type="button"
+          onClick={onRefresh}
+          disabled={isLoading}
+          className="inline-flex items-center gap-2 rounded-md border border-gray-300 px-3 py-1.5 text-sm text-gray-700 transition-colors hover:bg-gray-100 disabled:opacity-50 dark:border-gray-600 dark:text-gray-200 dark:hover:bg-gray-800"
+        >
+          <RefreshCw className={`h-4 w-4 ${isLoading ? 'animate-spin' : ''}`} />
+          {isLoading
+            ? t('sections.logs.viewer.refreshing')
+            : t('sections.logs.viewer.refresh')}
+        </button>
+      </div>
+
+      {error ? (
+        <p
+          role="alert"
+          className="flex items-center gap-2 rounded-lg bg-red-50 p-3 text-sm text-red-700 dark:bg-red-900/20 dark:text-red-400"
+        >
+          <AlertCircle className="h-4 w-4 shrink-0" />
+          {t('sections.logs.toast.loadFailed', { error })}
+        </p>
+      ) : (
+        <div className="grid grid-cols-1 gap-4">
+          <LogBlock
+            heading={t('sections.logs.viewer.serverHeading')}
+            content={data?.serverTail ?? ''}
+          />
+          <LogBlock
+            heading={t('sections.logs.viewer.tauriHeading')}
+            content={data?.tauriTail ?? ''}
+          />
+        </div>
+      )}
+    </div>
+  )
+}

--- a/app/apps/client/src/features/logs/components/LogsViewer.tsx
+++ b/app/apps/client/src/features/logs/components/LogsViewer.tsx
@@ -161,9 +161,19 @@ export function LogsViewer({
         </p>
       ) : (
         <>
-          {/* Level filter chips + search */}
-          <div className="flex flex-wrap items-center gap-2">
-            <div className="flex flex-wrap gap-1.5">
+          {/* Full-width search, with the level filters arranged below it. */}
+          <div className="space-y-2">
+            <div className="relative w-full">
+              <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400" />
+              <input
+                type="text"
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+                placeholder={t('sections.logs.viewer.search')}
+                className="w-full rounded-md border border-gray-300 bg-white py-2 pl-9 pr-3 text-sm text-gray-900 outline-none transition focus:border-indigo-500 focus:ring-2 focus:ring-indigo-500/30 dark:border-gray-600 dark:bg-gray-800 dark:text-white"
+              />
+            </div>
+            <div className="flex flex-wrap items-center gap-1.5">
               {FILTER_LEVELS.map((level) => (
                 <button
                   key={level}
@@ -182,16 +192,6 @@ export function LogsViewer({
                   )}
                 </button>
               ))}
-            </div>
-            <div className="relative ml-auto min-w-[180px] flex-1 sm:max-w-xs">
-              <Search className="pointer-events-none absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-gray-400" />
-              <input
-                type="text"
-                value={search}
-                onChange={(e) => setSearch(e.target.value)}
-                placeholder={t('sections.logs.viewer.search')}
-                className="w-full rounded-md border border-gray-300 bg-white py-1.5 pl-8 pr-3 text-sm text-gray-900 outline-none transition focus:border-indigo-500 focus:ring-2 focus:ring-indigo-500/30 dark:border-gray-600 dark:bg-gray-800 dark:text-white"
-              />
             </div>
           </div>
 

--- a/app/apps/client/src/features/logs/components/LogsViewer.tsx
+++ b/app/apps/client/src/features/logs/components/LogsViewer.tsx
@@ -1,7 +1,13 @@
-import { AlertCircle, RefreshCw } from 'lucide-react'
+import { AlertCircle, RefreshCw, Search } from 'lucide-react'
+import { useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import type { LogsContent } from '../service'
+import {
+  type LogLevel,
+  type ParsedLogLine,
+  parseLogLines,
+} from '../utils/parseLogLines'
 
 interface LogsViewerProps {
   data: LogsContent | null
@@ -10,16 +16,71 @@ interface LogsViewerProps {
   onRefresh: () => void
 }
 
-function LogBlock({ heading, content }: { heading: string; content: string }) {
+type FilterLevel = 'error' | 'warn' | 'info' | 'debug'
+const FILTER_LEVELS: FilterLevel[] = ['error', 'warn', 'info', 'debug']
+
+// Per-line text colour: errors red, warnings amber, info normal, debug muted.
+const LINE_COLOR: Record<LogLevel, string> = {
+  error: 'text-red-600 dark:text-red-400',
+  warn: 'text-amber-600 dark:text-amber-400',
+  info: 'text-gray-800 dark:text-gray-200',
+  debug: 'text-gray-400 dark:text-gray-500',
+  other: 'text-gray-600 dark:text-gray-300',
+}
+
+const CHIP_ACTIVE: Record<FilterLevel, string> = {
+  error:
+    'border-red-300 bg-red-50 text-red-700 dark:border-red-800 dark:bg-red-900/30 dark:text-red-300',
+  warn: 'border-amber-300 bg-amber-50 text-amber-700 dark:border-amber-800 dark:bg-amber-900/30 dark:text-amber-300',
+  info: 'border-gray-300 bg-gray-100 text-gray-700 dark:border-gray-600 dark:bg-gray-700/50 dark:text-gray-200',
+  debug:
+    'border-gray-300 bg-gray-100 text-gray-600 dark:border-gray-600 dark:bg-gray-700/50 dark:text-gray-300',
+}
+const CHIP_INACTIVE =
+  'border-gray-200 bg-transparent text-gray-400 dark:border-gray-700 dark:text-gray-500'
+
+const DOT: Record<FilterLevel, string> = {
+  error: 'bg-red-500',
+  warn: 'bg-amber-500',
+  info: 'bg-gray-400',
+  debug: 'bg-gray-300 dark:bg-gray-600',
+}
+
+function LogBlock({
+  heading,
+  lines,
+}: {
+  heading: string
+  lines: ParsedLogLine[]
+}) {
   const { t } = useTranslation('settings')
   return (
     <div className="min-w-0">
       <h4 className="mb-1.5 text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
         {heading}
       </h4>
-      <pre className="max-h-72 overflow-auto whitespace-pre-wrap break-words rounded-lg border border-gray-200 bg-gray-50 p-3 font-mono text-xs leading-relaxed text-gray-800 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-200">
-        {content.trim() ? content : t('sections.logs.viewer.empty')}
-      </pre>
+      <div className="max-h-72 overflow-auto rounded-lg border border-gray-200 bg-gray-50 p-3 font-mono text-xs leading-relaxed dark:border-gray-700 dark:bg-gray-900">
+        {lines.length === 0 ? (
+          <p className="text-gray-400 dark:text-gray-500">
+            {t('sections.logs.viewer.noMatches')}
+          </p>
+        ) : (
+          lines.map((line, i) => (
+            <div
+              // Log lines aren't uniquely identifiable; the list never reorders.
+              // biome-ignore lint/suspicious/noArrayIndexKey: log line list
+              key={i}
+              className={`whitespace-pre-wrap break-words ${
+                line.isSeparator
+                  ? 'mt-2 font-semibold text-indigo-600 dark:text-indigo-400'
+                  : LINE_COLOR[line.level]
+              }`}
+            >
+              {line.text}
+            </div>
+          ))
+        )}
+      </div>
     </div>
   )
 }
@@ -32,6 +93,44 @@ export function LogsViewer({
   onRefresh,
 }: LogsViewerProps) {
   const { t } = useTranslation('settings')
+  const [enabled, setEnabled] = useState<Record<FilterLevel, boolean>>({
+    error: true,
+    warn: true,
+    info: true,
+    debug: true,
+  })
+  const [search, setSearch] = useState('')
+
+  const serverParsed = useMemo(
+    () => parseLogLines(data?.serverTail ?? ''),
+    [data?.serverTail],
+  )
+  const tauriParsed = useMemo(
+    () => parseLogLines(data?.tauriTail ?? ''),
+    [data?.tauriTail],
+  )
+
+  const query = search.trim().toLowerCase()
+  const matches = useMemo(() => {
+    return (line: ParsedLogLine): boolean => {
+      // 'other' (separators / unparsed) bypass the level filter.
+      if (line.level !== 'other' && !enabled[line.level]) return false
+      if (query && !line.text.toLowerCase().includes(query)) return false
+      return true
+    }
+  }, [enabled, query])
+
+  const serverLines = useMemo(
+    () => serverParsed.filter(matches),
+    [serverParsed, matches],
+  )
+  const tauriLines = useMemo(
+    () => tauriParsed.filter(matches),
+    [tauriParsed, matches],
+  )
+
+  const toggle = (level: FilterLevel) =>
+    setEnabled((prev) => ({ ...prev, [level]: !prev[level] }))
 
   return (
     <div className="space-y-3">
@@ -61,16 +160,52 @@ export function LogsViewer({
           {t('sections.logs.toast.loadFailed', { error })}
         </p>
       ) : (
-        <div className="grid grid-cols-1 gap-4">
-          <LogBlock
-            heading={t('sections.logs.viewer.serverHeading')}
-            content={data?.serverTail ?? ''}
-          />
-          <LogBlock
-            heading={t('sections.logs.viewer.tauriHeading')}
-            content={data?.tauriTail ?? ''}
-          />
-        </div>
+        <>
+          {/* Level filter chips + search */}
+          <div className="flex flex-wrap items-center gap-2">
+            <div className="flex flex-wrap gap-1.5">
+              {FILTER_LEVELS.map((level) => (
+                <button
+                  key={level}
+                  type="button"
+                  onClick={() => toggle(level)}
+                  aria-pressed={enabled[level]}
+                  className={`inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs font-medium transition-colors ${
+                    enabled[level] ? CHIP_ACTIVE[level] : CHIP_INACTIVE
+                  }`}
+                >
+                  <span className={`h-2 w-2 rounded-full ${DOT[level]}`} />
+                  {t(
+                    `sections.logs.viewer.levels.${
+                      level === 'warn' ? 'warning' : level
+                    }`,
+                  )}
+                </button>
+              ))}
+            </div>
+            <div className="relative ml-auto min-w-[180px] flex-1 sm:max-w-xs">
+              <Search className="pointer-events-none absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-gray-400" />
+              <input
+                type="text"
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+                placeholder={t('sections.logs.viewer.search')}
+                className="w-full rounded-md border border-gray-300 bg-white py-1.5 pl-8 pr-3 text-sm text-gray-900 outline-none transition focus:border-indigo-500 focus:ring-2 focus:ring-indigo-500/30 dark:border-gray-600 dark:bg-gray-800 dark:text-white"
+              />
+            </div>
+          </div>
+
+          <div className="grid grid-cols-1 gap-4">
+            <LogBlock
+              heading={t('sections.logs.viewer.serverHeading')}
+              lines={serverLines}
+            />
+            <LogBlock
+              heading={t('sections.logs.viewer.tauriHeading')}
+              lines={tauriLines}
+            />
+          </div>
+        </>
       )}
     </div>
   )

--- a/app/apps/client/src/features/logs/hooks/useLogsContent.ts
+++ b/app/apps/client/src/features/logs/hooks/useLogsContent.ts
@@ -1,0 +1,44 @@
+import { useCallback, useEffect, useState } from 'react'
+
+import { createLogger } from '~/utils/logger'
+import { getLogsContent, type LogsContent } from '../service'
+
+const logger = createLogger('app:logs')
+
+interface UseLogsContent {
+  data: LogsContent | null
+  isLoading: boolean
+  error: string | null
+  refresh: () => Promise<void>
+}
+
+/**
+ * Loads the recent log tails for the viewer and exposes a `refresh` callback
+ * (used after a manual refresh or after clearing the logs).
+ */
+export function useLogsContent(): UseLogsContent {
+  const [data, setData] = useState<LogsContent | null>(null)
+  const [isLoading, setIsLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  const refresh = useCallback(async () => {
+    setIsLoading(true)
+    setError(null)
+    try {
+      const content = await getLogsContent()
+      setData(content)
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      logger.error(`Failed to load logs: ${message}`)
+      setError(message)
+    } finally {
+      setIsLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    void refresh()
+  }, [refresh])
+
+  return { data, isLoading, error, refresh }
+}

--- a/app/apps/client/src/features/logs/index.ts
+++ b/app/apps/client/src/features/logs/index.ts
@@ -1,2 +1,5 @@
+export { ClearLogs } from './components/ClearLogs'
+export { LogsPanel } from './components/LogsPanel'
+export { LogsViewer } from './components/LogsViewer'
 export { OpenLogsFolder } from './components/OpenLogsFolder'
-export { openLogsFolder } from './service'
+export { clearLogs, getLogsContent, openLogsFolder } from './service'

--- a/app/apps/client/src/features/logs/service/clearLogs.ts
+++ b/app/apps/client/src/features/logs/service/clearLogs.ts
@@ -1,0 +1,26 @@
+import { fetcher } from '~/utils/fetcher'
+
+interface ClearLogsResponse {
+  data?: { cleared: number; logsDir: string }
+  error?: string
+}
+
+/**
+ * Clears (empties) all local log files. Requires the `logs.clear` permission
+ * (enforced server-side).
+ */
+export async function clearLogs(): Promise<{
+  success: boolean
+  cleared?: number
+  error?: string
+}> {
+  const response = await fetcher<ClearLogsResponse>('/api/logs/clear', {
+    method: 'POST',
+  })
+
+  if (response.error) {
+    return { success: false, error: response.error }
+  }
+
+  return { success: true, cleared: response.data?.cleared }
+}

--- a/app/apps/client/src/features/logs/service/getLogsContent.ts
+++ b/app/apps/client/src/features/logs/service/getLogsContent.ts
@@ -1,0 +1,24 @@
+import { fetcher } from '~/utils/fetcher'
+
+export interface LogsContent {
+  serverTail: string
+  tauriTail: string
+  logsDir: string
+}
+
+interface LogsContentResponse {
+  data?: LogsContent
+  error?: string
+}
+
+/**
+ * Fetches the recent server + Tauri log tails for the in-app Logs viewer.
+ * Requires the `logs.view` permission (enforced server-side).
+ */
+export async function getLogsContent(): Promise<LogsContent> {
+  const response = await fetcher<LogsContentResponse>('/api/logs/content')
+  if (response.error || !response.data) {
+    throw new Error(response.error ?? 'Failed to load logs')
+  }
+  return response.data
+}

--- a/app/apps/client/src/features/logs/service/index.ts
+++ b/app/apps/client/src/features/logs/service/index.ts
@@ -1,1 +1,3 @@
+export { clearLogs } from './clearLogs'
+export { getLogsContent, type LogsContent } from './getLogsContent'
 export { openLogsFolder } from './openLogs'

--- a/app/apps/client/src/features/logs/utils/__tests__/parseLogLines.test.ts
+++ b/app/apps/client/src/features/logs/utils/__tests__/parseLogLines.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest'
+
+import { parseLogLines } from '../parseLogLines'
+
+describe('parseLogLines', () => {
+  it('classifies each level from the on-disk format', () => {
+    const blob = [
+      '[2026-06-06T08:25:50.245Z] [INFO] [midi] Initializing',
+      '[2026-06-06T08:25:50.246Z] [WARN] [http] GET /x → 404',
+      '[2026-06-06T08:25:50.247Z] [ERROR] [api-handler] boom',
+      '[2026-06-06T08:25:50.248Z] [DEBUG] [websocket] tick',
+    ].join('\n')
+
+    const lines = parseLogLines(blob)
+    expect(lines.map((l) => l.level)).toEqual([
+      'info',
+      'warn',
+      'error',
+      'debug',
+    ])
+  })
+
+  it('maps WARNING/TRACE/VERBOSE onto warn/debug', () => {
+    const blob = [
+      '[2026-06-06T08:25:50.245Z] [WARNING] x',
+      '[2026-06-06T08:25:50.246Z] [TRACE] y',
+      '[2026-06-06T08:25:50.247Z] [VERBOSE] z',
+    ].join('\n')
+    expect(parseLogLines(blob).map((l) => l.level)).toEqual([
+      'warn',
+      'debug',
+      'debug',
+    ])
+  })
+
+  it('marks day separators and inherits level on continuation lines', () => {
+    const blob = [
+      '=== server 2026-06-06 ===',
+      '[2026-06-06T08:25:50.247Z] [ERROR] [api] failed',
+      '    at someFunction (file.ts:10:5)',
+      '    at next (file.ts:20:1)',
+    ].join('\n')
+
+    const lines = parseLogLines(blob)
+    expect(lines[0]).toMatchObject({ isSeparator: true, level: 'other' })
+    expect(lines[1].level).toBe('error')
+    // Stack-trace continuation lines stay red (inherit the error level).
+    expect(lines[2].level).toBe('error')
+    expect(lines[3].level).toBe('error')
+  })
+
+  it('skips blank lines and handles empty input', () => {
+    expect(parseLogLines('')).toEqual([])
+    expect(parseLogLines('\n\n  \n')).toEqual([])
+  })
+})

--- a/app/apps/client/src/features/logs/utils/parseLogLines.ts
+++ b/app/apps/client/src/features/logs/utils/parseLogLines.ts
@@ -1,0 +1,66 @@
+/**
+ * Parses the on-disk log format
+ *   [ISO_TIMESTAMP] [LEVEL] [category] message
+ * (Tauri lines omit the category) into structured, colourable lines.
+ *
+ * Lines that don't start with a timestamp are either day separators
+ * ("=== server 2026-06-06 ===", emitted by readRecentLogs) or continuation
+ * lines of a multi-line message (e.g. a stack trace). Continuations inherit the
+ * previous line's level so a whole error block stays red.
+ */
+export type LogLevel = 'error' | 'warn' | 'info' | 'debug' | 'other'
+
+export interface ParsedLogLine {
+  level: LogLevel
+  /** True for the "=== server DATE ===" day separators. */
+  isSeparator: boolean
+  text: string
+}
+
+const LINE_RE = /^\[\d{4}-\d{2}-\d{2}T[^\]]+\]\s+\[([A-Za-z]+)\]/
+
+function toLevel(token: string): LogLevel {
+  switch (token.toLowerCase()) {
+    case 'error':
+      return 'error'
+    case 'warn':
+    case 'warning':
+      return 'warn'
+    case 'info':
+      return 'info'
+    case 'debug':
+    case 'trace':
+    case 'verbose':
+      return 'debug'
+    default:
+      return 'other'
+  }
+}
+
+export function parseLogLines(blob: string): ParsedLogLine[] {
+  if (!blob) return []
+  const out: ParsedLogLine[] = []
+  let lastLevel: LogLevel = 'other'
+
+  for (const text of blob.split('\n')) {
+    if (text.trim() === '') continue
+
+    const match = text.match(LINE_RE)
+    if (match) {
+      lastLevel = toLevel(match[1])
+      out.push({ level: lastLevel, isSeparator: false, text })
+      continue
+    }
+
+    if (text.startsWith('=== ')) {
+      lastLevel = 'other'
+      out.push({ level: 'other', isSeparator: true, text })
+      continue
+    }
+
+    // Continuation line (stack trace, wrapped message) — keep the parent level.
+    out.push({ level: lastLevel, isSeparator: false, text })
+  }
+
+  return out
+}

--- a/app/apps/client/src/features/presentation/components/rendering/ContentRenderer.tsx
+++ b/app/apps/client/src/features/presentation/components/rendering/ContentRenderer.tsx
@@ -49,7 +49,8 @@ export function ContentRenderer({
 
   switch (contentType) {
     case 'song':
-    case 'song_first_slide': {
+    case 'song_first_slide':
+    case 'song_last_slide': {
       const songConfig = config as SongContentConfig
       return (
         <SongRenderer

--- a/app/apps/client/src/features/presentation/components/rendering/ContentRenderer.tsx
+++ b/app/apps/client/src/features/presentation/components/rendering/ContentRenderer.tsx
@@ -48,7 +48,8 @@ export function ContentRenderer({
     'clockEnabled' in cfg && cfg.clockEnabled && clockConfig
 
   switch (contentType) {
-    case 'song': {
+    case 'song':
+    case 'song_first_slide': {
       const songConfig = config as SongContentConfig
       return (
         <SongRenderer

--- a/app/apps/client/src/features/presentation/components/rendering/ScreenContent.tsx
+++ b/app/apps/client/src/features/presentation/components/rendering/ScreenContent.tsx
@@ -51,10 +51,13 @@ export function ScreenContent({
   const currentConfig = screen.contentConfigs[contentType]
 
   // Check if chords display is enabled. Chord settings live on the `song`
-  // config as a single source of truth, so the first slide ("song_first_slide")
-  // reads them from `song` too — the operator only toggles chords in one place.
+  // config as a single source of truth, so the dedicated first/last slide
+  // layouts ("song_first_slide" / "song_last_slide") read them from `song` too —
+  // the operator only toggles chords in one place.
   const songConfig =
-    contentType === 'song' || contentType === 'song_first_slide'
+    contentType === 'song' ||
+    contentType === 'song_first_slide' ||
+    contentType === 'song_last_slide'
       ? (screen.contentConfigs.song as SongContentConfig | undefined)
       : null
   const displayChordsEnabled = songConfig?.displayChords ?? false

--- a/app/apps/client/src/features/presentation/components/rendering/ScreenContent.tsx
+++ b/app/apps/client/src/features/presentation/components/rendering/ScreenContent.tsx
@@ -50,10 +50,12 @@ export function ScreenContent({
 
   const currentConfig = screen.contentConfigs[contentType]
 
-  // Check if chords display is enabled
+  // Check if chords display is enabled. Chord settings live on the `song`
+  // config as a single source of truth, so the first slide ("song_first_slide")
+  // reads them from `song` too — the operator only toggles chords in one place.
   const songConfig =
-    contentType === 'song'
-      ? (currentConfig as SongContentConfig | undefined)
+    contentType === 'song' || contentType === 'song_first_slide'
+      ? (screen.contentConfigs.song as SongContentConfig | undefined)
       : null
   const displayChordsEnabled = songConfig?.displayChords ?? false
 

--- a/app/apps/client/src/features/presentation/components/rendering/ScreenContent.tsx
+++ b/app/apps/client/src/features/presentation/components/rendering/ScreenContent.tsx
@@ -291,6 +291,84 @@ export function ScreenContent({
     )
   }
 
+  // Render the song key ("gama") — shown on the first slide. contentData.songKey
+  // is only populated on the first slide, so visibility is gated automatically.
+  const renderSongKey = () => {
+    if (!config || !('songKey' in config) || !config.songKey) return null
+    const sk = config.songKey
+    if (sk.hidden) return null
+
+    const bounds = calculatePixelBounds(
+      sk.constraints,
+      sk.size,
+      canvasWidth,
+      canvasHeight,
+    )
+    const scaledBounds = scaleBounds(bounds)
+    const elementVisible = isVisible && !!contentData?.songKey
+
+    return (
+      <AnimatedText
+        key="songKey"
+        content={contentData?.songKey ?? ''}
+        contentKey={`songKey-${contentKey}`}
+        isVisible={elementVisible}
+        style={{
+          ...sk.style,
+          maxFontSize: sk.style.maxFontSize * fontScale,
+        }}
+        width={scaledBounds.width}
+        height={scaledBounds.height}
+        left={scaledBounds.x}
+        top={scaledBounds.y}
+        isHtml={false}
+        animationIn={sk.animationIn}
+        animationOut={sk.animationOut}
+        slideTransitionIn={sk.slideTransitionIn}
+        slideTransitionOut={sk.slideTransitionOut}
+      />
+    )
+  }
+
+  // Render the "Amin" element — shown on the last slide. contentData.amen is
+  // only populated on the last slide, so visibility is gated automatically.
+  const renderAmen = () => {
+    if (!config || !('amen' in config) || !config.amen) return null
+    const am = config.amen
+    if (am.hidden) return null
+
+    const bounds = calculatePixelBounds(
+      am.constraints,
+      am.size,
+      canvasWidth,
+      canvasHeight,
+    )
+    const scaledBounds = scaleBounds(bounds)
+    const elementVisible = isVisible && !!contentData?.amen
+
+    return (
+      <AnimatedText
+        key="amen"
+        content={contentData?.amen ?? ''}
+        contentKey={`amen-${contentKey}`}
+        isVisible={elementVisible}
+        style={{
+          ...am.style,
+          maxFontSize: am.style.maxFontSize * fontScale,
+        }}
+        width={scaledBounds.width}
+        height={scaledBounds.height}
+        left={scaledBounds.x}
+        top={scaledBounds.y}
+        isHtml={false}
+        animationIn={am.animationIn}
+        animationOut={am.animationOut}
+        slideTransitionIn={am.slideTransitionIn}
+        slideTransitionOut={am.slideTransitionOut}
+      />
+    )
+  }
+
   // Render person label
   const renderPersonLabel = () => {
     if (!config || !('personLabel' in config)) return null
@@ -664,6 +742,8 @@ export function ScreenContent({
       {renderMainText()}
       {renderContentText()}
       {renderReferenceText()}
+      {renderSongKey()}
+      {renderAmen()}
       {renderPersonLabel()}
       {renderClock()}
       {renderNextSlideSection()}

--- a/app/apps/client/src/features/presentation/components/rendering/ScreenContent.tsx
+++ b/app/apps/client/src/features/presentation/components/rendering/ScreenContent.tsx
@@ -302,6 +302,15 @@ export function ScreenContent({
     if (!config || !('songKey' in config) || !config.songKey) return null
     const sk = config.songKey
     if (sk.hidden) return null
+    // Only mount when this slide actually has a key value. The plain `song`
+    // config still carries a vestigial `songKey`, so without this guard the
+    // element would stay mounted when navigating to a slide that has no gama
+    // (e.g. slide 1 → slide 2) and play a lingering fade-out of the old key —
+    // an intermediate "first-slide" frame. Gating on the value unmounts it
+    // cleanly there, while still rendering it on the first slide and on a
+    // single-slide song (where the value is present), and still fading it out
+    // on screen hide (where the value persists and only `isVisible` changes).
+    if (!contentData?.songKey) return null
 
     const bounds = calculatePixelBounds(
       sk.constraints,
@@ -341,6 +350,10 @@ export function ScreenContent({
     if (!config || !('amen' in config) || !config.amen) return null
     const am = config.amen
     if (am.hidden) return null
+    // Only mount when this slide actually has an amin value — see renderSongKey
+    // above. Without this guard the vestigial `song.amen` element lingers with a
+    // fade-out when navigating away from the last slide.
+    if (!contentData?.amen) return null
 
     const bounds = calculatePixelBounds(
       am.constraints,

--- a/app/apps/client/src/features/presentation/components/rendering/types.ts
+++ b/app/apps/client/src/features/presentation/components/rendering/types.ts
@@ -11,6 +11,8 @@ export interface ContentData {
   contentText?: string
   personLabel?: string
   chords?: ChordMapping[] | null
+  songKey?: string // Song key ("gama"), populated only on the first slide
+  amen?: string // "Amin", populated only on the last slide
 }
 
 export interface VerseteTineriSummaryEntry {

--- a/app/apps/client/src/features/presentation/components/screen-editor/ScreenEditor.tsx
+++ b/app/apps/client/src/features/presentation/components/screen-editor/ScreenEditor.tsx
@@ -246,6 +246,26 @@ export function ScreenEditor({
           ...(updates.constraints && { constraints: updates.constraints }),
           ...(updates.size && { size: updates.size }),
         }
+      } else if (
+        elementType === 'songKey' &&
+        'songKey' in newConfig &&
+        newConfig.songKey
+      ) {
+        newConfig.songKey = {
+          ...newConfig.songKey,
+          ...(updates.constraints && { constraints: updates.constraints }),
+          ...(updates.size && { size: updates.size }),
+        }
+      } else if (
+        elementType === 'amen' &&
+        'amen' in newConfig &&
+        newConfig.amen
+      ) {
+        newConfig.amen = {
+          ...newConfig.amen,
+          ...(updates.constraints && { constraints: updates.constraints }),
+          ...(updates.size && { size: updates.size }),
+        }
       } else if (elementType === 'personLabel' && 'personLabel' in newConfig) {
         newConfig.personLabel = {
           ...newConfig.personLabel,

--- a/app/apps/client/src/features/presentation/components/screen-editor/ScreenEditor.tsx
+++ b/app/apps/client/src/features/presentation/components/screen-editor/ScreenEditor.tsx
@@ -1,6 +1,7 @@
 import { useQueryClient } from '@tanstack/react-query'
 import { Monitor, RotateCcw, Save, X, ZoomIn, ZoomOut } from 'lucide-react'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useTranslation } from 'react-i18next'
 
 import { Button } from '~/ui/button/Button'
 import { Combobox } from '~/ui/combobox/Combobox'
@@ -24,15 +25,24 @@ interface ScreenEditorProps {
   onClose: () => void
 }
 
-const CONTENT_TYPE_OPTIONS: { value: ContentType; label: string }[] = [
-  { value: 'song', label: 'Song' },
-  { value: 'bible', label: 'Bible Verse' },
-  { value: 'bible_passage', label: 'Bible Passage' },
-  { value: 'announcement', label: 'Announcement' },
-  { value: 'versete_tineri', label: 'Versete Tineri' },
-  { value: 'empty', label: 'Empty / Clock' },
-  { value: 'screen_share', label: 'Screen Share' },
+const CONTENT_TYPE_VALUES: ContentType[] = [
+  'song',
+  'song_first_slide',
+  'bible',
+  'bible_passage',
+  'announcement',
+  'versete_tineri',
+  'empty',
+  'screen_share',
 ]
+
+const getContentTypeOptions = (
+  t: (key: string) => string,
+): { value: ContentType; label: string }[] =>
+  CONTENT_TYPE_VALUES.map((value) => ({
+    value,
+    label: t(`screens.contentTypes.${value}`),
+  }))
 
 export function ScreenEditor({
   screen: initialScreen,
@@ -40,6 +50,8 @@ export function ScreenEditor({
   onClose,
 }: ScreenEditorProps) {
   const [state, actions] = useEditorState()
+  const { t } = useTranslation('presentation')
+  const contentTypeOptions = useMemo(() => getContentTypeOptions(t), [t])
   const { send } = useWebSocket()
   const queryClient = useQueryClient()
   const lastEmitRef = useRef<number>(0)
@@ -358,7 +370,7 @@ export function ScreenEditor({
                 actions.setSelectedContentType(value as ContentType)
                 actions.clearSelection()
               }}
-              options={CONTENT_TYPE_OPTIONS}
+              options={contentTypeOptions}
               className="w-44 sm:w-56"
               portalContainer={portalContainer}
             />

--- a/app/apps/client/src/features/presentation/components/screen-editor/ScreenEditor.tsx
+++ b/app/apps/client/src/features/presentation/components/screen-editor/ScreenEditor.tsx
@@ -28,6 +28,7 @@ interface ScreenEditorProps {
 const CONTENT_TYPE_VALUES: ContentType[] = [
   'song',
   'song_first_slide',
+  'song_last_slide',
   'bible',
   'bible_passage',
   'announcement',

--- a/app/apps/client/src/features/presentation/components/screen-editor/ScreenEditorCanvas.tsx
+++ b/app/apps/client/src/features/presentation/components/screen-editor/ScreenEditorCanvas.tsx
@@ -713,7 +713,7 @@ export function ScreenEditorCanvas({
       )
     }
 
-    // Song key "gama" — only configurable in the "Gama - Strofă" (first slide)
+    // Song key "gama" — only configurable in the "Cântec - Primul Slide" (first slide)
     // layout. The `song` config still carries a vestigial songKey for backward
     // compatibility, but it never renders at runtime, so hide it from the Song
     // tab to avoid the operator editing an element that has no effect.
@@ -761,7 +761,7 @@ export function ScreenEditorCanvas({
       )
     }
 
-    // Amin — only configurable in the "Strofă - Amin" (last slide) layout. The
+    // Amin — only configurable in the "Cântec - Ultimul Slide" (last slide) layout. The
     // `song` config still carries a vestigial amen for backward compatibility,
     // but it never renders at runtime on a multi-slide song, so hide it from the
     // Song tab to avoid editing an element that has no effect.

--- a/app/apps/client/src/features/presentation/components/screen-editor/ScreenEditorCanvas.tsx
+++ b/app/apps/client/src/features/presentation/components/screen-editor/ScreenEditorCanvas.tsx
@@ -51,6 +51,10 @@ const SAMPLE_CONTENT: Record<
     main: 'Aleluia, Aleluia!\nMărire Domnului!\nAleluia, Aleluia!\nSlăvit să fie El!',
     songKey: 'G',
   },
+  song_last_slide: {
+    main: 'Aleluia, Aleluia!\nMărire Domnului!\nAleluia, Aleluia!\nSlăvit să fie El!',
+    amen: 'Amin!',
+  },
   bible: {
     reference: 'Ioan 3:16',
     main: 'Fiindcă atât de mult a iubit Dumnezeu lumea, că a dat pe singurul Lui Fiu, pentru ca oricine crede în El să nu piară, ci să aibă viață veșnică.',
@@ -757,8 +761,16 @@ export function ScreenEditorCanvas({
       )
     }
 
-    // Amin (song, last slide)
-    if (config && 'amen' in config && config.amen) {
+    // Amin — only configurable in the "Strofă - Amin" (last slide) layout. The
+    // `song` config still carries a vestigial amen for backward compatibility,
+    // but it never renders at runtime on a multi-slide song, so hide it from the
+    // Song tab to avoid editing an element that has no effect.
+    if (
+      config &&
+      'amen' in config &&
+      config.amen &&
+      contentType === 'song_last_slide'
+    ) {
       const am = config.amen
       const bounds = calculatePixelBounds(
         am.constraints,

--- a/app/apps/client/src/features/presentation/components/screen-editor/ScreenEditorCanvas.tsx
+++ b/app/apps/client/src/features/presentation/components/screen-editor/ScreenEditorCanvas.tsx
@@ -47,6 +47,10 @@ const SAMPLE_CONTENT: Record<
     songKey: 'G',
     amen: 'Amin!',
   },
+  song_first_slide: {
+    main: 'Aleluia, Aleluia!\nMărire Domnului!\nAleluia, Aleluia!\nSlăvit să fie El!',
+    songKey: 'G',
+  },
   bible: {
     reference: 'Ioan 3:16',
     main: 'Fiindcă atât de mult a iubit Dumnezeu lumea, că a dat pe singurul Lui Fiu, pentru ca oricine crede în El să nu piară, ci să aibă viață veșnică.',
@@ -705,8 +709,16 @@ export function ScreenEditorCanvas({
       )
     }
 
-    // Song key "gama" (song, first slide)
-    if (config && 'songKey' in config && config.songKey) {
+    // Song key "gama" — only configurable in the "Gama - Strofă" (first slide)
+    // layout. The `song` config still carries a vestigial songKey for backward
+    // compatibility, but it never renders at runtime, so hide it from the Song
+    // tab to avoid the operator editing an element that has no effect.
+    if (
+      config &&
+      'songKey' in config &&
+      config.songKey &&
+      contentType === 'song_first_slide'
+    ) {
       const sk = config.songKey
       const bounds = calculatePixelBounds(
         sk.constraints,

--- a/app/apps/client/src/features/presentation/components/screen-editor/ScreenEditorCanvas.tsx
+++ b/app/apps/client/src/features/presentation/components/screen-editor/ScreenEditorCanvas.tsx
@@ -34,10 +34,18 @@ interface ScreenEditorCanvasProps {
 // Sample content for preview
 const SAMPLE_CONTENT: Record<
   ContentType,
-  { main?: string; reference?: string; person?: string }
+  {
+    main?: string
+    reference?: string
+    person?: string
+    songKey?: string
+    amen?: string
+  }
 > = {
   song: {
     main: 'Aleluia, Aleluia!\nMărire Domnului!\nAleluia, Aleluia!\nSlăvit să fie El!',
+    songKey: 'G',
+    amen: 'Amin!',
   },
   bible: {
     reference: 'Ioan 3:16',
@@ -690,6 +698,86 @@ export function ScreenEditorCanvas({
           <TextContent
             content={sample?.reference ?? 'Reference'}
             style={{ ...rt.style, maxFontSize: rt.style.maxFontSize * scale }}
+            containerWidth={bounds.width * scale}
+            containerHeight={bounds.height * scale}
+          />
+        </DraggableElement>,
+      )
+    }
+
+    // Song key "gama" (song, first slide)
+    if (config && 'songKey' in config && config.songKey) {
+      const sk = config.songKey
+      const bounds = calculatePixelBounds(
+        sk.constraints,
+        sk.size,
+        canvasWidth,
+        canvasHeight,
+      )
+
+      els.push(
+        <DraggableElement
+          key="songKey"
+          x={bounds.x * scale}
+          y={bounds.y * scale}
+          width={bounds.width * scale}
+          height={bounds.height * scale}
+          constraints={sk.constraints}
+          size={sk.size}
+          isSelected={selectedElement?.type === 'songKey'}
+          isHidden={sk.hidden}
+          onClick={() => onSelectElement({ type: 'songKey' })}
+          onConstraintChange={handleConstraintChange('songKey')}
+          onSizeChange={handleSizeChange('songKey')}
+          canvasWidth={displaySize.width}
+          canvasHeight={displaySize.height}
+          screenWidth={canvasWidth}
+          screenHeight={canvasHeight}
+          canvasRef={canvasRef}
+        >
+          <TextContent
+            content={sample?.songKey ?? 'G'}
+            style={{ ...sk.style, maxFontSize: sk.style.maxFontSize * scale }}
+            containerWidth={bounds.width * scale}
+            containerHeight={bounds.height * scale}
+          />
+        </DraggableElement>,
+      )
+    }
+
+    // Amin (song, last slide)
+    if (config && 'amen' in config && config.amen) {
+      const am = config.amen
+      const bounds = calculatePixelBounds(
+        am.constraints,
+        am.size,
+        canvasWidth,
+        canvasHeight,
+      )
+
+      els.push(
+        <DraggableElement
+          key="amen"
+          x={bounds.x * scale}
+          y={bounds.y * scale}
+          width={bounds.width * scale}
+          height={bounds.height * scale}
+          constraints={am.constraints}
+          size={am.size}
+          isSelected={selectedElement?.type === 'amen'}
+          isHidden={am.hidden}
+          onClick={() => onSelectElement({ type: 'amen' })}
+          onConstraintChange={handleConstraintChange('amen')}
+          onSizeChange={handleSizeChange('amen')}
+          canvasWidth={displaySize.width}
+          canvasHeight={displaySize.height}
+          screenWidth={canvasWidth}
+          screenHeight={canvasHeight}
+          canvasRef={canvasRef}
+        >
+          <TextContent
+            content={sample?.amen ?? 'Amin!'}
+            style={{ ...am.style, maxFontSize: am.style.maxFontSize * scale }}
             containerWidth={bounds.width * scale}
             containerHeight={bounds.height * scale}
           />

--- a/app/apps/client/src/features/presentation/components/screen-editor/ScreenEditorCanvas.tsx
+++ b/app/apps/client/src/features/presentation/components/screen-editor/ScreenEditorCanvas.tsx
@@ -800,7 +800,7 @@ export function ScreenEditorCanvas({
           canvasRef={canvasRef}
         >
           <TextContent
-            content={sample?.amen ?? 'Amin!'}
+            content={am.text || 'Amin!'}
             style={{ ...am.style, maxFontSize: am.style.maxFontSize * scale }}
             containerWidth={bounds.width * scale}
             containerHeight={bounds.height * scale}

--- a/app/apps/client/src/features/presentation/components/screen-editor/ScreenEditorSidebar.tsx
+++ b/app/apps/client/src/features/presentation/components/screen-editor/ScreenEditorSidebar.tsx
@@ -255,6 +255,38 @@ export function ScreenEditorSidebar({
               refConfig.slideTransitionIn ?? DEFAULT_SLIDE_TRANSITION_IN,
           },
         }
+      case 'songKey': {
+        if (!('songKey' in config) || !config.songKey) return null
+        const skConfig = config.songKey as ReferenceTextConfig
+        return {
+          path: ['songKey'],
+          config: {
+            ...skConfig,
+            animationIn: skConfig.animationIn ?? DEFAULT_ANIMATION_IN,
+            animationOut: skConfig.animationOut ?? DEFAULT_ANIMATION_OUT,
+            slideTransitionOut:
+              skConfig.slideTransitionOut ?? DEFAULT_SLIDE_TRANSITION_OUT,
+            slideTransitionIn:
+              skConfig.slideTransitionIn ?? DEFAULT_SLIDE_TRANSITION_IN,
+          },
+        }
+      }
+      case 'amen': {
+        if (!('amen' in config) || !config.amen) return null
+        const amenConfig = config.amen as ReferenceTextConfig
+        return {
+          path: ['amen'],
+          config: {
+            ...amenConfig,
+            animationIn: amenConfig.animationIn ?? DEFAULT_ANIMATION_IN,
+            animationOut: amenConfig.animationOut ?? DEFAULT_ANIMATION_OUT,
+            slideTransitionOut:
+              amenConfig.slideTransitionOut ?? DEFAULT_SLIDE_TRANSITION_OUT,
+            slideTransitionIn:
+              amenConfig.slideTransitionIn ?? DEFAULT_SLIDE_TRANSITION_IN,
+          },
+        }
+      }
       case 'personLabel':
         if (!('personLabel' in config)) return null
         // Ensure animation configs exist for backwards compatibility
@@ -342,7 +374,11 @@ export function ScreenEditorSidebar({
         <>
           <div className="px-4 py-3 border-b border-gray-200 dark:border-gray-800 bg-gray-50 dark:bg-gray-800/50">
             <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-200 capitalize">
-              {selectedElement.type.replace(/([A-Z])/g, ' $1').trim()}
+              {selectedElement.type === 'songKey'
+                ? t('screens.elements.songKey')
+                : selectedElement.type === 'amen'
+                  ? t('screens.elements.amen')
+                  : selectedElement.type.replace(/([A-Z])/g, ' $1').trim()}
             </h3>
           </div>
 

--- a/app/apps/client/src/features/presentation/components/screen-editor/ScreenEditorSidebar.tsx
+++ b/app/apps/client/src/features/presentation/components/screen-editor/ScreenEditorSidebar.tsx
@@ -1897,7 +1897,14 @@ export function ScreenEditorSidebar({
                     className="w-full h-24 px-3 py-2 text-sm border rounded-md border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500"
                     placeholder={t('screens.editor.previewTextPlaceholder')}
                     value={(() => {
-                      if (!selectedElement || !previewTexts) return ''
+                      if (!selectedElement) return ''
+                      // The "Amin" element has no underlying song data, so its
+                      // text is a saved config value (the operator's custom
+                      // label, default "Amin!"), not a preview-only override.
+                      if (selectedElement.type === 'amen') {
+                        return ('amen' in config && config.amen?.text) || ''
+                      }
+                      if (!previewTexts) return ''
                       switch (selectedElement.type) {
                         case 'mainText':
                         case 'contentText':
@@ -1911,7 +1918,14 @@ export function ScreenEditorSidebar({
                       }
                     })()}
                     onChange={(e) => {
-                      if (!selectedElement || !onSetPreviewText) return
+                      if (!selectedElement) return
+                      // Persist the custom "Amin" text to the config (it drives
+                      // both the editor preview and the projected output).
+                      if (selectedElement.type === 'amen') {
+                        updateConfig(['amen', 'text'], e.target.value || undefined)
+                        return
+                      }
+                      if (!onSetPreviewText) return
                       switch (selectedElement.type) {
                         case 'mainText':
                         case 'contentText':

--- a/app/apps/client/src/features/presentation/components/screen-editor/hooks/useEditorState.ts
+++ b/app/apps/client/src/features/presentation/components/screen-editor/hooks/useEditorState.ts
@@ -12,6 +12,8 @@ export type SelectedElement =
   | { type: 'mainText' }
   | { type: 'contentText' }
   | { type: 'referenceText' }
+  | { type: 'songKey' }
+  | { type: 'amen' }
   | { type: 'personLabel' }
   | { type: 'clock' }
   | { type: 'nextSlide' }

--- a/app/apps/client/src/features/presentation/components/screen-editor/hooks/useEditorState.ts
+++ b/app/apps/client/src/features/presentation/components/screen-editor/hooks/useEditorState.ts
@@ -32,6 +32,7 @@ type PreviewTextsMap = Record<ContentType, PreviewTexts>
 const createEmptyPreviewTexts = (): PreviewTextsMap => ({
   song: {},
   song_first_slide: {},
+  song_last_slide: {},
   bible: {},
   bible_passage: {},
   announcement: {},

--- a/app/apps/client/src/features/presentation/components/screen-editor/hooks/useEditorState.ts
+++ b/app/apps/client/src/features/presentation/components/screen-editor/hooks/useEditorState.ts
@@ -31,6 +31,7 @@ type PreviewTextsMap = Record<ContentType, PreviewTexts>
 
 const createEmptyPreviewTexts = (): PreviewTextsMap => ({
   song: {},
+  song_first_slide: {},
   bible: {},
   bible_passage: {},
   announcement: {},

--- a/app/apps/client/src/features/presentation/hooks/useKeyboardShortcuts.ts
+++ b/app/apps/client/src/features/presentation/hooks/useKeyboardShortcuts.ts
@@ -6,6 +6,7 @@ import {
 } from '~/features/keyboard-shortcuts'
 import {
   useClearSlide,
+  useClearTemporaryContent,
   useNavigateTemporary,
   usePresentationState,
   useShowSlide,
@@ -19,11 +20,23 @@ export function useKeyboardShortcuts() {
   const { data: state } = usePresentationState()
   const navigateTemporary = useNavigateTemporary()
   const clearSlide = useClearSlide()
+  const clearTemporary = useClearTemporaryContent()
   const showSlide = useShowSlide()
 
   // Determine if we have content to navigate (song slides or temporary content)
-  const hasNavigableContent =
-    !!state?.currentSongSlideId || !!state?.temporaryContent
+  const hasTemporaryContent = !!state?.temporaryContent
+  const hasNavigableContent = !!state?.currentSongSlideId || hasTemporaryContent
+
+  // Full close for the presenter remote's "black screen" button: drop the
+  // temporary content entirely (same end state as advancing past the last
+  // slide) so the presentation truly CLOSES, not just blanks with a restore.
+  const closePresentation = useCallback(() => {
+    if (hasTemporaryContent) {
+      clearTemporary.mutate()
+    } else {
+      clearSlide.mutate()
+    }
+  }, [hasTemporaryContent, clearTemporary, clearSlide])
 
   const handleKeyDown = useCallback(
     (event: KeyboardEvent): boolean => {
@@ -57,6 +70,25 @@ export function useKeyboardShortcuts() {
           clearSlide.mutate()
           return true
 
+        case 'b':
+        case 'B':
+        case '.':
+          // A presenter remote's "black screen" button typically sends "b" or
+          // ".". Fully CLOSE the live presentation (same end state as going
+          // past the last slide). Only when something is live, so we never
+          // swallow a stray keypress.
+          if (!hasNavigableContent) return false
+          event.preventDefault()
+          closePresentation()
+          return true
+
+        case 'F5':
+          // Presenter-remote "present/start" button. On the song page (higher
+          // priority) this presents the focused slide; here we just swallow it
+          // so the desktop webview never reloads on F5 elsewhere.
+          event.preventDefault()
+          return true
+
         case 'Enter':
           // Show presentation (unhide)
           event.preventDefault()
@@ -67,7 +99,13 @@ export function useKeyboardShortcuts() {
           return false
       }
     },
-    [hasNavigableContent, navigateTemporary, clearSlide, showSlide],
+    [
+      hasNavigableContent,
+      navigateTemporary,
+      clearSlide,
+      closePresentation,
+      showSlide,
+    ],
   )
 
   // Register with PRESENTATION priority (lowest) - page-specific handlers take precedence

--- a/app/apps/client/src/features/presentation/hooks/useKeyboardShortcuts.ts
+++ b/app/apps/client/src/features/presentation/hooks/useKeyboardShortcuts.ts
@@ -6,7 +6,6 @@ import {
 } from '~/features/keyboard-shortcuts'
 import {
   useClearSlide,
-  useClearTemporaryContent,
   useNavigateTemporary,
   usePresentationState,
   useShowSlide,
@@ -20,23 +19,11 @@ export function useKeyboardShortcuts() {
   const { data: state } = usePresentationState()
   const navigateTemporary = useNavigateTemporary()
   const clearSlide = useClearSlide()
-  const clearTemporary = useClearTemporaryContent()
   const showSlide = useShowSlide()
 
   // Determine if we have content to navigate (song slides or temporary content)
-  const hasTemporaryContent = !!state?.temporaryContent
-  const hasNavigableContent = !!state?.currentSongSlideId || hasTemporaryContent
-
-  // Full close for the presenter remote's "black screen" button: drop the
-  // temporary content entirely (same end state as advancing past the last
-  // slide) so the presentation truly CLOSES, not just blanks with a restore.
-  const closePresentation = useCallback(() => {
-    if (hasTemporaryContent) {
-      clearTemporary.mutate()
-    } else {
-      clearSlide.mutate()
-    }
-  }, [hasTemporaryContent, clearTemporary, clearSlide])
+  const hasNavigableContent =
+    !!state?.currentSongSlideId || !!state?.temporaryContent
 
   const handleKeyDown = useCallback(
     (event: KeyboardEvent): boolean => {
@@ -74,12 +61,12 @@ export function useKeyboardShortcuts() {
         case 'B':
         case '.':
           // A presenter remote's "black screen" button typically sends "b" or
-          // ".". Fully CLOSE the live presentation (same end state as going
-          // past the last slide). Only when something is live, so we never
-          // swallow a stray keypress.
+          // ".". Behave exactly like Escape — hide the presentation (show the
+          // clock) — but ONLY while something is being presented. When nothing
+          // is live it does nothing (and we don't swallow the keypress).
           if (!hasNavigableContent) return false
           event.preventDefault()
-          closePresentation()
+          clearSlide.mutate()
           return true
 
         case 'F5':
@@ -99,13 +86,7 @@ export function useKeyboardShortcuts() {
           return false
       }
     },
-    [
-      hasNavigableContent,
-      navigateTemporary,
-      clearSlide,
-      closePresentation,
-      showSlide,
-    ],
+    [hasNavigableContent, navigateTemporary, clearSlide, showSlide],
   )
 
   // Register with PRESENTATION priority (lowest) - page-specific handlers take precedence

--- a/app/apps/client/src/features/presentation/hooks/usePresentationContent.ts
+++ b/app/apps/client/src/features/presentation/hooks/usePresentationContent.ts
@@ -358,25 +358,34 @@ export function usePresentationContent({
             // Key ("gama") and "Amin" are now their own positionable/styleable
             // elements (see ScreenContent renderSongKey/renderAmen), so we emit
             // them as separate fields instead of injecting into the slide text.
+            const songKeyValue = resolveSongKey(
+              isFirstSlide,
+              temp.data.keyLine,
+              songConfig,
+            )
+            const amenValue = resolveAmen(isLastSlide, slideContent)
             // Resolve chords for this slide
             const resolvedChords = resolveSlideChords(
               temp.data.currentSlideIndex,
               temp.data.slides,
             )
-            // First slide → "Gama - Strofă" (song_first_slide), last slide →
-            // "Strofă - Amin" (song_last_slide), middle slides → `song`.
+            // First slide WITH a gama → "Gama - Strofă" (song_first_slide), last
+            // slide WITH an amin → "Strofă - Amin" (song_last_slide); otherwise
+            // the plain `song` layout so the strofa isn't shifted for an absent
+            // element.
             setContentType(
-              resolveSongSlideContentType(isFirstSlide, isLastSlide),
+              resolveSongSlideContentType(
+                isFirstSlide,
+                isLastSlide,
+                !!songKeyValue,
+                !!amenValue,
+              ),
             )
             setContentData({
               mainText: slideContent,
               chords: resolvedChords,
-              songKey: resolveSongKey(
-                isFirstSlide,
-                temp.data.keyLine,
-                songConfig,
-              ),
-              amen: resolveAmen(isLastSlide, slideContent),
+              songKey: songKeyValue,
+              amen: amenValue,
             })
             setContentKey(
               `song|${temp.data.songId}|${temp.data.currentSlideIndex}`,
@@ -539,20 +548,32 @@ export function usePresentationContent({
                 | SongContentConfig
                 | undefined
               // Key + Amin are emitted as separate elements (see above).
+              const songKeyValue = resolveSongKey(
+                isFirstSlide,
+                item.keyLine,
+                songCfg,
+              )
+              const amenValue = resolveAmen(isLastSlide, slideContent)
               // Resolve chords for this slide
               const queueChords = resolveSlideChords(slideIndex, item.slides)
 
               if (isCancelled) return
-              // First slide → "Gama - Strofă" (song_first_slide), last slide →
-              // "Strofă - Amin" (song_last_slide), middle slides → `song`.
+              // First slide WITH a gama → "Gama - Strofă" (song_first_slide),
+              // last slide WITH an amin → "Strofă - Amin" (song_last_slide);
+              // otherwise the plain `song` layout.
               setContentType(
-                resolveSongSlideContentType(isFirstSlide, isLastSlide),
+                resolveSongSlideContentType(
+                  isFirstSlide,
+                  isLastSlide,
+                  !!songKeyValue,
+                  !!amenValue,
+                ),
               )
               setContentData({
                 mainText: slideContent,
                 chords: queueChords,
-                songKey: resolveSongKey(isFirstSlide, item.keyLine, songCfg),
-                amen: resolveAmen(isLastSlide, slideContent),
+                songKey: songKeyValue,
+                amen: amenValue,
               })
               setContentKey(`song|${item.songId}|${slideIndex}`)
 

--- a/app/apps/client/src/features/presentation/hooks/usePresentationContent.ts
+++ b/app/apps/client/src/features/presentation/hooks/usePresentationContent.ts
@@ -359,7 +359,9 @@ export function usePresentationContent({
               temp.data.currentSlideIndex,
               temp.data.slides,
             )
-            setContentType('song')
+            // The first slide uses the dedicated "Gama - Strofă"
+            // (song_first_slide) layout; every following slide uses `song`.
+            setContentType(isFirstSlide ? 'song_first_slide' : 'song')
             setContentData({
               mainText: slideContent,
               chords: resolvedChords,
@@ -535,7 +537,9 @@ export function usePresentationContent({
               const queueChords = resolveSlideChords(slideIndex, item.slides)
 
               if (isCancelled) return
-              setContentType('song')
+              // First slide → "Gama - Strofă" (song_first_slide) layout; the
+              // rest of the song uses `song`.
+              setContentType(isFirstSlide ? 'song_first_slide' : 'song')
               setContentData({
                 mainText: slideContent,
                 chords: queueChords,

--- a/app/apps/client/src/features/presentation/hooks/usePresentationContent.ts
+++ b/app/apps/client/src/features/presentation/hooks/usePresentationContent.ts
@@ -10,8 +10,8 @@ import { useSongUpdateTimestamp } from '../context/WebSocketContext'
 import type { ContentType, ScreenConfig, SongContentConfig } from '../types'
 import { resolveSlideChords } from '../utils/resolveSlideChords'
 import {
-  resolveAmen,
   resolveSongKey,
+  resolveSongSlideBody,
   resolveSongSlideContentType,
 } from '../utils/songElements'
 
@@ -358,12 +358,15 @@ export function usePresentationContent({
             // Key ("gama") and "Amin" are now their own positionable/styleable
             // elements (see ScreenContent renderSongKey/renderAmen), so we emit
             // them as separate fields instead of injecting into the slide text.
+            // A standalone trailing "amin" line is pulled out of the lyrics into
+            // the amin element (so it isn't shown twice).
             const songKeyValue = resolveSongKey(
               isFirstSlide,
               temp.data.keyLine,
               songConfig,
             )
-            const amenValue = resolveAmen(isLastSlide, slideContent)
+            const { mainText: songMainText, amen: amenValue } =
+              resolveSongSlideBody(isLastSlide, slideContent)
             // Resolve chords for this slide
             const resolvedChords = resolveSlideChords(
               temp.data.currentSlideIndex,
@@ -382,7 +385,7 @@ export function usePresentationContent({
               ),
             )
             setContentData({
-              mainText: slideContent,
+              mainText: songMainText,
               chords: resolvedChords,
               songKey: songKeyValue,
               amen: amenValue,
@@ -547,13 +550,15 @@ export function usePresentationContent({
               const songCfg = screen?.contentConfigs?.song as
                 | SongContentConfig
                 | undefined
-              // Key + Amin are emitted as separate elements (see above).
+              // Key + Amin are emitted as separate elements (see above). A
+              // standalone trailing "amin" line is pulled out of the lyrics.
               const songKeyValue = resolveSongKey(
                 isFirstSlide,
                 item.keyLine,
                 songCfg,
               )
-              const amenValue = resolveAmen(isLastSlide, slideContent)
+              const { mainText: songMainText, amen: amenValue } =
+                resolveSongSlideBody(isLastSlide, slideContent)
               // Resolve chords for this slide
               const queueChords = resolveSlideChords(slideIndex, item.slides)
 
@@ -570,7 +575,7 @@ export function usePresentationContent({
                 ),
               )
               setContentData({
-                mainText: slideContent,
+                mainText: songMainText,
                 chords: queueChords,
                 songKey: songKeyValue,
                 amen: amenValue,

--- a/app/apps/client/src/features/presentation/hooks/usePresentationContent.ts
+++ b/app/apps/client/src/features/presentation/hooks/usePresentationContent.ts
@@ -9,7 +9,11 @@ import { calculateMaxExitAnimationDuration } from '../components/rendering/utils
 import { useSongUpdateTimestamp } from '../context/WebSocketContext'
 import type { ContentType, ScreenConfig, SongContentConfig } from '../types'
 import { resolveSlideChords } from '../utils/resolveSlideChords'
-import { resolveAmen, resolveSongKey } from '../utils/songElements'
+import {
+  resolveAmen,
+  resolveSongKey,
+  resolveSongSlideContentType,
+} from '../utils/songElements'
 
 const logger = createLogger('app:presentation:content')
 
@@ -359,9 +363,11 @@ export function usePresentationContent({
               temp.data.currentSlideIndex,
               temp.data.slides,
             )
-            // The first slide uses the dedicated "Gama - Strofă"
-            // (song_first_slide) layout; every following slide uses `song`.
-            setContentType(isFirstSlide ? 'song_first_slide' : 'song')
+            // First slide → "Gama - Strofă" (song_first_slide), last slide →
+            // "Strofă - Amin" (song_last_slide), middle slides → `song`.
+            setContentType(
+              resolveSongSlideContentType(isFirstSlide, isLastSlide),
+            )
             setContentData({
               mainText: slideContent,
               chords: resolvedChords,
@@ -537,9 +543,11 @@ export function usePresentationContent({
               const queueChords = resolveSlideChords(slideIndex, item.slides)
 
               if (isCancelled) return
-              // First slide → "Gama - Strofă" (song_first_slide) layout; the
-              // rest of the song uses `song`.
-              setContentType(isFirstSlide ? 'song_first_slide' : 'song')
+              // First slide → "Gama - Strofă" (song_first_slide), last slide →
+              // "Strofă - Amin" (song_last_slide), middle slides → `song`.
+              setContentType(
+                resolveSongSlideContentType(isFirstSlide, isLastSlide),
+              )
               setContentData({
                 mainText: slideContent,
                 chords: queueChords,

--- a/app/apps/client/src/features/presentation/hooks/usePresentationContent.ts
+++ b/app/apps/client/src/features/presentation/hooks/usePresentationContent.ts
@@ -372,8 +372,8 @@ export function usePresentationContent({
               temp.data.currentSlideIndex,
               temp.data.slides,
             )
-            // First slide WITH a gama → "Gama - Strofă" (song_first_slide), last
-            // slide WITH an amin → "Strofă - Amin" (song_last_slide); otherwise
+            // First slide WITH a gama → "Cântec - Primul Slide" (song_first_slide), last
+            // slide WITH an amin → "Cântec - Ultimul Slide" (song_last_slide); otherwise
             // the plain `song` layout so the strofa isn't shifted for an absent
             // element.
             setContentType(
@@ -563,8 +563,8 @@ export function usePresentationContent({
               const queueChords = resolveSlideChords(slideIndex, item.slides)
 
               if (isCancelled) return
-              // First slide WITH a gama → "Gama - Strofă" (song_first_slide),
-              // last slide WITH an amin → "Strofă - Amin" (song_last_slide);
+              // First slide WITH a gama → "Cântec - Primul Slide" (song_first_slide),
+              // last slide WITH an amin → "Cântec - Ultimul Slide" (song_last_slide);
               // otherwise the plain `song` layout.
               setContentType(
                 resolveSongSlideContentType(

--- a/app/apps/client/src/features/presentation/hooks/usePresentationContent.ts
+++ b/app/apps/client/src/features/presentation/hooks/usePresentationContent.ts
@@ -8,9 +8,8 @@ import { usePresentationState } from './usePresentationState'
 import { calculateMaxExitAnimationDuration } from '../components/rendering/utils/styleUtils'
 import { useSongUpdateTimestamp } from '../context/WebSocketContext'
 import type { ContentType, ScreenConfig, SongContentConfig } from '../types'
-import { addAminToLastSlide } from '../utils/addAminToLastSlide'
-import { addKeyLineToFirstSlide } from '../utils/addKeyLineToFirstSlide'
 import { resolveSlideChords } from '../utils/resolveSlideChords'
+import { resolveAmen, resolveSongKey } from '../utils/songElements'
 
 const logger = createLogger('app:presentation:content')
 
@@ -85,6 +84,8 @@ export interface ContentData {
   personLabel?: string
   secondaryContentText?: string
   chords?: ChordMapping[] | null
+  songKey?: string // Song key ("gama"), populated only on the first slide
+  amen?: string // "Amin", populated only on the last slide
 }
 
 export interface NextSlideData {
@@ -346,24 +347,29 @@ export function usePresentationContent({
             const isFirstSlide = temp.data.currentSlideIndex === 0
             const isLastSlide =
               temp.data.currentSlideIndex === temp.data.slides.length - 1
-            let slideContent = currentSlide.content
+            const slideContent = currentSlide.content
             const songConfig = screen?.contentConfigs?.song as
               | SongContentConfig
               | undefined
-            const shouldShowKeyLine = songConfig?.displayKeyLine ?? true
-            slideContent = addKeyLineToFirstSlide(
-              slideContent,
-              isFirstSlide,
-              shouldShowKeyLine ? temp.data.keyLine : null,
-            )
-            slideContent = addAminToLastSlide(slideContent, isLastSlide)
+            // Key ("gama") and "Amin" are now their own positionable/styleable
+            // elements (see ScreenContent renderSongKey/renderAmen), so we emit
+            // them as separate fields instead of injecting into the slide text.
             // Resolve chords for this slide
             const resolvedChords = resolveSlideChords(
               temp.data.currentSlideIndex,
               temp.data.slides,
             )
             setContentType('song')
-            setContentData({ mainText: slideContent, chords: resolvedChords })
+            setContentData({
+              mainText: slideContent,
+              chords: resolvedChords,
+              songKey: resolveSongKey(
+                isFirstSlide,
+                temp.data.keyLine,
+                songConfig,
+              ),
+              amen: resolveAmen(isLastSlide, slideContent),
+            })
             setContentKey(
               `song|${temp.data.songId}|${temp.data.currentSlideIndex}`,
             )
@@ -520,18 +526,11 @@ export function usePresentationContent({
               const slide = item.slides[slideIndex]
               const isFirstSlide = slideIndex === 0
               const isLastSlide = slideIndex === item.slides.length - 1
-              let slideContent = slide.content
+              const slideContent = slide.content
               const songCfg = screen?.contentConfigs?.song as
                 | SongContentConfig
                 | undefined
-              const showKeyLine = songCfg?.displayKeyLine ?? true
-              slideContent = addKeyLineToFirstSlide(
-                slideContent,
-                isFirstSlide,
-                showKeyLine ? item.keyLine : null,
-              )
-              slideContent = addAminToLastSlide(slideContent, isLastSlide)
-
+              // Key + Amin are emitted as separate elements (see above).
               // Resolve chords for this slide
               const queueChords = resolveSlideChords(slideIndex, item.slides)
 
@@ -540,6 +539,8 @@ export function usePresentationContent({
               setContentData({
                 mainText: slideContent,
                 chords: queueChords,
+                songKey: resolveSongKey(isFirstSlide, item.keyLine, songCfg),
+                amen: resolveAmen(isLastSlide, slideContent),
               })
               setContentKey(`song|${item.songId}|${slideIndex}`)
 

--- a/app/apps/client/src/features/presentation/hooks/usePresentationContent.ts
+++ b/app/apps/client/src/features/presentation/hooks/usePresentationContent.ts
@@ -7,7 +7,12 @@ import { createLogger } from '~/utils/logger'
 import { usePresentationState } from './usePresentationState'
 import { calculateMaxExitAnimationDuration } from '../components/rendering/utils/styleUtils'
 import { useSongUpdateTimestamp } from '../context/WebSocketContext'
-import type { ContentType, ScreenConfig, SongContentConfig } from '../types'
+import type {
+  ContentType,
+  ScreenConfig,
+  SongContentConfig,
+  SongLastSlideContentConfig,
+} from '../types'
 import { resolveSlideChords } from '../utils/resolveSlideChords'
 import {
   resolveSongKey,
@@ -365,8 +370,15 @@ export function usePresentationContent({
               temp.data.keyLine,
               songConfig,
             )
+            // Operator's custom "Amin" label (from the "Strofă - Amin" tab).
+            const customAmin =
+              (
+                screen?.contentConfigs?.song_last_slide as
+                  | SongLastSlideContentConfig
+                  | undefined
+              )?.amen?.text ?? songConfig?.amen?.text
             const { mainText: songMainText, amen: amenValue } =
-              resolveSongSlideBody(isLastSlide, slideContent)
+              resolveSongSlideBody(isLastSlide, slideContent, customAmin)
             // Resolve chords for this slide
             const resolvedChords = resolveSlideChords(
               temp.data.currentSlideIndex,
@@ -557,8 +569,15 @@ export function usePresentationContent({
                 item.keyLine,
                 songCfg,
               )
+              // Operator's custom "Amin" label (from the "Strofă - Amin" tab).
+              const customAmin =
+                (
+                  screen?.contentConfigs?.song_last_slide as
+                    | SongLastSlideContentConfig
+                    | undefined
+                )?.amen?.text ?? songCfg?.amen?.text
               const { mainText: songMainText, amen: amenValue } =
-                resolveSongSlideBody(isLastSlide, slideContent)
+                resolveSongSlideBody(isLastSlide, slideContent, customAmin)
               // Resolve chords for this slide
               const queueChords = resolveSlideChords(slideIndex, item.slides)
 

--- a/app/apps/client/src/features/presentation/service/highlights.ts
+++ b/app/apps/client/src/features/presentation/service/highlights.ts
@@ -16,11 +16,18 @@ function getHeaders(contentType?: string): Record<string, string> {
   if (contentType) {
     headers['Content-Type'] = contentType
   }
-  // Add auth cookie header for mobile (Tauri HTTP plugin needs explicit Cookie header)
-  if (isMobile()) {
+  // Mobile sends the auth token as a Cookie (Tauri HTTP plugin); desktop Tauri
+  // sends it as X-User-Auth (window.fetch forbids Cookie, and macOS WKWebView
+  // won't store the cross-site Secure cookie). Browser uses the same-origin
+  // cookie, so no header is needed.
+  if (isTauri) {
     const userToken = getStoredUserToken()
     if (userToken) {
-      headers['Cookie'] = `user_auth=${userToken}`
+      if (isMobile()) {
+        headers['Cookie'] = `user_auth=${userToken}`
+      } else {
+        headers['X-User-Auth'] = userToken
+      }
     }
   }
   return headers

--- a/app/apps/client/src/features/presentation/service/presentation.ts
+++ b/app/apps/client/src/features/presentation/service/presentation.ts
@@ -28,11 +28,18 @@ function getHeaders(contentType?: string): Record<string, string> {
   if (contentType) {
     headers['Content-Type'] = contentType
   }
-  // Add auth cookie header for mobile (Tauri HTTP plugin needs explicit Cookie header)
-  if (isMobile()) {
+  // Mobile sends the auth token as a Cookie (Tauri HTTP plugin); desktop Tauri
+  // sends it as X-User-Auth (window.fetch forbids Cookie, and macOS WKWebView
+  // won't store the cross-site Secure cookie). Browser uses the same-origin
+  // cookie, so no header is needed.
+  if (isTauri) {
     const userToken = getStoredUserToken()
     if (userToken) {
-      headers['Cookie'] = `user_auth=${userToken}`
+      if (isMobile()) {
+        headers['Cookie'] = `user_auth=${userToken}`
+      } else {
+        headers['X-User-Auth'] = userToken
+      }
     }
   }
   return headers

--- a/app/apps/client/src/features/presentation/service/screens.ts
+++ b/app/apps/client/src/features/presentation/service/screens.ts
@@ -27,10 +27,18 @@ function getHeaders(contentType?: string): Record<string, string> {
   if (contentType) {
     headers['Content-Type'] = contentType
   }
-  if (isMobile()) {
+  // Mobile sends the auth token as a Cookie (Tauri HTTP plugin); desktop Tauri
+  // sends it as X-User-Auth (window.fetch forbids Cookie, and macOS WKWebView
+  // won't store the cross-site Secure cookie). Browser uses the same-origin
+  // cookie, so no header is needed.
+  if (isTauri) {
     const userToken = getStoredUserToken()
     if (userToken) {
-      headers['Cookie'] = `user_auth=${userToken}`
+      if (isMobile()) {
+        headers['Cookie'] = `user_auth=${userToken}`
+      } else {
+        headers['X-User-Auth'] = userToken
+      }
     }
   }
   return headers

--- a/app/apps/client/src/features/presentation/types.ts
+++ b/app/apps/client/src/features/presentation/types.ts
@@ -338,6 +338,7 @@ export type ScreenType = 'primary' | 'stage' | 'livestream' | 'kiosk'
  */
 export type ContentType =
   | 'song'
+  | 'song_first_slide'
   | 'bible'
   | 'bible_passage'
   | 'announcement'
@@ -545,6 +546,21 @@ export interface SongContentConfig {
   chordFontSize?: number // Font size for chord annotations in px (default: 32)
 }
 
+/**
+ * Layout for a song's FIRST slide only ("Gama - Strofă"). Two separately
+ * positionable elements — the song key (gama) and the slide lyrics (strofa) —
+ * like the Bible reference/verse pair. Applies only to the first slide of a
+ * song; every following slide uses {@link SongContentConfig}. Chord/keyline
+ * display stay on the `song` config (single source), so they are not repeated
+ * here.
+ */
+export interface SongFirstSlideContentConfig {
+  background: ScreenBackgroundConfig
+  mainText: TextElementConfig // the lyrics of the first slide ("strofa")
+  songKey?: ReferenceTextConfig // the song key ("gama")
+  clockEnabled?: boolean // Per-slide-type enable, uses global clockConfig for position/style
+}
+
 export type ReferenceWrapperStyle = 'none' | 'parentheses' | 'brackets'
 
 export interface BibleContentConfig {
@@ -599,6 +615,7 @@ export interface ScreenShareContentConfig {
  */
 export type ContentTypeConfig =
   | SongContentConfig
+  | SongFirstSlideContentConfig
   | BibleContentConfig
   | AnnouncementContentConfig
   | VerseteTineriContentConfig
@@ -610,6 +627,7 @@ export type ContentTypeConfig =
  */
 export interface ContentConfigMap {
   song: SongContentConfig
+  song_first_slide: SongFirstSlideContentConfig
   bible: BibleContentConfig
   bible_passage: BibleContentConfig
   announcement: AnnouncementContentConfig

--- a/app/apps/client/src/features/presentation/types.ts
+++ b/app/apps/client/src/features/presentation/types.ts
@@ -548,7 +548,7 @@ export interface SongContentConfig {
 }
 
 /**
- * Layout for a song's FIRST slide only ("Gama - Strofă"). Two separately
+ * Layout for a song's FIRST slide only ("Cântec - Primul Slide"). Two separately
  * positionable elements — the song key (gama) and the slide lyrics (strofa) —
  * like the Bible reference/verse pair. Applies only to the first slide of a
  * song; every following slide uses {@link SongContentConfig}. Chord/keyline
@@ -563,7 +563,7 @@ export interface SongFirstSlideContentConfig {
 }
 
 /**
- * Layout for a song's LAST slide only ("Strofă - Amin"). Two separately
+ * Layout for a song's LAST slide only ("Cântec - Ultimul Slide"). Two separately
  * positionable elements — the slide lyrics (strofa) and the "Amin" — like the
  * Bible reference/verse pair. Applies only to the last slide of a song; every
  * preceding slide uses {@link SongContentConfig}. Chord display stays on the

--- a/app/apps/client/src/features/presentation/types.ts
+++ b/app/apps/client/src/features/presentation/types.ts
@@ -339,6 +339,7 @@ export type ScreenType = 'primary' | 'stage' | 'livestream' | 'kiosk'
 export type ContentType =
   | 'song'
   | 'song_first_slide'
+  | 'song_last_slide'
   | 'bible'
   | 'bible_passage'
   | 'announcement'
@@ -561,6 +562,20 @@ export interface SongFirstSlideContentConfig {
   clockEnabled?: boolean // Per-slide-type enable, uses global clockConfig for position/style
 }
 
+/**
+ * Layout for a song's LAST slide only ("Strofă - Amin"). Two separately
+ * positionable elements — the slide lyrics (strofa) and the "Amin" — like the
+ * Bible reference/verse pair. Applies only to the last slide of a song; every
+ * preceding slide uses {@link SongContentConfig}. Chord display stays on the
+ * `song` config (single source), so it is not repeated here.
+ */
+export interface SongLastSlideContentConfig {
+  background: ScreenBackgroundConfig
+  mainText: TextElementConfig // the lyrics of the last slide ("strofa")
+  amen?: ReferenceTextConfig // the "Amin" element
+  clockEnabled?: boolean // Per-slide-type enable, uses global clockConfig for position/style
+}
+
 export type ReferenceWrapperStyle = 'none' | 'parentheses' | 'brackets'
 
 export interface BibleContentConfig {
@@ -616,6 +631,7 @@ export interface ScreenShareContentConfig {
 export type ContentTypeConfig =
   | SongContentConfig
   | SongFirstSlideContentConfig
+  | SongLastSlideContentConfig
   | BibleContentConfig
   | AnnouncementContentConfig
   | VerseteTineriContentConfig
@@ -628,6 +644,7 @@ export type ContentTypeConfig =
 export interface ContentConfigMap {
   song: SongContentConfig
   song_first_slide: SongFirstSlideContentConfig
+  song_last_slide: SongLastSlideContentConfig
   bible: BibleContentConfig
   bible_passage: BibleContentConfig
   announcement: AnnouncementContentConfig

--- a/app/apps/client/src/features/presentation/types.ts
+++ b/app/apps/client/src/features/presentation/types.ts
@@ -537,6 +537,8 @@ export interface PersonLabelConfig {
 export interface SongContentConfig {
   background: ScreenBackgroundConfig
   mainText: TextElementConfig
+  songKey?: ReferenceTextConfig // Song key ("gama") element, shown on the first slide
+  amen?: ReferenceTextConfig // "Amin" element, shown on the last slide
   clockEnabled?: boolean // Per-slide-type enable, uses global clockConfig for position/style
   displayKeyLine?: boolean // Whether to display the song key line on the first slide (default: true)
   displayChords?: boolean // Whether to display chord annotations above lyrics (default: false)

--- a/app/apps/client/src/features/presentation/types.ts
+++ b/app/apps/client/src/features/presentation/types.ts
@@ -515,6 +515,12 @@ export interface ReferenceTextConfig {
   slideTransitionIn?: AnimationConfig // Animation for new content entering during slide change
   slideTransitionOut?: AnimationConfig // Animation for old content leaving during slide change
   hidden?: boolean
+  /**
+   * Custom label text. Used by the "Amin" element so the operator can replace
+   * the default "Amin!" with their own text. Empty/undefined keeps the default
+   * (or a standalone trailing "amin" line extracted from the slide).
+   */
+  text?: string
 }
 
 /**

--- a/app/apps/client/src/features/presentation/utils/__tests__/songElements.test.ts
+++ b/app/apps/client/src/features/presentation/utils/__tests__/songElements.test.ts
@@ -150,4 +150,22 @@ describe('resolveSongSlideBody', () => {
       resolveSongSlideBody(true, '<p>Amin slăvit</p><p>versul final</p>'),
     ).toEqual({ mainText: '<p>Amin slăvit</p><p>versul final</p>', amen: undefined })
   })
+
+  it('uses a custom amin label instead of the default "Amin!"', () => {
+    expect(
+      resolveSongSlideBody(true, '<p>Slăvit să fie El</p>', 'Slăvit!'),
+    ).toEqual({ mainText: '<p>Slăvit să fie El</p>', amen: 'Slăvit!' })
+  })
+
+  it('a custom amin label overrides an extracted trailing amin line', () => {
+    expect(
+      resolveSongSlideBody(true, '<p>Slăvit să fie El</p><p>Amin!</p>', 'Amin.'),
+    ).toEqual({ mainText: '<p>Slăvit să fie El</p>', amen: 'Amin.' })
+  })
+
+  it('ignores a blank custom amin label (falls back to default)', () => {
+    expect(
+      resolveSongSlideBody(true, '<p>Slăvit să fie El</p>', '   '),
+    ).toEqual({ mainText: '<p>Slăvit să fie El</p>', amen: 'Amin!' })
+  })
 })

--- a/app/apps/client/src/features/presentation/utils/__tests__/songElements.test.ts
+++ b/app/apps/client/src/features/presentation/utils/__tests__/songElements.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from 'vitest'
 
 import {
+  extractTrailingAmin,
   resolveAmen,
   resolveSongKey,
+  resolveSongSlideBody,
   resolveSongSlideContentType,
 } from '../songElements'
 
@@ -80,5 +82,72 @@ describe('resolveSongSlideContentType', () => {
     expect(resolveSongSlideContentType(true, true, false, true)).toBe(
       'song_last_slide',
     )
+  })
+})
+
+describe('extractTrailingAmin', () => {
+  it('extracts a standalone trailing "Amin!" paragraph', () => {
+    expect(
+      extractTrailingAmin('<p>Slăvit să fie El</p><p>Amin!</p>'),
+    ).toEqual({ mainText: '<p>Slăvit să fie El</p>', amen: 'Amin!' })
+  })
+
+  it('extracts a trailing <br>-separated amin inside the last paragraph', () => {
+    expect(extractTrailingAmin('<p>Slăvit<br>Amin!</p>')).toEqual({
+      mainText: '<p>Slăvit</p>',
+      amen: 'Amin!',
+    })
+  })
+
+  it('extracts a multi-word amin line and keeps its text', () => {
+    expect(
+      extractTrailingAmin('<p>versul</p><p>Amin, Amin!</p>'),
+    ).toEqual({ mainText: '<p>versul</p>', amen: 'Amin, Amin!' })
+  })
+
+  it('ignores trailing empty paragraphs before the amin', () => {
+    expect(
+      extractTrailingAmin('<p>versul</p><p>Amin!</p><p><br></p>'),
+    ).toEqual({ mainText: '<p>versul</p>', amen: 'Amin!' })
+  })
+
+  it('handles a slide whose only line is an amin', () => {
+    expect(extractTrailingAmin('<p>Amin!</p>')).toEqual({
+      mainText: '',
+      amen: 'Amin!',
+    })
+  })
+
+  it('returns null when the last line is not a standalone amin', () => {
+    expect(extractTrailingAmin('<p>line1</p><p>line2</p>')).toBeNull()
+    expect(extractTrailingAmin('<p>versul</p><p>Slăvit, Amin</p>')).toBeNull()
+  })
+})
+
+describe('resolveSongSlideBody', () => {
+  it('leaves non-last slides untouched', () => {
+    expect(resolveSongSlideBody(false, '<p>versul</p>')).toEqual({
+      mainText: '<p>versul</p>',
+      amen: undefined,
+    })
+  })
+
+  it('pulls a trailing amin line into the amin element', () => {
+    expect(
+      resolveSongSlideBody(true, '<p>Slăvit să fie El</p><p>Amin!</p>'),
+    ).toEqual({ mainText: '<p>Slăvit să fie El</p>', amen: 'Amin!' })
+  })
+
+  it('adds a standard "Amin!" when the last slide has no amin', () => {
+    expect(resolveSongSlideBody(true, '<p>Slăvit să fie El</p>')).toEqual({
+      mainText: '<p>Slăvit să fie El</p>',
+      amen: 'Amin!',
+    })
+  })
+
+  it('keeps an inline (non-trailing) amin in the lyrics without an element', () => {
+    expect(
+      resolveSongSlideBody(true, '<p>Amin slăvit</p><p>versul final</p>'),
+    ).toEqual({ mainText: '<p>Amin slăvit</p><p>versul final</p>', amen: undefined })
   })
 })

--- a/app/apps/client/src/features/presentation/utils/__tests__/songElements.test.ts
+++ b/app/apps/client/src/features/presentation/utils/__tests__/songElements.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest'
+
+import { resolveAmen, resolveSongKey } from '../songElements'
+
+describe('resolveSongKey', () => {
+  it('returns the key only on the first slide', () => {
+    expect(resolveSongKey(true, 'G', undefined)).toBe('G')
+    expect(resolveSongKey(false, 'G', undefined)).toBeUndefined()
+  })
+
+  it('respects displayKeyLine=false', () => {
+    expect(resolveSongKey(true, 'G', { displayKeyLine: false })).toBeUndefined()
+    expect(resolveSongKey(true, 'G', { displayKeyLine: true })).toBe('G')
+  })
+
+  it('returns undefined when there is no key', () => {
+    expect(resolveSongKey(true, null, undefined)).toBeUndefined()
+    expect(resolveSongKey(true, '', undefined)).toBeUndefined()
+    expect(resolveSongKey(true, '   ', undefined)).toBeUndefined()
+  })
+
+  it('trims the key value', () => {
+    expect(resolveSongKey(true, '  Am  ', undefined)).toBe('Am')
+  })
+})
+
+describe('resolveAmen', () => {
+  it('returns "Amin!" only on the last slide', () => {
+    expect(resolveAmen(true, 'Slăvit să fie El!')).toBe('Amin!')
+    expect(resolveAmen(false, 'Slăvit să fie El!')).toBeUndefined()
+  })
+
+  it('is suppressed when the slide already contains "amin" (any case)', () => {
+    expect(resolveAmen(true, 'Amin, Amin!')).toBeUndefined()
+    expect(resolveAmen(true, '<p>amin</p>')).toBeUndefined()
+    expect(resolveAmen(true, 'AMIN')).toBeUndefined()
+  })
+})

--- a/app/apps/client/src/features/presentation/utils/__tests__/songElements.test.ts
+++ b/app/apps/client/src/features/presentation/utils/__tests__/songElements.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest'
 
-import { resolveAmen, resolveSongKey } from '../songElements'
+import {
+  resolveAmen,
+  resolveSongKey,
+  resolveSongSlideContentType,
+} from '../songElements'
 
 describe('resolveSongKey', () => {
   it('returns the key only on the first slide', () => {
@@ -34,5 +38,23 @@ describe('resolveAmen', () => {
     expect(resolveAmen(true, 'Amin, Amin!')).toBeUndefined()
     expect(resolveAmen(true, '<p>amin</p>')).toBeUndefined()
     expect(resolveAmen(true, 'AMIN')).toBeUndefined()
+  })
+})
+
+describe('resolveSongSlideContentType', () => {
+  it('uses the first-slide layout for the first slide', () => {
+    expect(resolveSongSlideContentType(true, false)).toBe('song_first_slide')
+  })
+
+  it('uses the last-slide layout for the last slide', () => {
+    expect(resolveSongSlideContentType(false, true)).toBe('song_last_slide')
+  })
+
+  it('uses the plain song layout for middle slides', () => {
+    expect(resolveSongSlideContentType(false, false)).toBe('song')
+  })
+
+  it('falls back to song for a single-slide song (both first and last)', () => {
+    expect(resolveSongSlideContentType(true, true)).toBe('song')
   })
 })

--- a/app/apps/client/src/features/presentation/utils/__tests__/songElements.test.ts
+++ b/app/apps/client/src/features/presentation/utils/__tests__/songElements.test.ts
@@ -42,19 +42,43 @@ describe('resolveAmen', () => {
 })
 
 describe('resolveSongSlideContentType', () => {
-  it('uses the first-slide layout for the first slide', () => {
-    expect(resolveSongSlideContentType(true, false)).toBe('song_first_slide')
+  it('uses the first-slide layout for a first slide that has a gama', () => {
+    expect(resolveSongSlideContentType(true, false, true, false)).toBe(
+      'song_first_slide',
+    )
   })
 
-  it('uses the last-slide layout for the last slide', () => {
-    expect(resolveSongSlideContentType(false, true)).toBe('song_last_slide')
+  it('falls back to song for a first slide WITHOUT a gama', () => {
+    expect(resolveSongSlideContentType(true, false, false, false)).toBe('song')
+  })
+
+  it('uses the last-slide layout for a last slide that has an amin', () => {
+    expect(resolveSongSlideContentType(false, true, false, true)).toBe(
+      'song_last_slide',
+    )
+  })
+
+  it('falls back to song for a last slide WITHOUT an amin', () => {
+    expect(resolveSongSlideContentType(false, true, false, false)).toBe('song')
   })
 
   it('uses the plain song layout for middle slides', () => {
-    expect(resolveSongSlideContentType(false, false)).toBe('song')
+    expect(resolveSongSlideContentType(false, false, false, false)).toBe('song')
   })
 
-  it('falls back to song for a single-slide song (both first and last)', () => {
-    expect(resolveSongSlideContentType(true, true)).toBe('song')
+  it('falls back to song for a single-slide song showing both gama and amin', () => {
+    expect(resolveSongSlideContentType(true, true, true, true)).toBe('song')
+  })
+
+  it('uses the first-slide layout for a single slide with only a gama', () => {
+    expect(resolveSongSlideContentType(true, true, true, false)).toBe(
+      'song_first_slide',
+    )
+  })
+
+  it('uses the last-slide layout for a single slide with only an amin', () => {
+    expect(resolveSongSlideContentType(true, true, false, true)).toBe(
+      'song_last_slide',
+    )
   })
 })

--- a/app/apps/client/src/features/presentation/utils/defaultConfigs.ts
+++ b/app/apps/client/src/features/presentation/utils/defaultConfigs.ts
@@ -14,6 +14,7 @@ import type {
   ScreenType,
   SizeWithUnits,
   SongContentConfig,
+  SongFirstSlideContentConfig,
   TextStyle,
   VerseteTineriContentConfig,
 } from '../types'
@@ -167,6 +168,41 @@ export function getDefaultSongConfig(): SongContentConfig {
     },
     clockEnabled: false,
     displayKeyLine: true,
+  }
+}
+
+// ============================================================================
+// SONG FIRST SLIDE CONTENT CONFIG ("Gama - Strofă")
+// ============================================================================
+
+// First-slide-only layout: the song key (gama) + the first slide's lyrics
+// (strofa), positioned/styled separately from the rest of the song. Defaults
+// mirror the `song` config so there is no jump until the operator repositions
+// them. Chord/keyline display stay on the `song` config (single source).
+export function getDefaultSongFirstSlideConfig(): SongFirstSlideContentConfig {
+  return {
+    background: getDefaultBackground(),
+    mainText: {
+      constraints: constraints(10, 5),
+      size: sizeWithUnits(90, 80),
+      style: getDefaultTextStyle({ maxFontSize: 120 }),
+      padding: 20,
+      animationIn: getDefaultAnimationIn(),
+      animationOut: getDefaultAnimationOut(),
+    },
+    songKey: {
+      constraints: constraints(2, 5),
+      size: sizeWithUnits(40, 6),
+      style: getDefaultTextStyle({
+        maxFontSize: 32,
+        autoScale: false,
+        alignment: 'left',
+        bold: true,
+      }),
+      animationIn: getDefaultAnimationIn(),
+      animationOut: getDefaultAnimationOut(),
+    },
+    clockEnabled: false,
   }
 }
 
@@ -336,6 +372,7 @@ export function getDefaultContentConfigs(
 
   // Base configs
   const songConfig = getDefaultSongConfig()
+  const songFirstSlideConfig = getDefaultSongFirstSlideConfig()
   const bibleConfig = getDefaultBibleConfig()
   const announcementConfig = getDefaultAnnouncementConfig()
   const verseteTineriConfig = getDefaultVerseteTineriConfig()
@@ -344,6 +381,7 @@ export function getDefaultContentConfigs(
   // Adjust for stage screens (content gets 78% height)
   if (isStage) {
     songConfig.mainText.size.height = 65
+    songFirstSlideConfig.mainText.size.height = 65
     bibleConfig.contentText.size.height = 63
     announcementConfig.mainText.size.height = 65
     verseteTineriConfig.contentText.size.height = 57
@@ -366,6 +404,14 @@ export function getDefaultContentConfigs(
     songConfig.mainText.animationOut.type = 'slide-down'
     songConfig.mainText.animationOut.duration = 150
 
+    songFirstSlideConfig.background = transparentBg
+    addShadow(songFirstSlideConfig.mainText)
+    songFirstSlideConfig.mainText.animationIn.type = 'slide-up'
+    songFirstSlideConfig.mainText.animationIn.duration = 200
+    songFirstSlideConfig.mainText.animationOut.type = 'slide-down'
+    songFirstSlideConfig.mainText.animationOut.duration = 150
+    if (songFirstSlideConfig.songKey) addShadow(songFirstSlideConfig.songKey)
+
     bibleConfig.background = transparentBg
     addShadow(bibleConfig.referenceText)
     addShadow(bibleConfig.contentText)
@@ -384,6 +430,7 @@ export function getDefaultContentConfigs(
 
   return {
     song: songConfig,
+    song_first_slide: songFirstSlideConfig,
     bible: bibleConfig,
     bible_passage: bibleConfig, // Same as bible
     announcement: announcementConfig,

--- a/app/apps/client/src/features/presentation/utils/defaultConfigs.ts
+++ b/app/apps/client/src/features/presentation/utils/defaultConfigs.ts
@@ -173,7 +173,7 @@ export function getDefaultSongConfig(): SongContentConfig {
 }
 
 // ============================================================================
-// SONG FIRST SLIDE CONTENT CONFIG ("Gama - Strofă")
+// SONG FIRST SLIDE CONTENT CONFIG ("Cântec - Primul Slide")
 // ============================================================================
 
 // First-slide-only layout: the song key (gama) + the first slide's lyrics
@@ -208,7 +208,7 @@ export function getDefaultSongFirstSlideConfig(): SongFirstSlideContentConfig {
 }
 
 // ============================================================================
-// SONG LAST SLIDE CONTENT CONFIG ("Strofă - Amin")
+// SONG LAST SLIDE CONTENT CONFIG ("Cântec - Ultimul Slide")
 // ============================================================================
 
 // Last-slide-only layout: the last slide's lyrics (strofa) + the "Amin",

--- a/app/apps/client/src/features/presentation/utils/defaultConfigs.ts
+++ b/app/apps/client/src/features/presentation/utils/defaultConfigs.ts
@@ -15,6 +15,7 @@ import type {
   SizeWithUnits,
   SongContentConfig,
   SongFirstSlideContentConfig,
+  SongLastSlideContentConfig,
   TextStyle,
   VerseteTineriContentConfig,
 } from '../types'
@@ -207,6 +208,40 @@ export function getDefaultSongFirstSlideConfig(): SongFirstSlideContentConfig {
 }
 
 // ============================================================================
+// SONG LAST SLIDE CONTENT CONFIG ("Strofă - Amin")
+// ============================================================================
+
+// Last-slide-only layout: the last slide's lyrics (strofa) + the "Amin",
+// positioned/styled separately from the rest of the song. Defaults mirror the
+// `song` config so there is no jump until the operator repositions them.
+export function getDefaultSongLastSlideConfig(): SongLastSlideContentConfig {
+  return {
+    background: getDefaultBackground(),
+    mainText: {
+      constraints: constraints(10, 5),
+      size: sizeWithUnits(90, 80),
+      style: getDefaultTextStyle({ maxFontSize: 120 }),
+      padding: 20,
+      animationIn: getDefaultAnimationIn(),
+      animationOut: getDefaultAnimationOut(),
+    },
+    amen: {
+      constraints: constraints(85, 5),
+      size: sizeWithUnits(90, 10),
+      style: getDefaultTextStyle({
+        maxFontSize: 48,
+        autoScale: false,
+        alignment: 'center',
+        italic: true,
+      }),
+      animationIn: getDefaultAnimationIn(),
+      animationOut: getDefaultAnimationOut(),
+    },
+    clockEnabled: false,
+  }
+}
+
+// ============================================================================
 // BIBLE CONTENT CONFIG
 // ============================================================================
 
@@ -373,6 +408,7 @@ export function getDefaultContentConfigs(
   // Base configs
   const songConfig = getDefaultSongConfig()
   const songFirstSlideConfig = getDefaultSongFirstSlideConfig()
+  const songLastSlideConfig = getDefaultSongLastSlideConfig()
   const bibleConfig = getDefaultBibleConfig()
   const announcementConfig = getDefaultAnnouncementConfig()
   const verseteTineriConfig = getDefaultVerseteTineriConfig()
@@ -382,6 +418,7 @@ export function getDefaultContentConfigs(
   if (isStage) {
     songConfig.mainText.size.height = 65
     songFirstSlideConfig.mainText.size.height = 65
+    songLastSlideConfig.mainText.size.height = 65
     bibleConfig.contentText.size.height = 63
     announcementConfig.mainText.size.height = 65
     verseteTineriConfig.contentText.size.height = 57
@@ -412,6 +449,14 @@ export function getDefaultContentConfigs(
     songFirstSlideConfig.mainText.animationOut.duration = 150
     if (songFirstSlideConfig.songKey) addShadow(songFirstSlideConfig.songKey)
 
+    songLastSlideConfig.background = transparentBg
+    addShadow(songLastSlideConfig.mainText)
+    songLastSlideConfig.mainText.animationIn.type = 'slide-up'
+    songLastSlideConfig.mainText.animationIn.duration = 200
+    songLastSlideConfig.mainText.animationOut.type = 'slide-down'
+    songLastSlideConfig.mainText.animationOut.duration = 150
+    if (songLastSlideConfig.amen) addShadow(songLastSlideConfig.amen)
+
     bibleConfig.background = transparentBg
     addShadow(bibleConfig.referenceText)
     addShadow(bibleConfig.contentText)
@@ -431,6 +476,7 @@ export function getDefaultContentConfigs(
   return {
     song: songConfig,
     song_first_slide: songFirstSlideConfig,
+    song_last_slide: songLastSlideConfig,
     bible: bibleConfig,
     bible_passage: bibleConfig, // Same as bible
     announcement: announcementConfig,

--- a/app/apps/client/src/features/presentation/utils/openDisplayWindow.ts
+++ b/app/apps/client/src/features/presentation/utils/openDisplayWindow.ts
@@ -194,9 +194,7 @@ async function openInNativeWindow(
       console.log('[openInNativeWindow] existingWindow:', existingWindow)
       if (existingWindow) {
         // biome-ignore lint/suspicious/noConsole: Critical debugging for Tauri window creation
-        console.log(
-          `[openInNativeWindow] Window exists, focus=${focus}`,
-        )
+        console.log(`[openInNativeWindow] Window exists, focus=${focus}`)
         if (focus) {
           await existingWindow.setFocus()
         }
@@ -319,18 +317,34 @@ async function openInNativeWindow(
         webview.listen('tauri://move', trackState)
         webview.listen('tauri://resize', trackState)
 
-        // Restore focus to the control room window if it was taken by the
-        // OS when the new display window appeared. Done after fullscreen /
-        // maximize because those can trigger another focus shift.
+        // Restore focus to the control room window if it was taken by the OS
+        // when the new display window appeared. Operators present from the main
+        // window (keyboard / presenter remote), so it must keep focus — the
+        // screen that "appears and disappears" should never steal it.
+        //
+        // Done after fullscreen / maximize because those trigger another focus
+        // shift, and re-asserted on a short delay: macOS/Windows can hand focus
+        // back to the freshly-created window a beat AFTER our first attempt
+        // (especially once the fullscreen transition settles), so a single
+        // setFocus loses that race.
         if (mainWindowToRefocus) {
-          try {
-            await mainWindowToRefocus.setFocus()
-          } catch (error) {
-            // biome-ignore lint/suspicious/noConsole: Tauri focus restoration
-            console.warn(
-              '[openInNativeWindow] Failed to restore focus to main window:',
-              error,
-            )
+          const reclaimFocus = async () => {
+            try {
+              await mainWindowToRefocus.setFocus()
+            } catch (error) {
+              // biome-ignore lint/suspicious/noConsole: Tauri focus restoration
+              console.warn(
+                '[openInNativeWindow] Failed to restore focus to main window:',
+                error,
+              )
+            }
+          }
+          await reclaimFocus()
+          // The OS can hand focus back to the new window again once it finishes
+          // appearing and the fullscreen transition animates (≈1s on macOS), so
+          // re-assert a few more times across that window.
+          for (const delay of [200, 500, 900]) {
+            setTimeout(reclaimFocus, delay)
           }
         }
       })

--- a/app/apps/client/src/features/presentation/utils/openDisplayWindow.ts
+++ b/app/apps/client/src/features/presentation/utils/openDisplayWindow.ts
@@ -317,34 +317,47 @@ async function openInNativeWindow(
         webview.listen('tauri://move', trackState)
         webview.listen('tauri://resize', trackState)
 
-        // Restore focus to the control room window if it was taken by the OS
-        // when the new display window appeared. Operators present from the main
-        // window (keyboard / presenter remote), so it must keep focus — the
-        // screen that "appears and disappears" should never steal it.
+        // Keep keyboard focus on the control window so the operator can keep
+        // navigating verses (keyboard / presenter remote) while the screen
+        // shows — the projector window must not steal focus.
         //
-        // Done after fullscreen / maximize because those trigger another focus
-        // shift, and re-asserted on a short delay: macOS/Windows can hand focus
-        // back to the freshly-created window a beat AFTER our first attempt
-        // (especially once the fullscreen transition settles), so a single
-        // setFocus loses that race.
+        // BUT only when the screen has its own monitor. setFocus() also RAISES
+        // the control window; on a single monitor that would cover the
+        // projection and the song would seem to "not display". With one
+        // monitor we leave the screen in front (visible) instead. With a
+        // second monitor the projection is on the other screen, so refocusing
+        // the control window is harmless and keyboard input keeps working.
         if (mainWindowToRefocus) {
-          const reclaimFocus = async () => {
+          const isMultiMonitor = await (async () => {
             try {
-              await mainWindowToRefocus.setFocus()
-            } catch (error) {
-              // biome-ignore lint/suspicious/noConsole: Tauri focus restoration
-              console.warn(
-                '[openInNativeWindow] Failed to restore focus to main window:',
-                error,
+              const { availableMonitors } = await import(
+                '@tauri-apps/api/window'
               )
+              return (await availableMonitors()).length > 1
+            } catch {
+              return false
             }
-          }
-          await reclaimFocus()
-          // The OS can hand focus back to the new window again once it finishes
-          // appearing and the fullscreen transition animates (≈1s on macOS), so
-          // re-assert a few more times across that window.
-          for (const delay of [200, 500, 900]) {
-            setTimeout(reclaimFocus, delay)
+          })()
+
+          if (isMultiMonitor) {
+            const reclaimFocus = async () => {
+              try {
+                await mainWindowToRefocus.setFocus()
+              } catch (error) {
+                // biome-ignore lint/suspicious/noConsole: Tauri focus restoration
+                console.warn(
+                  '[openInNativeWindow] Failed to restore focus to main window:',
+                  error,
+                )
+              }
+            }
+            await reclaimFocus()
+            // The OS can hand focus back to the new window again once it
+            // finishes appearing / the fullscreen transition animates
+            // (≈1s on macOS), so re-assert a few more times across that window.
+            for (const delay of [200, 500, 900]) {
+              setTimeout(reclaimFocus, delay)
+            }
           }
         }
       })

--- a/app/apps/client/src/features/presentation/utils/songElements.ts
+++ b/app/apps/client/src/features/presentation/utils/songElements.ts
@@ -2,11 +2,11 @@ import type { ContentType, SongContentConfig } from '../types'
 
 /**
  * Picks the screen content type for a given song slide:
- *  - the FIRST slide uses the dedicated "Gama - Strofă" (`song_first_slide`)
+ *  - the FIRST slide uses the dedicated "Cântec - Primul Slide" (`song_first_slide`)
  *    layout (gama + strofa) — but ONLY when the slide actually shows a gama
  *    (`hasKey`); without a key it falls back to the plain `song` layout so the
  *    strofa isn't shifted to make room for an absent element,
- *  - the LAST slide uses "Strofă - Amin" (`song_last_slide`) layout
+ *  - the LAST slide uses "Cântec - Ultimul Slide" (`song_last_slide`) layout
  *    (strofa + amin) — but ONLY when the slide actually shows an amin
  *    (`hasAmen`); otherwise it falls back to `song`,
  *  - every middle slide uses `song`.

--- a/app/apps/client/src/features/presentation/utils/songElements.ts
+++ b/app/apps/client/src/features/presentation/utils/songElements.ts
@@ -127,13 +127,23 @@ export function extractTrailingAmin(
  * the amin element ([[extractTrailingAmin]]); otherwise the lyrics are kept
  * as-is and a standard "Amin!" element is added only when the slide has no
  * "amin" at all (see [[resolveAmen]]).
+ *
+ * `customAmin` is the operator's configured amin label (`song_last_slide.amen.text`).
+ * When set it replaces the shown amin text — both the extracted line and the
+ * default "Amin!" — so the screen shows exactly what was configured.
  */
 export function resolveSongSlideBody(
   isLastSlide: boolean,
   slideContent: string,
+  customAmin?: string,
 ): { mainText: string; amen: string | undefined } {
   if (!isLastSlide) return { mainText: slideContent, amen: undefined }
+  const custom = customAmin?.trim() || undefined
   const extracted = extractTrailingAmin(slideContent)
-  if (extracted) return extracted
-  return { mainText: slideContent, amen: resolveAmen(isLastSlide, slideContent) }
+  if (extracted) {
+    return { mainText: extracted.mainText, amen: custom ?? extracted.amen }
+  }
+  // Suppress when an amin appears inline (mid-lyrics) and isn't a trailing line.
+  if (/amin/i.test(slideContent)) return { mainText: slideContent, amen: undefined }
+  return { mainText: slideContent, amen: custom ?? 'Amin!' }
 }

--- a/app/apps/client/src/features/presentation/utils/songElements.ts
+++ b/app/apps/client/src/features/presentation/utils/songElements.ts
@@ -1,4 +1,24 @@
-import type { SongContentConfig } from '../types'
+import type { ContentType, SongContentConfig } from '../types'
+
+/**
+ * Picks the screen content type for a given song slide:
+ *  - the FIRST slide uses the dedicated "Gama - Strofă" (`song_first_slide`)
+ *    layout (gama + strofa),
+ *  - the LAST slide uses "Strofă - Amin" (`song_last_slide`) layout
+ *    (strofa + amin),
+ *  - every middle slide uses `song`.
+ * A single-slide song is both first and last; it falls back to `song`, whose
+ * config keeps both the gama and the amin elements so neither is lost.
+ */
+export function resolveSongSlideContentType(
+  isFirstSlide: boolean,
+  isLastSlide: boolean,
+): ContentType {
+  if (isFirstSlide && isLastSlide) return 'song'
+  if (isFirstSlide) return 'song_first_slide'
+  if (isLastSlide) return 'song_last_slide'
+  return 'song'
+}
 
 /**
  * Value for the song-key ("gama") element. It only appears on the FIRST slide,

--- a/app/apps/client/src/features/presentation/utils/songElements.ts
+++ b/app/apps/client/src/features/presentation/utils/songElements.ts
@@ -3,20 +3,27 @@ import type { ContentType, SongContentConfig } from '../types'
 /**
  * Picks the screen content type for a given song slide:
  *  - the FIRST slide uses the dedicated "Gama - Strofă" (`song_first_slide`)
- *    layout (gama + strofa),
+ *    layout (gama + strofa) — but ONLY when the slide actually shows a gama
+ *    (`hasKey`); without a key it falls back to the plain `song` layout so the
+ *    strofa isn't shifted to make room for an absent element,
  *  - the LAST slide uses "Strofă - Amin" (`song_last_slide`) layout
- *    (strofa + amin),
+ *    (strofa + amin) — but ONLY when the slide actually shows an amin
+ *    (`hasAmen`); otherwise it falls back to `song`,
  *  - every middle slide uses `song`.
- * A single-slide song is both first and last; it falls back to `song`, whose
- * config keeps both the gama and the amin elements so neither is lost.
+ * A single-slide song that shows both a gama and an amin falls back to `song`,
+ * whose config keeps both elements so neither is lost.
  */
 export function resolveSongSlideContentType(
   isFirstSlide: boolean,
   isLastSlide: boolean,
+  hasKey: boolean,
+  hasAmen: boolean,
 ): ContentType {
-  if (isFirstSlide && isLastSlide) return 'song'
-  if (isFirstSlide) return 'song_first_slide'
-  if (isLastSlide) return 'song_last_slide'
+  const useFirst = isFirstSlide && hasKey
+  const useLast = isLastSlide && hasAmen
+  if (useFirst && useLast) return 'song'
+  if (useFirst) return 'song_first_slide'
+  if (useLast) return 'song_last_slide'
   return 'song'
 }
 

--- a/app/apps/client/src/features/presentation/utils/songElements.ts
+++ b/app/apps/client/src/features/presentation/utils/songElements.ts
@@ -1,0 +1,33 @@
+import type { SongContentConfig } from '../types'
+
+/**
+ * Value for the song-key ("gama") element. It only appears on the FIRST slide,
+ * only when the key-line display is enabled (`displayKeyLine`, default true),
+ * and only when the song actually has a key. The element's position/style and
+ * its on/off visibility live in the screen config (`song.songKey`); this just
+ * decides the text to show.
+ */
+export function resolveSongKey(
+  isFirstSlide: boolean,
+  keyLine: string | null | undefined,
+  songConfig: Pick<SongContentConfig, 'displayKeyLine'> | undefined,
+): string | undefined {
+  if (!isFirstSlide) return undefined
+  if ((songConfig?.displayKeyLine ?? true) === false) return undefined
+  const key = keyLine?.trim()
+  return key ? key : undefined
+}
+
+/**
+ * Value for the "Amin" element. It only appears on the LAST slide, and is
+ * suppressed when the slide text already contains "amin" so the word isn't
+ * shown twice (mirrors the previous inline behaviour).
+ */
+export function resolveAmen(
+  isLastSlide: boolean,
+  slideContent: string,
+): string | undefined {
+  if (!isLastSlide) return undefined
+  if (/amin/i.test(slideContent)) return undefined
+  return 'Amin!'
+}

--- a/app/apps/client/src/features/presentation/utils/songElements.ts
+++ b/app/apps/client/src/features/presentation/utils/songElements.ts
@@ -58,3 +58,82 @@ export function resolveAmen(
   if (/amin/i.test(slideContent)) return undefined
   return 'Amin!'
 }
+
+/** Strip HTML tags + decode the few entities the lyrics use, to plain text. */
+function htmlToPlainText(html: string): string {
+  return html
+    .replace(/<br\s*\/?>/gi, ' ')
+    .replace(/<[^>]*>/g, '')
+    .replace(/&nbsp;/gi, ' ')
+    .replace(/&amp;/gi, '&')
+    .replace(/\s+/g, ' ')
+    .trim()
+}
+
+/** True when a text line consists solely of one or more "amin" words. */
+function isAminLine(text: string): boolean {
+  return /^(?:amin[\s,.!…]*)+$/i.test(text.trim())
+}
+
+/**
+ * If a song slide's lyrics end with a standalone "amin" line, pull it out so it
+ * can be shown through the dedicated amin element instead of being rendered as
+ * plain lyrics. Lyrics are stored one line per `<p>` (see songs slidesMarkdown),
+ * but a trailing `<br>`-separated amin inside the last paragraph is handled too.
+ * Returns the lyrics WITHOUT the amin line plus the extracted amin text, or
+ * `null` when the last line isn't an amin.
+ */
+export function extractTrailingAmin(
+  htmlContent: string,
+): { mainText: string; amen: string } | null {
+  // Drop trailing empty paragraphs / line breaks / whitespace first.
+  const trimmed = htmlContent.replace(
+    /(?:<p>(?:\s|&nbsp;|<br\s*\/?>)*<\/p>|<br\s*\/?>|\s)+$/gi,
+    '',
+  )
+
+  // The last paragraph (lines are one-per-<p>).
+  const lastP = trimmed.match(/<p\b[^>]*>((?:(?!<\/p>)[\s\S])*)<\/p>\s*$/i)
+  if (!lastP || lastP.index === undefined) return null
+  const lastInner = lastP[1]
+  const before = trimmed.slice(0, lastP.index)
+
+  // Case A: the whole last paragraph is just an amin.
+  const lastText = htmlToPlainText(lastInner)
+  if (isAminLine(lastText)) {
+    return {
+      mainText: before.replace(/(?:<br\s*\/?>|\s)+$/gi, ''),
+      amen: lastText,
+    }
+  }
+
+  // Case B: the last paragraph ends with a <br>-separated amin line.
+  const brSplit = lastInner.match(/^([\s\S]*)<br\s*\/?>\s*((?:(?!<br)[\s\S])*)$/i)
+  if (brSplit) {
+    const head = brSplit[1]
+    const tailText = htmlToPlainText(brSplit[2])
+    if (isAminLine(tailText) && htmlToPlainText(head).length > 0) {
+      const cleanedHead = head.replace(/(?:<br\s*\/?>|\s)+$/gi, '')
+      return { mainText: `${before}<p>${cleanedHead}</p>`, amen: tailText }
+    }
+  }
+
+  return null
+}
+
+/**
+ * Resolves the lyrics (`mainText`) and the amin value for a song slide. On the
+ * last slide, a standalone trailing "amin" line is moved out of the lyrics into
+ * the amin element ([[extractTrailingAmin]]); otherwise the lyrics are kept
+ * as-is and a standard "Amin!" element is added only when the slide has no
+ * "amin" at all (see [[resolveAmen]]).
+ */
+export function resolveSongSlideBody(
+  isLastSlide: boolean,
+  slideContent: string,
+): { mainText: string; amen: string | undefined } {
+  if (!isLastSlide) return { mainText: slideContent, amen: undefined }
+  const extracted = extractTrailingAmin(slideContent)
+  if (extracted) return extracted
+  return { mainText: slideContent, amen: resolveAmen(isLastSlide, slideContent) }
+}

--- a/app/apps/client/src/features/settings/registry.ts
+++ b/app/apps/client/src/features/settings/registry.ts
@@ -8,6 +8,7 @@ import {
   Palette,
   PanelLeft,
   Radio,
+  ScrollText,
   Sliders,
   Tv,
   User,
@@ -169,6 +170,13 @@ export const SETTINGS_GROUPS: SettingsNavGroupDef[] = [
     id: 'advanced',
     labelKey: 'nav.groups.advanced',
     items: [
+      {
+        id: 'logs',
+        labelKey: 'nav.items.logs',
+        icon: ScrollText,
+        to: '/settings/logs',
+        visible: (ctx) => ctx.hasPermission('logs.view'),
+      },
       {
         id: 'developer',
         labelKey: 'nav.items.developer',

--- a/app/apps/client/src/features/songs/components/CategoryManager/CategoryCard.tsx
+++ b/app/apps/client/src/features/songs/components/CategoryManager/CategoryCard.tsx
@@ -1,4 +1,4 @@
-import { Pencil, Trash2 } from 'lucide-react'
+import { Eye, EyeOff, Pencil, Trash2 } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 
 import type { SongCategory } from '../../types'
@@ -7,20 +7,34 @@ interface CategoryCardProps {
   category: SongCategory
   onEdit: () => void
   onDelete: () => void
+  onToggleHidden: () => void
 }
 
 export function CategoryCard({
   category,
   onEdit,
   onDelete,
+  onToggleHidden,
 }: CategoryCardProps) {
   const { t } = useTranslation('settings')
+  const isHidden = category.isHidden === 1
 
   return (
-    <div className="flex items-center gap-3 p-3 bg-gray-50 dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700">
+    <div
+      className={`flex items-center gap-3 p-3 bg-gray-50 dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 ${
+        isHidden ? 'opacity-60' : ''
+      }`}
+    >
       <div className="flex-1 min-w-0">
-        <span className="text-sm font-medium text-gray-900 dark:text-white truncate block">
-          {category.name}
+        <span className="flex items-center gap-2">
+          <span className="text-sm font-medium text-gray-900 dark:text-white truncate">
+            {category.name}
+          </span>
+          {isHidden && (
+            <span className="shrink-0 rounded-full bg-gray-200 px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide text-gray-600 dark:bg-gray-700 dark:text-gray-300">
+              {t('sections.categories.hiddenBadge')}
+            </span>
+          )}
         </span>
         <span className="text-xs text-gray-500 dark:text-gray-400">
           {t('sections.categories.songCount', { count: category.songCount })}
@@ -30,6 +44,18 @@ export function CategoryCard({
       </div>
 
       <div className="flex items-center gap-1">
+        <button
+          type="button"
+          onClick={onToggleHidden}
+          className="p-2 text-gray-500 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors"
+          title={
+            isHidden
+              ? t('sections.categories.actions.show')
+              : t('sections.categories.actions.hide')
+          }
+        >
+          {isHidden ? <EyeOff size={16} /> : <Eye size={16} />}
+        </button>
         <button
           type="button"
           onClick={onEdit}

--- a/app/apps/client/src/features/songs/components/CategoryManager/CategoryManager.tsx
+++ b/app/apps/client/src/features/songs/components/CategoryManager/CategoryManager.tsx
@@ -55,6 +55,24 @@ export function CategoryManager() {
     }
   }
 
+  const handleToggleHidden = async (category: SongCategory) => {
+    const result = await upsertCategory.mutateAsync({
+      id: category.id,
+      name: category.name,
+      isHidden: category.isHidden === 1 ? 0 : 1,
+    })
+    if (result.success) {
+      showToast(
+        category.isHidden === 1
+          ? t('sections.categories.toast.shown')
+          : t('sections.categories.toast.hidden'),
+        'success',
+      )
+    } else {
+      showToast(t('sections.categories.toast.error'), 'error')
+    }
+  }
+
   const handleDelete = async () => {
     if (modal.type !== 'delete') return
 
@@ -115,6 +133,7 @@ export function CategoryManager() {
               category={category}
               onEdit={() => setModal({ type: 'edit', category })}
               onDelete={() => setModal({ type: 'delete', category })}
+              onToggleHidden={() => handleToggleHidden(category)}
             />
           ))}
         </div>

--- a/app/apps/client/src/features/songs/components/SongList.tsx
+++ b/app/apps/client/src/features/songs/components/SongList.tsx
@@ -91,20 +91,17 @@ export function SongList({
     return []
   })
 
-  const handleTagChange = useCallback(
-    (newTagIds: Array<number | string>) => {
-      const numericIds = newTagIds.filter(
-        (id): id is number => typeof id === 'number',
-      )
-      setTagIds(numericIds)
-      try {
-        localStorage.setItem(TAG_FILTER_STORAGE_KEY, JSON.stringify(numericIds))
-      } catch {
-        // Ignore storage errors
-      }
-    },
-    [],
-  )
+  const handleTagChange = useCallback((newTagIds: Array<number | string>) => {
+    const numericIds = newTagIds.filter(
+      (id): id is number => typeof id === 'number',
+    )
+    setTagIds(numericIds)
+    try {
+      localStorage.setItem(TAG_FILTER_STORAGE_KEY, JSON.stringify(numericIds))
+    } catch {
+      // Ignore storage errors
+    }
+  }, [])
 
   // Initialize category filter from local storage or props
   const [categoryIds, setCategoryIds] = useState<number[]>(() => {
@@ -340,6 +337,13 @@ export function SongList({
   )
 
   const { data: categories } = useCategories()
+  // Hidden categories are dropped from the filter UI (their songs are already
+  // excluded from the list server-side). `categories` (all) is still used for
+  // resolving a song's category name.
+  const visibleCategories = useMemo(
+    () => categories?.filter((c) => c.isHidden !== 1),
+    [categories],
+  )
   const { data: songTags } = useTags()
   const { data: bookmarks = [] } = useSongBookmarks()
 
@@ -715,7 +719,7 @@ export function SongList({
     const allCategoriesLabel = t('search.allCategories')
     const labels = [
       allCategoriesLabel,
-      ...(categories?.map((c) => c.name) ?? []),
+      ...(visibleCategories?.map((c) => c.name) ?? []),
     ]
     const longestLabel = labels.reduce(
       (longest, label) => (label.length > longest.length ? label : longest),
@@ -723,7 +727,7 @@ export function SongList({
     )
     // Approximate width: ~8px per character + 48px for padding/icons
     return Math.max(140, longestLabel.length * 8 + 48)
-  }, [categories, t])
+  }, [visibleCategories, t])
 
   const [isCategoryOpen, setIsCategoryOpen] = useState(false)
 
@@ -731,39 +735,39 @@ export function SongList({
     <div className="flex flex-col h-full min-h-0 bg-white dark:bg-gray-800 p-3 rounded-lg border border-gray-200 dark:border-gray-700">
       <div className="flex-shrink-0 pb-3 space-y-2 border-b border-gray-200 dark:border-gray-700">
         <div className="flex gap-2">
-        <div className="relative flex-1">
-          <Search
-            size={16}
-            className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400"
-          />
-          <input
-            ref={searchInputRef}
-            type="text"
-            value={localQuery}
-            onChange={handleSearchChange}
-            onKeyDown={handleKeyDown}
-            autoCorrect="off"
-            autoCapitalize="off"
-            spellCheck={false}
-            onMouseDown={(e) => {
-              if (localQuery) {
-                if (hasSelectedAllRef.current) return
-                e.preventDefault()
-                e.currentTarget.focus()
-                e.currentTarget.select()
+          <div className="relative flex-1">
+            <Search
+              size={16}
+              className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400"
+            />
+            <input
+              ref={searchInputRef}
+              type="text"
+              value={localQuery}
+              onChange={handleSearchChange}
+              onKeyDown={handleKeyDown}
+              autoCorrect="off"
+              autoCapitalize="off"
+              spellCheck={false}
+              onMouseDown={(e) => {
+                if (localQuery) {
+                  if (hasSelectedAllRef.current) return
+                  e.preventDefault()
+                  e.currentTarget.focus()
+                  e.currentTarget.select()
+                  hasSelectedAllRef.current = true
+                }
+                setSelectedIndex(-1)
+              }}
+              onFocus={(e) => {
+                e.target.select()
                 hasSelectedAllRef.current = true
-              }
-              setSelectedIndex(-1)
-            }}
-            onFocus={(e) => {
-              e.target.select()
-              hasSelectedAllRef.current = true
-              setSelectedIndex(-1)
-            }}
-            onBlur={() => {
-              hasSelectedAllRef.current = false
-            }}
-            placeholder={t('search.placeholder')}
+                setSelectedIndex(-1)
+              }}
+              onBlur={() => {
+                hasSelectedAllRef.current = false
+              }}
+              placeholder={t('search.placeholder')}
               className={`
               w-full 
               pl-9 
@@ -778,157 +782,156 @@ export function SongList({
               text-gray-900 
               dark:text-white 
               placeholder-gray-400
-              ${
-                searchSongShortcut ? 'pr-20' : 'pr-9'
-              }
-              `
-          }
-          />
-          {(showPendingIndicator || aiSearchMutation.isPending) && (
-            <div
-              className={`absolute top-1/2 transform -translate-y-1/2 flex items-center gap-1 ${
-                searchSongShortcut ? 'right-14' : 'right-3'
-              }`}
+              ${searchSongShortcut ? 'pr-20' : 'pr-9'}
+              `}
+            />
+            {(showPendingIndicator || aiSearchMutation.isPending) && (
+              <div
+                className={`absolute top-1/2 transform -translate-y-1/2 flex items-center gap-1 ${
+                  searchSongShortcut ? 'right-14' : 'right-3'
+                }`}
+              >
+                {aiSearchMutation.isPending ? (
+                  <>
+                    <Sparkles className="w-4 h-4 text-indigo-500 animate-pulse" />
+                    <span className="text-xs text-indigo-500">
+                      {t('search.aiProcessing')}
+                    </span>
+                  </>
+                ) : (
+                  <div className="w-2 h-2 bg-indigo-500 rounded-full animate-pulse" />
+                )}
+              </div>
+            )}
+            {searchSongShortcut && (
+              <div className="absolute right-3 top-1/2 transform -translate-y-1/2">
+                <KeyboardShortcutBadge shortcut={searchSongShortcut} />
+              </div>
+            )}
+          </div>
+          {aiSearchAvailable && (
+            <button
+              type="button"
+              onClick={handleAISearch}
+              disabled={!localQuery.trim() || aiSearchMutation.isPending}
+              className={`px-2 py-1.5 md:px-3 md:py-2 rounded-lg border transition-colors flex items-center gap-1.5 focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500 ${
+                isAISearchActive
+                  ? 'bg-indigo-600 text-white border-indigo-600'
+                  : 'bg-white dark:bg-gray-800 border-gray-300 dark:border-gray-600 text-gray-500 dark:text-gray-400'
+              } disabled:opacity-50 disabled:cursor-not-allowed`}
+              title={t('search.aiSearchTooltip')}
             >
-              {aiSearchMutation.isPending ? (
-                <>
-                  <Sparkles className="w-4 h-4 text-indigo-500 animate-pulse" />
-                  <span className="text-xs text-indigo-500">
-                    {t('search.aiProcessing')}
-                  </span>
-                </>
-              ) : (
-                <div className="w-2 h-2 bg-indigo-500 rounded-full animate-pulse" />
-              )}
-            </div>
+              <Sparkles className="w-4 h-4" />
+            </button>
           )}
-          {searchSongShortcut && (
-            <div className="absolute right-3 top-1/2 transform -translate-y-1/2">
-              <KeyboardShortcutBadge shortcut={searchSongShortcut} />
-            </div>
-          )}
-        </div>
-        {aiSearchAvailable && (
-          <button
-            type="button"
-            onClick={handleAISearch}
-            disabled={!localQuery.trim() || aiSearchMutation.isPending}
-            className={`px-2 py-1.5 md:px-3 md:py-2 rounded-lg border transition-colors flex items-center gap-1.5 focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500 ${
-              isAISearchActive
-                ? 'bg-indigo-600 text-white border-indigo-600'
-                : 'bg-white dark:bg-gray-800 border-gray-300 dark:border-gray-600 text-gray-500 dark:text-gray-400'
-            } disabled:opacity-50 disabled:cursor-not-allowed`}
-            title={t('search.aiSearchTooltip')}
-          >
-            <Sparkles className="w-4 h-4" />
-          </button>
-        )}
-        <SongFiltersDropdown
-          filters={filtersState}
-          onChange={handleFiltersChange}
-        />
-        {/* Category dropdown: icon on mobile, full dropdown on desktop */}
-        {/* The wrapper itself is md:hidden — leaving an empty div in the
+          <SongFiltersDropdown
+            filters={filtersState}
+            onChange={handleFiltersChange}
+          />
+          {/* Category dropdown: icon on mobile, full dropdown on desktop */}
+          {/* The wrapper itself is md:hidden — leaving an empty div in the
             flex row at desktop sizes adds a phantom gap-2 between the
             filter button and the desktop combobox. */}
-        <div className="relative md:hidden">
-          <button
-            type="button"
-            onClick={() => setIsCategoryOpen(!isCategoryOpen)}
-            className={`px-2 py-1.5 rounded-lg border transition-colors flex items-center ${
-              categoryIds.length > 0
-                ? 'bg-indigo-50 dark:bg-indigo-900/30 border-indigo-300 dark:border-indigo-600 text-indigo-600 dark:text-indigo-400'
-                : 'bg-white dark:bg-gray-800 border-gray-300 dark:border-gray-600 text-gray-500 dark:text-gray-400'
-            }`}
-            title={t('search.allCategories')}
-          >
-            <FolderOpen className="w-4 h-4" />
-            {categoryIds.length > 0 && (
-              <span className="ml-1 text-xs font-medium">
-                {categoryIds.length}
-              </span>
-            )}
-          </button>
-          {isCategoryOpen && (
-            <>
-              <div
-                className="md:hidden fixed inset-0 z-10"
-                onClick={() => setIsCategoryOpen(false)}
-              />
-              <div
-                className="md:hidden absolute right-0 top-full mt-1 z-20 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-lg shadow-lg overflow-hidden"
-                style={{ minWidth: 200, maxWidth: 'calc(100vw - 24px)' }}
-              >
-                <div className="p-1 max-h-64 overflow-y-auto">
-                  {categories?.map((category) => {
-                    const isSelected = categoryIds.includes(category.id)
-                    return (
-                      <button
-                        key={category.id}
-                        type="button"
-                        onClick={() => {
-                          const next = isSelected
-                            ? categoryIds.filter((id) => id !== category.id)
-                            : [...categoryIds, category.id]
-                          handleCategoryChange(next)
-                        }}
-                        className={`w-full flex items-center gap-2 px-3 py-2 text-sm text-left rounded hover:bg-gray-100 dark:hover:bg-gray-700 ${
-                          isSelected
-                            ? 'bg-indigo-50 dark:bg-indigo-900/20 text-indigo-600 dark:text-indigo-400'
-                            : 'text-gray-900 dark:text-white'
-                        }`}
-                      >
-                        <div
-                          className={`w-4 h-4 rounded border flex items-center justify-center flex-shrink-0 ${
+          <div className="relative md:hidden">
+            <button
+              type="button"
+              onClick={() => setIsCategoryOpen(!isCategoryOpen)}
+              className={`px-2 py-1.5 rounded-lg border transition-colors flex items-center ${
+                categoryIds.length > 0
+                  ? 'bg-indigo-50 dark:bg-indigo-900/30 border-indigo-300 dark:border-indigo-600 text-indigo-600 dark:text-indigo-400'
+                  : 'bg-white dark:bg-gray-800 border-gray-300 dark:border-gray-600 text-gray-500 dark:text-gray-400'
+              }`}
+              title={t('search.allCategories')}
+            >
+              <FolderOpen className="w-4 h-4" />
+              {categoryIds.length > 0 && (
+                <span className="ml-1 text-xs font-medium">
+                  {categoryIds.length}
+                </span>
+              )}
+            </button>
+            {isCategoryOpen && (
+              <>
+                <div
+                  className="md:hidden fixed inset-0 z-10"
+                  onClick={() => setIsCategoryOpen(false)}
+                />
+                <div
+                  className="md:hidden absolute right-0 top-full mt-1 z-20 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-lg shadow-lg overflow-hidden"
+                  style={{ minWidth: 200, maxWidth: 'calc(100vw - 24px)' }}
+                >
+                  <div className="p-1 max-h-64 overflow-y-auto">
+                    {visibleCategories?.map((category) => {
+                      const isSelected = categoryIds.includes(category.id)
+                      return (
+                        <button
+                          key={category.id}
+                          type="button"
+                          onClick={() => {
+                            const next = isSelected
+                              ? categoryIds.filter((id) => id !== category.id)
+                              : [...categoryIds, category.id]
+                            handleCategoryChange(next)
+                          }}
+                          className={`w-full flex items-center gap-2 px-3 py-2 text-sm text-left rounded hover:bg-gray-100 dark:hover:bg-gray-700 ${
                             isSelected
-                              ? 'bg-indigo-600 border-indigo-600'
-                              : 'border-gray-300 dark:border-gray-500'
+                              ? 'bg-indigo-50 dark:bg-indigo-900/20 text-indigo-600 dark:text-indigo-400'
+                              : 'text-gray-900 dark:text-white'
                           }`}
                         >
-                          {isSelected && <X className="w-3 h-3 text-white" />}
-                        </div>
-                        {category.name}
-                      </button>
-                    )
-                  })}
+                          <div
+                            className={`w-4 h-4 rounded border flex items-center justify-center flex-shrink-0 ${
+                              isSelected
+                                ? 'bg-indigo-600 border-indigo-600'
+                                : 'border-gray-300 dark:border-gray-500'
+                            }`}
+                          >
+                            {isSelected && <X className="w-3 h-3 text-white" />}
+                          </div>
+                          {category.name}
+                        </button>
+                      )
+                    })}
+                  </div>
                 </div>
-              </div>
-            </>
-          )}
-        </div>
-        <div
-          className="hidden md:block"
-          style={{ width: categoryDropdownWidth }}
-        >
-          <MultiSelectCombobox
-            options={
-              categories?.map((category) => ({
-                value: category.id,
-                label: category.name,
-              })) ?? []
-            }
-            value={categoryIds}
-            onChange={handleCategoryChange}
-            placeholder={t('search.allCategories')}
-            allSelectedLabel={t('search.allCategories')}
-            emptyMeansAll
-          />
-        </div>
-        {(songTags?.length ?? 0) > 0 && (
-          <div className="hidden md:block min-w-[140px]">
+              </>
+            )}
+          </div>
+          <div
+            className="hidden md:block"
+            style={{ width: categoryDropdownWidth }}
+          >
             <MultiSelectCombobox
               options={
-                songTags?.map((tag) => ({ value: tag.id, label: tag.name })) ??
-                []
+                visibleCategories?.map((category) => ({
+                  value: category.id,
+                  label: category.name,
+                })) ?? []
               }
-              value={tagIds}
-              onChange={handleTagChange}
-              placeholder={t('tags.filterAll')}
-              allOptionLabel={t('tags.filterAll')}
+              value={categoryIds}
+              onChange={handleCategoryChange}
+              placeholder={t('search.allCategories')}
+              allSelectedLabel={t('search.allCategories')}
+              emptyMeansAll
             />
           </div>
-        )}
-      </div>
+          {(songTags?.length ?? 0) > 0 && (
+            <div className="hidden md:block min-w-[140px]">
+              <MultiSelectCombobox
+                options={
+                  songTags?.map((tag) => ({
+                    value: tag.id,
+                    label: tag.name,
+                  })) ?? []
+                }
+                value={tagIds}
+                onChange={handleTagChange}
+                placeholder={t('tags.filterAll')}
+                allOptionLabel={t('tags.filterAll')}
+              />
+            </div>
+          )}
+        </div>
       </div>
 
       {isLoading ? (

--- a/app/apps/client/src/features/songs/hooks/useSongSlideSelectionKeyboard.ts
+++ b/app/apps/client/src/features/songs/hooks/useSongSlideSelectionKeyboard.ts
@@ -46,6 +46,10 @@ export function useSongSlideSelectionKeyboard({
           return true
 
         case 'Enter':
+        // F5 is what a presenter remote's "present/start" button sends — start
+        // presenting the currently-focused slide (first verse, last, whatever
+        // is selected), same as Enter.
+        case 'F5':
           event.preventDefault()
           onPresentSlide()
           return true

--- a/app/apps/client/src/features/songs/hooks/useUpsertCategory.ts
+++ b/app/apps/client/src/features/songs/hooks/useUpsertCategory.ts
@@ -1,20 +1,49 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 
 import { upsertCategory } from '../service'
-import type { UpsertCategoryInput } from '../types'
+import type { SongCategory, UpsertCategoryInput } from '../types'
 
 export function useUpsertCategory() {
   const queryClient = useQueryClient()
 
   return useMutation({
     mutationFn: (input: UpsertCategoryInput) => upsertCategory(input),
-    onSuccess: (result) => {
-      if (result.success) {
-        queryClient.invalidateQueries({ queryKey: ['categories'] })
-        // Hiding/showing a category changes which songs are listed, so the song
-        // browser must refetch too.
-        queryClient.invalidateQueries({ queryKey: ['songs'] })
+    // Optimistically patch an existing category in the cache so the UI (e.g.
+    // the hide/show eye) updates INSTANTLY instead of waiting for the round
+    // trip. New categories (no id) have nothing to patch yet.
+    onMutate: async (input) => {
+      if (!input.id) return
+      await queryClient.cancelQueries({ queryKey: ['categories'] })
+      const previous = queryClient.getQueryData<SongCategory[]>(['categories'])
+      queryClient.setQueryData<SongCategory[]>(['categories'], (old) =>
+        old?.map((c) =>
+          c.id === input.id
+            ? {
+                ...c,
+                ...(input.name !== undefined ? { name: input.name } : {}),
+                ...(input.priority !== undefined
+                  ? { priority: input.priority }
+                  : {}),
+                ...(input.isHidden !== undefined
+                  ? { isHidden: input.isHidden }
+                  : {}),
+              }
+            : c,
+        ),
+      )
+      return { previous }
+    },
+    onError: (_err, _input, context) => {
+      // Roll back the optimistic patch if the request failed.
+      if (context?.previous) {
+        queryClient.setQueryData(['categories'], context.previous)
       }
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: ['categories'] })
+      // Hiding/showing a category changes which songs are listed, so the song
+      // browser must refetch too.
+      queryClient.invalidateQueries({ queryKey: ['songs'] })
     },
   })
 }

--- a/app/apps/client/src/features/songs/hooks/useUpsertCategory.ts
+++ b/app/apps/client/src/features/songs/hooks/useUpsertCategory.ts
@@ -11,6 +11,9 @@ export function useUpsertCategory() {
     onSuccess: (result) => {
       if (result.success) {
         queryClient.invalidateQueries({ queryKey: ['categories'] })
+        // Hiding/showing a category changes which songs are listed, so the song
+        // browser must refetch too.
+        queryClient.invalidateQueries({ queryKey: ['songs'] })
       }
     },
   })

--- a/app/apps/client/src/features/songs/hooks/useUpsertCategory.ts
+++ b/app/apps/client/src/features/songs/hooks/useUpsertCategory.ts
@@ -44,6 +44,9 @@ export function useUpsertCategory() {
       // Hiding/showing a category changes which songs are listed, so the song
       // browser must refetch too.
       queryClient.invalidateQueries({ queryKey: ['songs'] })
+      // …and the version "possible matches" must drop/restore that category's
+      // songs as well.
+      queryClient.invalidateQueries({ queryKey: ['song-similar'] })
     },
   })
 }

--- a/app/apps/client/src/features/songs/types.ts
+++ b/app/apps/client/src/features/songs/types.ts
@@ -8,6 +8,8 @@ export interface SongCategory {
   name: string
   priority: number
   songCount: number
+  /** 1 = hidden from the song browser (filters + list + search). */
+  isHidden: number
   createdAt: number
   updatedAt: number
 }
@@ -115,6 +117,8 @@ export interface UpsertCategoryInput {
   id?: number
   name: string
   priority?: number
+  /** 1 = hide the category (and its songs); 0 = show. */
+  isHidden?: number
 }
 
 export interface UpsertTagInput {

--- a/app/apps/client/src/features/users/components/UserPermissions.tsx
+++ b/app/apps/client/src/features/users/components/UserPermissions.tsx
@@ -24,6 +24,7 @@ const GROUP_ORDER: PermissionGroup[] = [
   'queue',
   'song_key',
   'settings',
+  'logs',
   'displays',
   'users',
 ]

--- a/app/apps/client/src/features/users/service/users.ts
+++ b/app/apps/client/src/features/users/service/users.ts
@@ -146,9 +146,8 @@ export async function getAllRoles(): Promise<RoleWithPermissions[]> {
  * Returns null when no session is active (server reachable but signed out).
  */
 export async function getCurrentUser(): Promise<CurrentUser | null> {
-  const response = await fetcher<ApiResponse<CurrentUser | null>>(
-    '/api/auth/me',
-  )
+  const response =
+    await fetcher<ApiResponse<CurrentUser | null>>('/api/auth/me')
   return response.data ?? null
 }
 
@@ -156,8 +155,9 @@ export async function getCurrentUser(): Promise<CurrentUser | null> {
  * Fetches the minimal user list for the local login screen.
  */
 export async function getLocalUsers(): Promise<LocalUser[]> {
-  const response =
-    await fetcher<ApiResponse<LocalUser[]>>('/api/auth/local-users')
+  const response = await fetcher<ApiResponse<LocalUser[]>>(
+    '/api/auth/local-users',
+  )
   return response.data
 }
 
@@ -222,6 +222,36 @@ export function getLogoutRedirectUrl(): string {
  */
 export async function logout(): Promise<void> {
   await fetcher('/api/auth/logout', { method: 'POST' })
+}
+
+/**
+ * sessionStorage flag set by {@link performLogout} so the login gate shows the
+ * account picker instead of instantly auto-signing a sole passwordless account
+ * back in. Read + cleared at runtime by the gate's auto-login effect (logout
+ * refreshes the auth context rather than reloading the page, so a mount-time
+ * read would miss it).
+ */
+export const LOGGED_OUT_FLAG = 'church-hub:logged-out'
+
+/**
+ * Performs a deliberate logout: marks the intent then clears the session cookie
+ * via the fetch logout. Callers should then `refresh()` the permissions context
+ * (a pure re-read of /api/auth/me) rather than navigating/reloading — top-level
+ * navigation to the sidecar origin is unreliable in the packaged desktop
+ * webview (app on `tauri.localhost`, API on `localhost`), which is what made
+ * the old redirect-based logout do nothing.
+ */
+export async function performLogout(): Promise<void> {
+  try {
+    sessionStorage.setItem(LOGGED_OUT_FLAG, '1')
+  } catch {
+    // sessionStorage unavailable — non-fatal, normal logout still proceeds.
+  }
+  try {
+    await logout()
+  } catch {
+    // Best-effort: the caller refreshes regardless so the gate re-checks.
+  }
 }
 
 /**

--- a/app/apps/client/src/features/users/service/users.ts
+++ b/app/apps/client/src/features/users/service/users.ts
@@ -1,5 +1,19 @@
-import { getApiUrl } from '~/config'
+import { getApiUrl, isMobile, isTauri } from '~/config'
+import {
+  clearStoredUserToken,
+  setStoredUserToken,
+} from '~/service/api-url'
 import { fetcher } from '../../../utils/fetcher'
+
+/**
+ * The packaged desktop app (macOS WKWebView) can't store the cross-site
+ * `Secure` session cookie, so it authenticates by persisting the user token and
+ * sending it as an `X-User-Auth` header instead. This only applies to desktop
+ * Tauri — mobile pairs via an auth URL, and the browser uses the cookie.
+ */
+function isDesktopTauri(): boolean {
+  return isTauri() && !isMobile()
+}
 import type {
   CreateUserInput,
   CreateUserResult,
@@ -165,6 +179,8 @@ export interface LoginResult {
   user: CurrentUser | null
   /** One-time ticket to finalize the session via top-level navigation. */
   ticket: string
+  /** The user auth token (localhost only) — persisted on desktop Tauri. */
+  token?: string
 }
 
 /**
@@ -178,6 +194,7 @@ export async function login(
   const response = await fetcher<
     Partial<ApiResponse<CurrentUser | null>> & {
       ticket?: string
+      token?: string
       error?: string
     }
   >('/api/auth/login', {
@@ -185,13 +202,23 @@ export async function login(
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ userId, password }),
   })
-  // The server returns `{ data, ticket }` on success and `{ error }` on
+  // The server returns `{ data, ticket, token }` on success and `{ error }` on
   // failure (e.g. 401 for wrong credentials). The shared fetcher does not
   // throw on non-ok responses, so we surface failures here ourselves.
   if (!response.ticket) {
     throw new Error(response.error ?? 'Invalid credentials')
   }
-  return { user: response.data ?? null, ticket: response.ticket }
+  // On desktop Tauri persist the token so subsequent requests (including the
+  // immediate `refresh()` → /api/auth/me) authenticate via the X-User-Auth
+  // header instead of the cookie the WKWebView can't store.
+  if (response.token && isDesktopTauri()) {
+    setStoredUserToken(response.token)
+  }
+  return {
+    user: response.data ?? null,
+    ticket: response.ticket,
+    token: response.token,
+  }
 }
 
 /**
@@ -251,6 +278,11 @@ export async function performLogout(): Promise<void> {
     await logout()
   } catch {
     // Best-effort: the caller refreshes regardless so the gate re-checks.
+  }
+  // Drop the persisted desktop token so the next /api/auth/me is unauthenticated
+  // and the gate shows the account picker.
+  if (isDesktopTauri()) {
+    clearStoredUserToken()
   }
 }
 

--- a/app/apps/client/src/features/users/types.ts
+++ b/app/apps/client/src/features/users/types.ts
@@ -52,6 +52,9 @@ export type BuiltInPermission =
   // Song Key Configuration
   | 'song_key.view'
   | 'song_key.edit'
+  // Application Logs (view the local log files / clear them)
+  | 'logs.view'
+  | 'logs.clear'
 
 /**
  * Dynamic permission for custom pages
@@ -127,6 +130,9 @@ export const ALL_PERMISSIONS: BuiltInPermission[] = [
   // Song Key Configuration
   'song_key.view',
   'song_key.edit',
+  // Application Logs
+  'logs.view',
+  'logs.clear',
 ]
 
 /**
@@ -187,6 +193,7 @@ export const PERMISSION_GROUPS = {
     'users.delete',
   ] as Permission[],
   song_key: ['song_key.view', 'song_key.edit'] as Permission[],
+  logs: ['logs.view', 'logs.clear'] as Permission[],
 } as const
 
 export type PermissionGroup = keyof typeof PERMISSION_GROUPS

--- a/app/apps/client/src/i18n/locales/en/presentation.json
+++ b/app/apps/client/src/i18n/locales/en/presentation.json
@@ -50,6 +50,10 @@
     "visibility": {
       "hideElement": "Hide element"
     },
+    "elements": {
+      "songKey": "Song key",
+      "amen": "Amen"
+    },
     "position": {
       "x": "X Position",
       "y": "Y Position",

--- a/app/apps/client/src/i18n/locales/en/presentation.json
+++ b/app/apps/client/src/i18n/locales/en/presentation.json
@@ -31,6 +31,7 @@
     },
     "contentTypes": {
       "song": "Song",
+      "song_first_slide": "Song (first slide)",
       "bible": "Bible Verse",
       "bible_passage": "Bible Passage",
       "announcement": "Announcement",

--- a/app/apps/client/src/i18n/locales/en/presentation.json
+++ b/app/apps/client/src/i18n/locales/en/presentation.json
@@ -32,6 +32,7 @@
     "contentTypes": {
       "song": "Song",
       "song_first_slide": "Song (first slide)",
+      "song_last_slide": "Song (last slide)",
       "bible": "Bible Verse",
       "bible_passage": "Bible Passage",
       "announcement": "Announcement",

--- a/app/apps/client/src/i18n/locales/en/settings.json
+++ b/app/apps/client/src/i18n/locales/en/settings.json
@@ -18,6 +18,7 @@
       "livestream": "Livestream",
       "sidebar": "Sidebar",
       "developer": "Developer",
+      "logs": "Logs",
       "shortcuts": "Shortcuts"
     }
   },
@@ -291,7 +292,8 @@
         "settings": "Settings",
         "displays": "Displays",
         "users": "User Management",
-        "song_key": "Song Keys"
+        "song_key": "Song Keys",
+        "logs": "Logs"
       },
       "permissionLabels": {
         "songs.view": "View songs",
@@ -333,7 +335,9 @@
         "users.edit": "Edit users",
         "users.delete": "Delete users",
         "song_key.view": "View song keys",
-        "song_key.edit": "Edit song keys"
+        "song_key.edit": "Edit song keys",
+        "logs.view": "View application logs",
+        "logs.clear": "Clear application logs"
       },
       "actions": {
         "edit": "Edit",
@@ -923,6 +927,8 @@
       }
     },
     "logs": {
+      "title": "Application Logs",
+      "description": "View the app's local log files and clear them. Useful for diagnosing issues and errors.",
       "card": {
         "title": "Application Logs",
         "description": "Open the folder containing application logs. Attach the latest files when reporting an issue."
@@ -931,9 +937,36 @@
         "open": "Open Logs Folder",
         "opening": "Opening..."
       },
+      "viewer": {
+        "empty": "No logs to display.",
+        "refresh": "Refresh",
+        "refreshing": "Refreshing...",
+        "serverHeading": "Server logs",
+        "tauriHeading": "App (Tauri) logs"
+      },
+      "clear": {
+        "card": {
+          "title": "Clear logs",
+          "description": "Permanently empty all local log files on this device."
+        },
+        "button": {
+          "clear": "Clear logs",
+          "clearing": "Clearing..."
+        },
+        "confirm": {
+          "title": "Clear all logs?",
+          "message": "This empties every local log file on this device.",
+          "warning": "This action cannot be undone.",
+          "cancel": "Cancel",
+          "confirm": "Clear logs"
+        }
+      },
       "toast": {
         "opened": "Logs folder opened",
-        "failed": "Failed to open logs folder: {{error}}"
+        "failed": "Failed to open logs folder: {{error}}",
+        "cleared": "Logs cleared",
+        "clearFailed": "Failed to clear logs: {{error}}",
+        "loadFailed": "Failed to load logs: {{error}}"
       }
     },
     "about": {

--- a/app/apps/client/src/i18n/locales/en/settings.json
+++ b/app/apps/client/src/i18n/locales/en/settings.json
@@ -401,8 +401,11 @@
       "songCount_other": "{{count}} songs",
       "actions": {
         "edit": "Edit",
-        "delete": "Delete"
+        "delete": "Delete",
+        "hide": "Hide",
+        "show": "Show"
       },
+      "hiddenBadge": "Hidden",
       "modals": {
         "create": {
           "title": "Add New Category",
@@ -423,6 +426,8 @@
         "updated": "Category updated successfully",
         "deleted": "Category deleted successfully",
         "reordered": "Category order updated",
+        "hidden": "Category hidden",
+        "shown": "Category shown",
         "error": "An error occurred"
       },
       "uncategorized": {

--- a/app/apps/client/src/i18n/locales/en/settings.json
+++ b/app/apps/client/src/i18n/locales/en/settings.json
@@ -944,10 +944,18 @@
       },
       "viewer": {
         "empty": "No logs to display.",
+        "noMatches": "No logs match your filters.",
+        "search": "Search logs…",
         "refresh": "Refresh",
         "refreshing": "Refreshing...",
         "serverHeading": "Server logs",
-        "tauriHeading": "App (Tauri) logs"
+        "tauriHeading": "App (Tauri) logs",
+        "levels": {
+          "error": "Errors",
+          "warning": "Warnings",
+          "info": "Info",
+          "debug": "Debug"
+        }
       },
       "clear": {
         "card": {

--- a/app/apps/client/src/i18n/locales/ro/presentation.json
+++ b/app/apps/client/src/i18n/locales/ro/presentation.json
@@ -32,6 +32,7 @@
     "contentTypes": {
       "song": "Cântec",
       "song_first_slide": "Gama - Strofă",
+      "song_last_slide": "Strofă - Amin",
       "bible": "Verset Biblic",
       "bible_passage": "Pasaj Biblic",
       "announcement": "Anunț",

--- a/app/apps/client/src/i18n/locales/ro/presentation.json
+++ b/app/apps/client/src/i18n/locales/ro/presentation.json
@@ -31,6 +31,7 @@
     },
     "contentTypes": {
       "song": "Cântec",
+      "song_first_slide": "Gama - Strofă",
       "bible": "Verset Biblic",
       "bible_passage": "Pasaj Biblic",
       "announcement": "Anunț",

--- a/app/apps/client/src/i18n/locales/ro/presentation.json
+++ b/app/apps/client/src/i18n/locales/ro/presentation.json
@@ -50,6 +50,10 @@
     "visibility": {
       "hideElement": "Ascunde elementul"
     },
+    "elements": {
+      "songKey": "Gama",
+      "amen": "Amin"
+    },
     "position": {
       "x": "Poziție X",
       "y": "Poziție Y",

--- a/app/apps/client/src/i18n/locales/ro/presentation.json
+++ b/app/apps/client/src/i18n/locales/ro/presentation.json
@@ -31,8 +31,8 @@
     },
     "contentTypes": {
       "song": "Cântec",
-      "song_first_slide": "Gama - Strofă",
-      "song_last_slide": "Strofă - Amin",
+      "song_first_slide": "Cântec - Primul Slide",
+      "song_last_slide": "Cântec - Ultimul Slide",
       "bible": "Verset Biblic",
       "bible_passage": "Pasaj Biblic",
       "announcement": "Anunț",

--- a/app/apps/client/src/i18n/locales/ro/settings.json
+++ b/app/apps/client/src/i18n/locales/ro/settings.json
@@ -945,10 +945,18 @@
       },
       "viewer": {
         "empty": "Nu există jurnale de afișat.",
+        "noMatches": "Niciun jurnal nu corespunde filtrelor.",
+        "search": "Caută în jurnale…",
         "refresh": "Reîmprospătează",
         "refreshing": "Se reîmprospătează...",
         "serverHeading": "Jurnale server",
-        "tauriHeading": "Jurnale aplicație (Tauri)"
+        "tauriHeading": "Jurnale aplicație (Tauri)",
+        "levels": {
+          "error": "Erori",
+          "warning": "Avertismente",
+          "info": "Info",
+          "debug": "Depanare"
+        }
       },
       "clear": {
         "card": {

--- a/app/apps/client/src/i18n/locales/ro/settings.json
+++ b/app/apps/client/src/i18n/locales/ro/settings.json
@@ -402,8 +402,11 @@
       "songCount_other": "{{count}} cântări",
       "actions": {
         "edit": "Editează",
-        "delete": "Șterge"
+        "delete": "Șterge",
+        "hide": "Ascunde",
+        "show": "Arată"
       },
+      "hiddenBadge": "Ascunsă",
       "modals": {
         "create": {
           "title": "Adaugă Categorie Nouă",
@@ -424,6 +427,8 @@
         "updated": "Categorie actualizată cu succes",
         "deleted": "Categorie ștearsă cu succes",
         "reordered": "Ordinea categoriilor actualizată",
+        "hidden": "Categorie ascunsă",
+        "shown": "Categorie afișată",
         "error": "A apărut o eroare"
       },
       "uncategorized": {

--- a/app/apps/client/src/i18n/locales/ro/settings.json
+++ b/app/apps/client/src/i18n/locales/ro/settings.json
@@ -18,6 +18,7 @@
       "livestream": "Live Stream",
       "sidebar": "Bara Laterală",
       "developer": "Dezvoltatori",
+      "logs": "Jurnale",
       "shortcuts": "Scurtături"
     }
   },
@@ -291,7 +292,8 @@
         "settings": "Setări",
         "displays": "Afișaje",
         "users": "Administrare utilizatori",
-        "song_key": "Gama cântări"
+        "song_key": "Gama cântări",
+        "logs": "Jurnale"
       },
       "permissionLabels": {
         "songs.view": "Vizualizare cântări",
@@ -333,7 +335,9 @@
         "users.edit": "Editare utilizatori",
         "users.delete": "Ștergere utilizatori",
         "song_key.view": "Vizualizare gama cântări",
-        "song_key.edit": "Editare gama cântări"
+        "song_key.edit": "Editare gama cântări",
+        "logs.view": "Vizualizare jurnale aplicație",
+        "logs.clear": "Ștergere jurnale aplicație"
       },
       "actions": {
         "edit": "Editează",
@@ -924,6 +928,8 @@
       }
     },
     "logs": {
+      "title": "Jurnale Aplicație",
+      "description": "Vizualizează fișierele de jurnal locale ale aplicației și șterge-le. Util pentru diagnosticarea problemelor și erorilor.",
       "card": {
         "title": "Jurnale Aplicație",
         "description": "Deschide folderul cu jurnalele aplicației. Atașează ultimele fișiere când raportezi o problemă."
@@ -932,9 +938,36 @@
         "open": "Deschide Folderul cu Jurnale",
         "opening": "Se deschide..."
       },
+      "viewer": {
+        "empty": "Nu există jurnale de afișat.",
+        "refresh": "Reîmprospătează",
+        "refreshing": "Se reîmprospătează...",
+        "serverHeading": "Jurnale server",
+        "tauriHeading": "Jurnale aplicație (Tauri)"
+      },
+      "clear": {
+        "card": {
+          "title": "Șterge jurnalele",
+          "description": "Golește definitiv toate fișierele de jurnal locale de pe acest dispozitiv."
+        },
+        "button": {
+          "clear": "Șterge jurnalele",
+          "clearing": "Se șterge..."
+        },
+        "confirm": {
+          "title": "Ștergi toate jurnalele?",
+          "message": "Aceasta golește fiecare fișier de jurnal local de pe acest dispozitiv.",
+          "warning": "Această acțiune nu poate fi anulată.",
+          "cancel": "Anulează",
+          "confirm": "Șterge jurnalele"
+        }
+      },
       "toast": {
         "opened": "Folderul cu jurnale a fost deschis",
-        "failed": "Nu s-a putut deschide folderul cu jurnale: {{error}}"
+        "failed": "Nu s-a putut deschide folderul cu jurnale: {{error}}",
+        "cleared": "Jurnalele au fost șterse",
+        "clearFailed": "Nu s-au putut șterge jurnalele: {{error}}",
+        "loadFailed": "Nu s-au putut încărca jurnalele: {{error}}"
       }
     },
     "about": {

--- a/app/apps/client/src/routeTree.gen.ts
+++ b/app/apps/client/src/routeTree.gen.ts
@@ -28,6 +28,7 @@ import { Route as SettingsShortcutsRouteImport } from './routes/settings/shortcu
 import { Route as SettingsScreensRouteImport } from './routes/settings/screens'
 import { Route as SettingsProfileRouteImport } from './routes/settings/profile'
 import { Route as SettingsMidiRouteImport } from './routes/settings/midi'
+import { Route as SettingsLogsRouteImport } from './routes/settings/logs'
 import { Route as SettingsLivestreamRouteImport } from './routes/settings/livestream'
 import { Route as SettingsKioskRouteImport } from './routes/settings/kiosk'
 import { Route as SettingsDeveloperRouteImport } from './routes/settings/developer'
@@ -137,6 +138,11 @@ const SettingsMidiRoute = SettingsMidiRouteImport.update({
   path: '/midi',
   getParentRoute: () => SettingsRouteRoute,
 } as any)
+const SettingsLogsRoute = SettingsLogsRouteImport.update({
+  id: '/logs',
+  path: '/logs',
+  getParentRoute: () => SettingsRouteRoute,
+} as any)
 const SettingsLivestreamRoute = SettingsLivestreamRouteImport.update({
   id: '/livestream',
   path: '/livestream',
@@ -215,6 +221,7 @@ export interface FileRoutesByFullPath {
   '/settings/developer': typeof SettingsDeveloperRoute
   '/settings/kiosk': typeof SettingsKioskRoute
   '/settings/livestream': typeof SettingsLivestreamRoute
+  '/settings/logs': typeof SettingsLogsRoute
   '/settings/midi': typeof SettingsMidiRoute
   '/settings/profile': typeof SettingsProfileRoute
   '/settings/screens': typeof SettingsScreensRoute
@@ -248,6 +255,7 @@ export interface FileRoutesByTo {
   '/settings/developer': typeof SettingsDeveloperRoute
   '/settings/kiosk': typeof SettingsKioskRoute
   '/settings/livestream': typeof SettingsLivestreamRoute
+  '/settings/logs': typeof SettingsLogsRoute
   '/settings/midi': typeof SettingsMidiRoute
   '/settings/profile': typeof SettingsProfileRoute
   '/settings/screens': typeof SettingsScreensRoute
@@ -283,6 +291,7 @@ export interface FileRoutesById {
   '/settings/developer': typeof SettingsDeveloperRoute
   '/settings/kiosk': typeof SettingsKioskRoute
   '/settings/livestream': typeof SettingsLivestreamRoute
+  '/settings/logs': typeof SettingsLogsRoute
   '/settings/midi': typeof SettingsMidiRoute
   '/settings/profile': typeof SettingsProfileRoute
   '/settings/screens': typeof SettingsScreensRoute
@@ -319,6 +328,7 @@ export interface FileRouteTypes {
     | '/settings/developer'
     | '/settings/kiosk'
     | '/settings/livestream'
+    | '/settings/logs'
     | '/settings/midi'
     | '/settings/profile'
     | '/settings/screens'
@@ -352,6 +362,7 @@ export interface FileRouteTypes {
     | '/settings/developer'
     | '/settings/kiosk'
     | '/settings/livestream'
+    | '/settings/logs'
     | '/settings/midi'
     | '/settings/profile'
     | '/settings/screens'
@@ -386,6 +397,7 @@ export interface FileRouteTypes {
     | '/settings/developer'
     | '/settings/kiosk'
     | '/settings/livestream'
+    | '/settings/logs'
     | '/settings/midi'
     | '/settings/profile'
     | '/settings/screens'
@@ -564,6 +576,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof SettingsMidiRouteImport
       parentRoute: typeof SettingsRouteRoute
     }
+    '/settings/logs': {
+      id: '/settings/logs'
+      path: '/logs'
+      fullPath: '/settings/logs'
+      preLoaderRoute: typeof SettingsLogsRouteImport
+      parentRoute: typeof SettingsRouteRoute
+    }
     '/settings/livestream': {
       id: '/settings/livestream'
       path: '/livestream'
@@ -666,6 +685,7 @@ interface SettingsRouteRouteChildren {
   SettingsDeveloperRoute: typeof SettingsDeveloperRoute
   SettingsKioskRoute: typeof SettingsKioskRoute
   SettingsLivestreamRoute: typeof SettingsLivestreamRoute
+  SettingsLogsRoute: typeof SettingsLogsRoute
   SettingsMidiRoute: typeof SettingsMidiRoute
   SettingsProfileRoute: typeof SettingsProfileRoute
   SettingsScreensRoute: typeof SettingsScreensRoute
@@ -684,6 +704,7 @@ const SettingsRouteRouteChildren: SettingsRouteRouteChildren = {
   SettingsDeveloperRoute: SettingsDeveloperRoute,
   SettingsKioskRoute: SettingsKioskRoute,
   SettingsLivestreamRoute: SettingsLivestreamRoute,
+  SettingsLogsRoute: SettingsLogsRoute,
   SettingsMidiRoute: SettingsMidiRoute,
   SettingsProfileRoute: SettingsProfileRoute,
   SettingsScreensRoute: SettingsScreensRoute,

--- a/app/apps/client/src/router.tsx
+++ b/app/apps/client/src/router.tsx
@@ -23,6 +23,7 @@ import { ApiUrlSetup } from './features/api-url-config'
 import { routeTree } from './routeTree.gen'
 import DefaultCatchBoundary from './ui/DefaultCatchBoundary'
 import { ErrorBoundary } from './ui/error-boundary'
+import { captureActivity } from './utils/activity-logger'
 import { getServerConfig } from './utils/tauri-commands'
 
 const router = createRouter({
@@ -36,6 +37,18 @@ declare module '@tanstack/react-router' {
   interface Register {
     router: typeof router
   }
+}
+
+// Record navigation so the activity log shows which pages/options the operator
+// opened — a breadcrumb trail that makes errors far easier to interpret.
+// Best-effort: never let logging break navigation.
+try {
+  router.subscribe('onResolved', (event) => {
+    const path = event.toLocation?.pathname
+    if (path) captureActivity('navigate', { source: 'router', path })
+  })
+} catch {
+  // Non-fatal — navigation logging is best-effort.
 }
 
 // Check if we're running in Tauri context

--- a/app/apps/client/src/routes/settings/logs.tsx
+++ b/app/apps/client/src/routes/settings/logs.tsx
@@ -1,0 +1,24 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { useTranslation } from 'react-i18next'
+
+import { LogsPanel } from '~/features/logs'
+import { SettingsLeafGuard, SettingsSection } from '~/features/settings'
+
+export const Route = createFileRoute('/settings/logs')({
+  component: LogsSettings,
+})
+
+function LogsSettings() {
+  const { t } = useTranslation('settings')
+
+  return (
+    <SettingsLeafGuard itemId="logs">
+      <SettingsSection
+        title={t('sections.logs.title')}
+        description={t('sections.logs.description')}
+      >
+        <LogsPanel />
+      </SettingsSection>
+    </SettingsLeafGuard>
+  )
+}

--- a/app/apps/client/src/routes/songs/index.tsx
+++ b/app/apps/client/src/routes/songs/index.tsx
@@ -12,6 +12,7 @@ import { useSearchHistoryById } from '~/features/songs/hooks'
 import { openSongWindow } from '~/features/songs/utils/openSongWindow'
 import { useMarcajeBoundary } from '~/hooks/useMarcajeBoundary'
 import { PagePermissionGuard } from '~/ui/PagePermissionGuard'
+import { PermissionGate } from '~/ui/PermissionGate'
 
 interface SongsSearchParams {
   q?: string
@@ -287,16 +288,20 @@ function SongsPage() {
                 </span>
               </button>
             )}
-            <button
-              type="button"
-              onClick={() =>
-                navigate({ to: '/songs/$songId', params: { songId: 'new' } })
-              }
-              className="flex items-center gap-2 px-3 py-2 lg:px-3 text-sm bg-indigo-600 hover:bg-indigo-700 text-white rounded-lg transition-colors"
-            >
-              <Plus className="w-4 h-4" />
-              <span className="hidden sm:inline">{t('actions.create')}</span>
-            </button>
+            {/* Creating songs requires songs.create — hide the button entirely
+                for users without it (the /songs/new route is guarded too). */}
+            <PermissionGate permission="songs.create">
+              <button
+                type="button"
+                onClick={() =>
+                  navigate({ to: '/songs/$songId', params: { songId: 'new' } })
+                }
+                className="flex items-center gap-2 px-3 py-2 lg:px-3 text-sm bg-indigo-600 hover:bg-indigo-700 text-white rounded-lg transition-colors"
+              >
+                <Plus className="w-4 h-4" />
+                <span className="hidden sm:inline">{t('actions.create')}</span>
+              </button>
+            </PermissionGate>
           </div>
         </div>
 

--- a/app/apps/client/src/service/api-url/api-url.ts
+++ b/app/apps/client/src/service/api-url/api-url.ts
@@ -67,6 +67,33 @@ export function getStoredUserToken(): string | null {
 }
 
 /**
+ * Persists the user auth token (used by the desktop app to send it as an
+ * `X-User-Auth` header, since the cross-site `Secure` cookie can't be stored by
+ * macOS WKWebView over http://localhost).
+ */
+export function setStoredUserToken(token: string): void {
+  if (typeof window === 'undefined') return
+  try {
+    localStorage.setItem(USER_AUTH_STORAGE_KEY, token)
+  } catch {
+    // Silently fail - storage errors are not critical
+  }
+}
+
+/**
+ * Clears the stored user auth token (on logout). Leaves the stored API URL
+ * (mobile pairing) intact.
+ */
+export function clearStoredUserToken(): void {
+  if (typeof window === 'undefined') return
+  try {
+    localStorage.removeItem(USER_AUTH_STORAGE_KEY)
+  } catch {
+    // Silently fail - storage errors are not critical
+  }
+}
+
+/**
  * Saves the API URL and optional user token to localStorage
  * Also sets the user_auth cookie if a token is provided
  */

--- a/app/apps/client/src/service/api-url/index.ts
+++ b/app/apps/client/src/service/api-url/index.ts
@@ -1,9 +1,11 @@
 export {
   clearApiUrl,
+  clearStoredUserToken,
   getStoredApiUrl,
   getStoredUserToken,
   isValidApiUrl,
   parseAuthUrl,
   setApiUrl,
+  setStoredUserToken,
   testApiConnection,
 } from './api-url'

--- a/app/apps/client/src/utils/activity-logger.ts
+++ b/app/apps/client/src/utils/activity-logger.ts
@@ -1,0 +1,40 @@
+/**
+ * Lightweight user-activity logger. Records what the operator does — navigating
+ * between pages, logging in/out, switching accounts, clearing logs, and other
+ * notable clicks — to the console (debug) AND the on-disk server log (via
+ * {@link forwardActivityToServer}) under the `activity` category.
+ *
+ * This is intentionally distinct from error reporting (error-handler.ts): it's
+ * an audit/breadcrumb trail that makes the error logs far easier to interpret
+ * ("what was the user doing right before this failed?").
+ */
+import { forwardActivityToServer } from './forwardActivityToServer'
+import { createLogger } from './logger'
+
+const logger = createLogger('app:activity')
+
+interface ActivityContext {
+  source?: string
+  [key: string]: unknown
+}
+
+/**
+ * Record a user activity event.
+ *
+ * @param action  A short, stable action key (e.g. `navigate`, `login`,
+ *                `logout`, `account-switch`, `logs.clear`).
+ * @param context Optional structured details (path, target user, etc.).
+ */
+export function captureActivity(
+  action: string,
+  context?: ActivityContext,
+): void {
+  const source = context?.source ?? 'app'
+  logger.debug(`${action}`, context)
+  forwardActivityToServer({
+    action,
+    message: action,
+    source,
+    context,
+  })
+}

--- a/app/apps/client/src/utils/fetcher.ts
+++ b/app/apps/client/src/utils/fetcher.ts
@@ -48,17 +48,24 @@ export async function fetcher<T>(
   url: string,
   options?: RequestInit & ClientOptions & { timeout?: number },
 ): Promise<T> {
-  // Get auth token for mobile
-  const userToken = isMobile() ? getStoredUserToken() : null
+  // Auth token for Tauri (mobile + desktop). In a browser the same-origin
+  // cookie is used, so no explicit header is needed.
+  const userToken = isTauri ? getStoredUserToken() : null
 
-  // Build headers with auth token if on mobile
   const headers: Record<string, string> = {
     ...((options?.headers as Record<string, string>) ?? {}),
   }
 
-  // Add auth cookie header for mobile (Tauri HTTP plugin needs explicit Cookie header)
+  // Mobile uses the Tauri HTTP plugin, which can set the `Cookie` header.
+  // Desktop uses `window.fetch`, which forbids the `Cookie` header — and macOS
+  // WKWebView won't store the cross-site `Secure` cookie anyway — so send the
+  // token in `X-User-Auth` (read as a fallback by the server auth middleware).
   if (userToken) {
-    headers['Cookie'] = `user_auth=${userToken}`
+    if (isMobile()) {
+      headers['Cookie'] = `user_auth=${userToken}`
+    } else {
+      headers['X-User-Auth'] = userToken
+    }
   }
 
   const fullUrl = `${getApiBaseUrl()}${url}`

--- a/app/apps/client/src/utils/forwardActivityToServer.ts
+++ b/app/apps/client/src/utils/forwardActivityToServer.ts
@@ -1,0 +1,68 @@
+/**
+ * Forward client-side USER ACTIVITY (navigation, login/logout, key actions) to
+ * the server so it lands in the on-disk log (`server-YYYY-MM-DD.log`, category
+ * `activity`). This gives an audit trail of what the operator did leading up to
+ * an error — the browser can't write to disk itself.
+ *
+ * Kept in a SEPARATE queue from error forwarding so chatty navigation events
+ * can never starve the error reporter's per-session budget. Fire-and-forget
+ * with light batching; failures are swallowed (never report a reporting
+ * failure — it would loop).
+ */
+import { getApiUrl } from '~/config'
+
+export interface ClientActivityPayload {
+  action: string
+  message?: string
+  source?: string
+  context?: Record<string, unknown>
+}
+
+const queue: ClientActivityPayload[] = []
+const MAX_QUEUE = 100
+// Generous per-session cap — activity is higher-volume than errors, but still
+// bounded so a runaway loop can't post forever.
+const MAX_PER_SESSION = 5000
+let sentThisSession = 0
+let flushTimer: ReturnType<typeof setTimeout> | null = null
+
+function flush(): void {
+  flushTimer = null
+  if (queue.length === 0) return
+
+  const apiUrl = getApiUrl()
+  if (!apiUrl) {
+    // No server to forward to (e.g. mobile without a configured URL). Drop the
+    // batch rather than grow unbounded.
+    queue.length = 0
+    return
+  }
+
+  const batch = queue.splice(0, MAX_QUEUE)
+  sentThisSession += batch.length
+
+  // keepalive so events logged during unload (e.g. a logout navigation) still
+  // get sent.
+  void fetch(`${apiUrl}/api/client-activity`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ events: batch }),
+    keepalive: true,
+  }).catch(() => {
+    // Swallow — never report a reporting failure (would loop).
+  })
+}
+
+/**
+ * Queue a client activity event for forwarding to the server log. Debounced
+ * ~1s so bursts coalesce into one request.
+ */
+export function forwardActivityToServer(payload: ClientActivityPayload): void {
+  if (sentThisSession >= MAX_PER_SESSION) return
+  if (queue.length >= MAX_QUEUE) queue.shift()
+  queue.push(payload)
+
+  if (flushTimer === null) {
+    flushTimer = setTimeout(flush, 1000)
+  }
+}

--- a/app/apps/server/src/db/migrations/add-category-hidden-flag.ts
+++ b/app/apps/server/src/db/migrations/add-category-hidden-flag.ts
@@ -1,0 +1,37 @@
+import type { Database } from 'bun:sqlite'
+
+const DEBUG = process.env.DEBUG === 'true'
+
+function log(level: 'debug' | 'info' | 'warning' | 'error', message: string) {
+  if (level === 'debug' && !DEBUG) return
+  // biome-ignore lint/suspicious/noConsole: migration logging
+  console.log(`[add-category-hidden-flag:${level}] ${message}`)
+}
+
+/**
+ * Adds the `is_hidden` flag to `song_categories` (default 0 = visible).
+ *
+ * A hidden category is NOT deleted: it stays in the database with its songs
+ * intact, but it's dropped from the song browser's category filters and its
+ * songs are excluded from the song list / search. Admins can re-show it from
+ * Settings → Songs. Lets operators hide a whole category (and its songs)
+ * without losing any data.
+ *
+ * Idempotent: only adds the column if it's missing.
+ */
+export function addCategoryHiddenFlag(db: Database): void {
+  const columns = db
+    .query<{ name: string }, []>('PRAGMA table_info(song_categories)')
+    .all()
+
+  if (columns.some((col) => col.name === 'is_hidden')) {
+    log('debug', '"is_hidden" already present — nothing to do.')
+    return
+  }
+
+  log('info', 'Adding "is_hidden" column to song_categories (default 0)...')
+  db.run(
+    'ALTER TABLE song_categories ADD COLUMN is_hidden INTEGER NOT NULL DEFAULT 0',
+  )
+  log('info', 'category is_hidden migration complete')
+}

--- a/app/apps/server/src/db/migrations/add-logs-permissions.ts
+++ b/app/apps/server/src/db/migrations/add-logs-permissions.ts
@@ -1,0 +1,53 @@
+import type { Database } from 'bun:sqlite'
+
+const DEBUG = process.env.DEBUG === 'true'
+
+function log(level: 'debug' | 'info' | 'warning' | 'error', message: string) {
+  if (level === 'debug' && !DEBUG) return
+  // biome-ignore lint/suspicious/noConsole: migration logging
+  console.log(`[add-logs-permissions:${level}] ${message}`)
+}
+
+/**
+ * Backfills the new `logs.view` permission for roles and users that already
+ * have `settings.edit`. Before this feature, the logs folder was reachable
+ * from the (settings.edit-gated) Developer settings, so settings editors could
+ * already see logs — this keeps that access when the dedicated Logs section
+ * moves behind `logs.view`.
+ *
+ * `logs.clear` is intentionally NOT backfilled: clearing logs is a new,
+ * destructive capability that an admin grants explicitly.
+ *
+ * Idempotent: `INSERT OR IGNORE` against the unique
+ * `(user_id, permission)` / `(role_id, permission)` constraints, so it's safe
+ * to re-run on every boot.
+ */
+export function addLogsPermissions(db: Database): void {
+  // Role-level backfill: any role that already has `settings.edit` gets
+  // `logs.view`.
+  const roleResult = db.run(
+    `INSERT OR IGNORE INTO role_permissions (role_id, permission)
+     SELECT DISTINCT role_id, 'logs.view'
+     FROM role_permissions
+     WHERE permission = 'settings.edit'`,
+  )
+
+  // User-level backfill: any user with an explicit `settings.edit` override
+  // gets `logs.view`. Role-derived perms are handled above.
+  const userResult = db.run(
+    `INSERT OR IGNORE INTO user_permissions (user_id, permission)
+     SELECT DISTINCT user_id, 'logs.view'
+     FROM user_permissions
+     WHERE permission = 'settings.edit'`,
+  )
+
+  if (roleResult.changes === 0 && userResult.changes === 0) {
+    log('debug', 'logs.view already present everywhere — nothing to do.')
+    return
+  }
+
+  log(
+    'info',
+    `Backfilled logs.view — ${roleResult.changes} role grant(s), ${userResult.changes} user grant(s).`,
+  )
+}

--- a/app/apps/server/src/db/migrations/index.ts
+++ b/app/apps/server/src/db/migrations/index.ts
@@ -3,6 +3,7 @@ import type { BunSQLiteDatabase } from 'drizzle-orm/bun-sqlite'
 
 import { addCloseOnEscape } from './add-close-on-escape'
 import { addLastPresentedAt } from './add-last-presented-at'
+import { addLogsPermissions } from './add-logs-permissions'
 import { addPreviewScreen } from './add-preview-screen'
 import { addSongGroups } from './add-song-groups'
 import { addSongVersionsPermissions } from './add-song-versions-permissions'
@@ -166,6 +167,16 @@ export function runMigrations(
     'add_song_versions_permissions',
     'Running add song_versions permissions migration',
     () => addSongVersionsPermissions(rawDb),
+  )
+
+  // Backfill the new logs.view permission onto roles + users that already had
+  // settings.edit, so settings editors keep the log access they had via the
+  // Developer settings before the dedicated Logs section existed. Must run
+  // after seedSystemRoles so the admin role already has logs.* from the seed.
+  runStep(
+    'add_logs_permissions',
+    'Running add logs permissions migration',
+    () => addLogsPermissions(rawDb),
   )
 
   // Add screen behavior columns BEFORE seeding default screens so the seed can

--- a/app/apps/server/src/db/migrations/index.ts
+++ b/app/apps/server/src/db/migrations/index.ts
@@ -1,6 +1,7 @@
 import { join } from 'node:path'
 import type { BunSQLiteDatabase } from 'drizzle-orm/bun-sqlite'
 
+import { addCategoryHiddenFlag } from './add-category-hidden-flag'
 import { addCloseOnEscape } from './add-close-on-escape'
 import { addLastPresentedAt } from './add-last-presented-at'
 import { addLogsPermissions } from './add-logs-permissions'
@@ -190,6 +191,14 @@ export function runMigrations(
   // preview panel. Defaults the main (first primary) screen on existing DBs.
   runStep('add_preview_screen', 'Running add is_preview_screen migration', () =>
     addPreviewScreen(rawDb),
+  )
+
+  // is_hidden on song_categories: lets an admin hide a category (and its songs)
+  // from the song browser without deleting anything.
+  runStep(
+    'add_category_hidden_flag',
+    'Running add category is_hidden migration',
+    () => addCategoryHiddenFlag(rawDb),
   )
 
   // Seed default screens

--- a/app/apps/server/src/db/migrations/seed.ts
+++ b/app/apps/server/src/db/migrations/seed.ts
@@ -49,6 +49,9 @@ const ALL_PERMISSIONS = [
   'users.create',
   'users.edit',
   'users.delete',
+  // Application logs — view the local log files / clear them.
+  'logs.view',
+  'logs.clear',
 ]
 
 const ROLE_TEMPLATES: Record<string, string[]> = {

--- a/app/apps/server/src/db/schema/presentation.ts
+++ b/app/apps/server/src/db/schema/presentation.ts
@@ -15,6 +15,7 @@ export const screenTypes = ['primary', 'stage', 'livestream', 'kiosk'] as const
 // Content types that can be rendered on screens
 export const contentTypes = [
   'song',
+  'song_first_slide',
   'bible',
   'bible_passage',
   'announcement',

--- a/app/apps/server/src/db/schema/presentation.ts
+++ b/app/apps/server/src/db/schema/presentation.ts
@@ -16,6 +16,7 @@ export const screenTypes = ['primary', 'stage', 'livestream', 'kiosk'] as const
 export const contentTypes = [
   'song',
   'song_first_slide',
+  'song_last_slide',
   'bible',
   'bible_passage',
   'announcement',

--- a/app/apps/server/src/db/schema/songs.ts
+++ b/app/apps/server/src/db/schema/songs.ts
@@ -14,6 +14,9 @@ export const songCategories = sqliteTable(
     id: integer('id').primaryKey({ autoIncrement: true }),
     name: text('name').notNull().unique(),
     priority: integer('priority').notNull().default(1),
+    // 1 = hidden: the category and its songs are dropped from the song browser
+    // (filters + list + search) but kept in the DB so it can be re-shown.
+    isHidden: integer('is_hidden').notNull().default(0),
     createdAt: integer('created_at', { mode: 'timestamp' })
       .notNull()
       .default(sql`(unixepoch())`),

--- a/app/apps/server/src/index.ts
+++ b/app/apps/server/src/index.ts
@@ -5897,9 +5897,12 @@ async function startRealServer(): Promise<void> {
             )
           }
 
-          // Re-index songs when updating category name
+          // Re-index songs when updating category name, and drop the search
+          // results cache — its key doesn't encode category name or hidden
+          // state, so a stale entry could otherwise resurface a hidden song.
           if (body.id) {
             updateSearchIndexByCategory(body.id)
+            clearSearchCache()
           }
 
           return handleCors(

--- a/app/apps/server/src/index.ts
+++ b/app/apps/server/src/index.ts
@@ -290,6 +290,7 @@ import {
   getAllSongs,
   getAllSongsWithSlides,
   getAllTags,
+  getCategoryById,
   getGroupForSong,
   getSimilarSongs,
   getSongGroupWithMembers,
@@ -5882,6 +5883,10 @@ async function startRealServer(): Promise<void> {
             )
           }
 
+          // Capture the current name BEFORE updating so we only pay for the
+          // (expensive) FTS re-index when the name actually changes.
+          const previousName = body.id ? getCategoryById(body.id)?.name : null
+
           const category = upsertCategory(body)
 
           if (!category) {
@@ -5897,11 +5902,15 @@ async function startRealServer(): Promise<void> {
             )
           }
 
-          // Re-index songs when updating category name, and drop the search
-          // results cache — its key doesn't encode category name or hidden
-          // state, so a stale entry could otherwise resurface a hidden song.
+          // Re-index songs ONLY when the category name actually changed (the
+          // FTS index stores category_name). A hide/show toggle leaves names
+          // and content untouched, so we skip the costly per-song re-index and
+          // just drop the search results cache (its key encodes neither the
+          // category name nor the hidden state).
           if (body.id) {
-            updateSearchIndexByCategory(body.id)
+            if (previousName != null && category.name !== previousName) {
+              updateSearchIndexByCategory(body.id)
+            }
             clearSearchCache()
           }
 

--- a/app/apps/server/src/index.ts
+++ b/app/apps/server/src/index.ts
@@ -57,7 +57,7 @@ if (process.argv.includes('--probe-midi')) {
   }
 }
 
-import { logToFile } from './utils/fileLogger'
+import { authLogger, logToFile } from './utils/fileLogger'
 // PostHog client (errors + events) — initialised on import.
 import {
   captureAppStarted,
@@ -161,7 +161,7 @@ import {
   initializeOBSAutoConnect,
   initializeOBSCallbacks,
 } from './service/livestream/obs'
-import { openLogsFolder, readRecentLogs } from './service/logs'
+import { clearLogs, openLogsFolder, readRecentLogs } from './service/logs'
 import {
   initializeMIDI,
   setAllLEDs,
@@ -825,6 +825,19 @@ async function startRealServer(): Promise<void> {
     )
     res.headers.set('Access-Control-Allow-Credentials', 'true')
     res.headers.set('Access-Control-Max-Age', '86400')
+
+    // Persist every failed response (4xx/5xx) to the on-disk log so the Logs
+    // viewer and bug reports surface what went wrong (permission denials,
+    // validation errors, server crashes) — not just unhandled exceptions.
+    if (res.status >= 400) {
+      const { pathname } = new URL(req.url)
+      logToFile(
+        'http',
+        res.status >= 500 ? 'error' : 'warn',
+        `${req.method} ${pathname} → ${res.status}`,
+      )
+    }
+
     return res
   }
 
@@ -1016,6 +1029,10 @@ async function startRealServer(): Promise<void> {
             isLocalhost(req),
           )
           if (!result) {
+            authLogger.warn('Login failed: invalid credentials', {
+              userId: body.userId,
+              localhost: isLocalhost(req),
+            })
             return handleCors(
               req,
               new Response(JSON.stringify({ error: 'Invalid credentials' }), {
@@ -1036,6 +1053,12 @@ async function startRealServer(): Promise<void> {
                   : user.permissions,
               }
             : null
+
+          authLogger.info('Login success', {
+            userId: user?.id ?? body.userId,
+            userName: user?.name,
+            localhost: isLocalhost(req),
+          })
 
           // Also issue a one-time ticket so the client can finalize the switch
           // via a top-level navigation (reliable cookie overwrite on desktop).
@@ -1082,6 +1105,7 @@ async function startRealServer(): Promise<void> {
         if (!token) {
           // Expired/invalid ticket — just go back to the app (still signed in
           // as whoever the current cookie is).
+          authLogger.warn('Account switch failed: expired/invalid ticket')
           return handleCors(
             req,
             new Response(null, {
@@ -1090,6 +1114,12 @@ async function startRealServer(): Promise<void> {
             }),
           )
         }
+
+        const switchedUser = await getUserByToken(token)
+        authLogger.info('Account switch', {
+          userId: switchedUser?.id ?? null,
+          userName: switchedUser?.name ?? null,
+        })
 
         return handleCors(
           req,
@@ -1105,6 +1135,16 @@ async function startRealServer(): Promise<void> {
 
       // POST /api/auth/logout - clear the auth cookie
       if (req.method === 'POST' && url.pathname === '/api/auth/logout') {
+        // Resolve who is logging out (from the current cookie) before clearing,
+        // so the auth trail records the user.
+        const logoutAuth = await combinedAuthMiddleware(req)
+        const logoutUser = logoutAuth.context?.userId
+          ? getUserById(logoutAuth.context.userId)
+          : null
+        authLogger.info('Logout', {
+          userId: logoutUser?.id ?? null,
+          userName: logoutUser?.name ?? null,
+        })
         return handleCors(
           req,
           new Response(JSON.stringify({ data: { success: true } }), {
@@ -1257,6 +1297,54 @@ async function startRealServer(): Promise<void> {
                 headers: { 'Content-Type': 'application/json' },
               },
             ),
+          )
+        }
+      }
+
+      // POST /api/client-activity (PUBLIC) — ingest client-side user activity
+      // (navigation, login/logout clicks, key actions) into the SAME on-disk
+      // log under the `activity` category, so the Logs viewer shows what the
+      // operator did leading up to an error. Public + pre-auth on purpose:
+      // activity (e.g. the login screen) happens before a session exists.
+      if (req.method === 'POST' && url.pathname === '/api/client-activity') {
+        try {
+          const body = (await req.json()) as {
+            events?: Array<{
+              action?: string
+              message?: string
+              source?: string
+              context?: Record<string, unknown>
+            }>
+          }
+          const events = Array.isArray(body?.events)
+            ? body.events.slice(0, 100)
+            : []
+          const trunc = (s: unknown, max: number): string =>
+            typeof s === 'string' ? s.slice(0, max) : ''
+          for (const e of events) {
+            const action = trunc(e?.action, 200) || 'action'
+            const message = trunc(e?.message, 2000) || action
+            const data = {
+              action,
+              client_source: trunc(e?.source, 200) || undefined,
+              ...(e?.context ?? {}),
+            }
+            logToFile('activity', 'info', message, data)
+          }
+          return handleCors(
+            req,
+            new Response(
+              JSON.stringify({ data: { received: events.length } }),
+              { headers: { 'Content-Type': 'application/json' } },
+            ),
+          )
+        } catch {
+          return handleCors(
+            req,
+            new Response(JSON.stringify({ error: 'Invalid activity body' }), {
+              status: 400,
+              headers: { 'Content-Type': 'application/json' },
+            }),
           )
         }
       }
@@ -2262,6 +2350,53 @@ async function startRealServer(): Promise<void> {
         return handleCors(
           req,
           new Response(JSON.stringify({ data: { path: getLogsDir() } }), {
+            headers: { 'Content-Type': 'application/json' },
+          }),
+        )
+      }
+
+      // GET /api/logs/content - Read the recent server + Tauri log tails for the
+      // in-app Logs viewer. Gated by logs.view (permission-based, so a granted
+      // remote operator can view them too).
+      if (req.method === 'GET' && url.pathname === '/api/logs/content') {
+        const permError = checkPermission('logs.view')
+        if (permError) return permError
+
+        // Viewer-friendly caps, clamped so a crafted query can't read the whole
+        // disk into memory.
+        const daysParam = Number(url.searchParams.get('days'))
+        const bytesParam = Number(url.searchParams.get('maxBytes'))
+        const daysBack =
+          Number.isFinite(daysParam) && daysParam > 0
+            ? Math.min(Math.floor(daysParam), 14)
+            : 3
+        const maxBytes =
+          Number.isFinite(bytesParam) && bytesParam > 0
+            ? Math.min(Math.floor(bytesParam), 1024 * 1024)
+            : 256 * 1024
+
+        const logs = await readRecentLogs(maxBytes, daysBack)
+        return handleCors(
+          req,
+          new Response(JSON.stringify({ data: logs }), {
+            headers: { 'Content-Type': 'application/json' },
+          }),
+        )
+      }
+
+      // POST /api/logs/clear - Empty all local log files. Gated by logs.clear.
+      if (req.method === 'POST' && url.pathname === '/api/logs/clear') {
+        const permError = checkPermission('logs.clear')
+        if (permError) return permError
+
+        const result = clearLogs()
+        authLogger.info('Logs cleared', {
+          cleared: result.cleared,
+          by: _context?.userId ?? null,
+        })
+        return handleCors(
+          req,
+          new Response(JSON.stringify({ data: result }), {
             headers: { 'Content-Type': 'application/json' },
           }),
         )

--- a/app/apps/server/src/index.ts
+++ b/app/apps/server/src/index.ts
@@ -822,7 +822,7 @@ async function startRealServer(): Promise<void> {
     // Must explicitly list all allowed headers
     res.headers.set(
       'Access-Control-Allow-Headers',
-      'Content-Type, Authorization, Cookie, Accept, Origin, X-Requested-With, Cache-Control, Pragma',
+      'Content-Type, Authorization, Cookie, X-User-Auth, Accept, Origin, X-Requested-With, Cache-Control, Pragma',
     )
     res.headers.set('Access-Control-Allow-Credentials', 'true')
     res.headers.set('Access-Control-Max-Age', '86400')
@@ -1065,9 +1065,16 @@ async function startRealServer(): Promise<void> {
           // via a top-level navigation (reliable cookie overwrite on desktop).
           const ticket = createLoginTicket(result.token)
 
+          // On localhost (the packaged desktop app) the cross-site `Secure`
+          // cookie can't be stored by macOS WKWebView, so also return the token
+          // in the body; the desktop client persists it and sends it back as an
+          // `X-User-Auth` header. Remote/LAN clients (same-origin cookie works)
+          // never receive it.
+          const token = isLocalhost(req) ? result.token : undefined
+
           return handleCors(
             req,
-            new Response(JSON.stringify({ data: currentUser, ticket }), {
+            new Response(JSON.stringify({ data: currentUser, ticket, token }), {
               headers: {
                 'Content-Type': 'application/json',
                 'Set-Cookie': buildAuthCookie(result.token, 31536000),

--- a/app/apps/server/src/middleware/auth.ts
+++ b/app/apps/server/src/middleware/auth.ts
@@ -134,10 +134,15 @@ export async function authMiddleware(req: Request): Promise<AuthResult> {
     logger.info('Invalid system token provided')
   }
 
-  // 2. user_auth cookie — resolve the logged-in user
+  // 2. user_auth — resolve the logged-in user. Normally carried by the
+  //    `user_auth` cookie, but the packaged desktop app on macOS (WKWebView)
+  //    can't store the cross-site `Secure` cookie over http://localhost, so the
+  //    client sends the same token in an `X-User-Auth` header instead. Accept
+  //    either.
   const cookieHeader = req.headers.get('Cookie') || ''
   const cookies = parseCookies(cookieHeader)
-  const userToken = cookies['user_auth']
+  const userToken =
+    cookies['user_auth'] || req.headers.get('X-User-Auth') || undefined
 
   if (userToken) {
     const user = await getUserByToken(userToken)

--- a/app/apps/server/src/openapi/paths/logs.ts
+++ b/app/apps/server/src/openapi/paths/logs.ts
@@ -98,6 +98,59 @@ export const logsPaths = {
       },
     },
   },
+  '/api/client-activity': {
+    post: {
+      tags: ['Logs'],
+      summary: 'Ingest client-side user activity into the local log',
+      description:
+        'Accepts a batch of user activity events (navigation, login/logout, key actions) and writes them to the on-disk log under the `activity` category, so the Logs viewer shows what the operator did. Public and pre-auth on purpose. At most 100 events per request; fields are truncated.',
+      requestBody: {
+        required: true,
+        content: {
+          'application/json': {
+            schema: {
+              type: 'object',
+              required: ['events'],
+              properties: {
+                events: {
+                  type: 'array',
+                  maxItems: 100,
+                  items: {
+                    type: 'object',
+                    properties: {
+                      action: { type: 'string' },
+                      message: { type: 'string' },
+                      source: { type: 'string' },
+                      context: { type: 'object', additionalProperties: true },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      responses: {
+        '200': {
+          description: 'Activity recorded',
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                properties: {
+                  data: {
+                    type: 'object',
+                    properties: { received: { type: 'integer' } },
+                  },
+                },
+              },
+            },
+          },
+        },
+        '400': { description: 'Invalid activity body' },
+      },
+    },
+  },
   '/api/logs/path': {
     get: {
       tags: ['Logs'],
@@ -123,6 +176,92 @@ export const logsPaths = {
             },
           },
         },
+      },
+    },
+  },
+  '/api/logs/content': {
+    get: {
+      tags: ['Logs'],
+      summary: 'Read recent application logs',
+      description:
+        'Returns the tail of the recent server and Tauri log files for the in-app Logs viewer. Requires the `logs.view` permission.',
+      parameters: [
+        {
+          name: 'days',
+          in: 'query',
+          required: false,
+          schema: { type: 'integer', minimum: 1, maximum: 14, default: 3 },
+          description: 'How many days back to include (clamped to 1–14).',
+        },
+        {
+          name: 'maxBytes',
+          in: 'query',
+          required: false,
+          schema: {
+            type: 'integer',
+            minimum: 1,
+            maximum: 1048576,
+            default: 262144,
+          },
+          description:
+            'Maximum bytes read per file per day (clamped to ≤ 1 MiB).',
+        },
+      ],
+      responses: {
+        '200': {
+          description: 'Recent log tails',
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                properties: {
+                  data: {
+                    type: 'object',
+                    properties: {
+                      serverTail: { type: 'string' },
+                      tauriTail: { type: 'string' },
+                      logsDir: { type: 'string' },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        '403': { description: 'Missing logs.view permission' },
+      },
+    },
+  },
+  '/api/logs/clear': {
+    post: {
+      tags: ['Logs'],
+      summary: 'Clear application logs',
+      description:
+        'Empties every local `.log` file (server + Tauri daily logs). Requires the `logs.clear` permission.',
+      responses: {
+        '200': {
+          description: 'Logs cleared',
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                properties: {
+                  data: {
+                    type: 'object',
+                    properties: {
+                      cleared: {
+                        type: 'integer',
+                        description: 'Number of log files emptied',
+                      },
+                      logsDir: { type: 'string' },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        '403': { description: 'Missing logs.clear permission' },
       },
     },
   },

--- a/app/apps/server/src/openapi/schemas/screens.ts
+++ b/app/apps/server/src/openapi/schemas/screens.ts
@@ -10,6 +10,7 @@ export const screenSchemas = {
     enum: [
       'song',
       'song_first_slide',
+      'song_last_slide',
       'bible',
       'bible_passage',
       'announcement',

--- a/app/apps/server/src/openapi/schemas/screens.ts
+++ b/app/apps/server/src/openapi/schemas/screens.ts
@@ -9,6 +9,7 @@ export const screenSchemas = {
     type: 'string',
     enum: [
       'song',
+      'song_first_slide',
       'bible',
       'bible_passage',
       'announcement',

--- a/app/apps/server/src/service/livestream/obs/scene-automation.ts
+++ b/app/apps/server/src/service/livestream/obs/scene-automation.ts
@@ -94,9 +94,15 @@ export function getSceneForContentType(
   const db = getDatabase()
   const scenes = db.select().from(obsScenes).orderBy(obsScenes.sortOrder).all()
 
+  // A song's first slide ("Gama - Strofă") is its own content type for screen
+  // layout purposes, but for OBS scene automation it is still a song slide —
+  // reuse whatever scene is configured for `song`.
+  const lookupType: ContentType =
+    contentType === 'song_first_slide' ? 'song' : contentType
+
   for (const scene of scenes) {
     const contentTypes = parseContentTypes(scene.contentTypes)
-    if (contentTypes.includes(contentType)) {
+    if (contentTypes.includes(lookupType)) {
       const currentScene = obsConnection.getCurrentScene()
       return {
         id: scene.id,

--- a/app/apps/server/src/service/livestream/obs/scene-automation.ts
+++ b/app/apps/server/src/service/livestream/obs/scene-automation.ts
@@ -94,15 +94,9 @@ export function getSceneForContentType(
   const db = getDatabase()
   const scenes = db.select().from(obsScenes).orderBy(obsScenes.sortOrder).all()
 
-  // A song's first slide ("Gama - Strofă") is its own content type for screen
-  // layout purposes, but for OBS scene automation it is still a song slide —
-  // reuse whatever scene is configured for `song`.
-  const lookupType: ContentType =
-    contentType === 'song_first_slide' ? 'song' : contentType
-
   for (const scene of scenes) {
     const contentTypes = parseContentTypes(scene.contentTypes)
-    if (contentTypes.includes(lookupType)) {
+    if (contentTypes.includes(contentType)) {
       const currentScene = obsConnection.getCurrentScene()
       return {
         id: scene.id,

--- a/app/apps/server/src/service/logs/clearLogs.ts
+++ b/app/apps/server/src/service/logs/clearLogs.ts
@@ -1,0 +1,40 @@
+import { existsSync, readdirSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+import { getLogsDir } from '../../utils/paths'
+
+export interface ClearLogsResult {
+  /** How many `.log` files were emptied. */
+  cleared: number
+  logsDir: string
+}
+
+/**
+ * Empties every `.log` file in the logs directory (server + tauri daily logs).
+ *
+ * Files are TRUNCATED rather than deleted: the file logger appends with
+ * `appendFileSync` (no held handle) so truncation is race-safe, keeps today's
+ * file path valid for continued logging, and avoids the cross-platform
+ * unlink-while-open hazards (e.g. the Tauri side keeps its daily log open on
+ * Windows). A file that is momentarily locked is skipped rather than failing
+ * the whole operation.
+ */
+export function clearLogs(): ClearLogsResult {
+  const dir = getLogsDir()
+  if (!existsSync(dir)) {
+    return { cleared: 0, logsDir: dir }
+  }
+
+  const files = readdirSync(dir).filter((name) => name.endsWith('.log'))
+  let cleared = 0
+  for (const name of files) {
+    try {
+      writeFileSync(join(dir, name), '')
+      cleared++
+    } catch {
+      // Skip files that can't be truncated right now (e.g. a transient lock).
+    }
+  }
+
+  return { cleared, logsDir: dir }
+}

--- a/app/apps/server/src/service/logs/index.ts
+++ b/app/apps/server/src/service/logs/index.ts
@@ -1,2 +1,3 @@
+export { type ClearLogsResult, clearLogs } from './clearLogs'
 export { openLogsFolder } from './openLogsFolder'
-export { readRecentLogs, type RecentLogs } from './readRecentLogs'
+export { type RecentLogs, readRecentLogs } from './readRecentLogs'

--- a/app/apps/server/src/service/presentation/screens.ts
+++ b/app/apps/server/src/service/presentation/screens.ts
@@ -170,6 +170,39 @@ function getDefaultSongConfig() {
   }
 }
 
+// Layout for a song's FIRST slide only ("Gama - Strofă"): two elements — the
+// song key (gama) and the slide lyrics (strofa) — positioned/styled separately
+// from the rest of the song's slides (which keep the `song` config). Defaults
+// mirror the `song` config so there is no visual jump until the operator
+// repositions them. Chord/keyline display stay on the `song` config (single
+// source), so this layout has no displayChords/displayKeyLine of its own.
+function getDefaultSongFirstSlideConfig() {
+  return {
+    background: getDefaultBackground(),
+    mainText: {
+      constraints: constraints(10, 5),
+      size: sizeWithUnits(90, 80),
+      style: getDefaultTextStyle({ maxFontSize: 120 }),
+      padding: 20,
+      animationIn: getDefaultAnimation('in'),
+      animationOut: getDefaultAnimation('out'),
+    },
+    songKey: {
+      constraints: constraints(2, 5),
+      size: sizeWithUnits(40, 6),
+      style: getDefaultTextStyle({
+        maxFontSize: 32,
+        autoScale: false,
+        alignment: 'left',
+        bold: true,
+      }),
+      animationIn: getDefaultAnimation('in'),
+      animationOut: getDefaultAnimation('out'),
+    },
+    clockEnabled: false,
+  }
+}
+
 function getDefaultBibleConfig() {
   return {
     background: getDefaultBackground(),
@@ -276,6 +309,8 @@ function getDefaultContentConfig(
   switch (contentType) {
     case 'song':
       return getDefaultSongConfig()
+    case 'song_first_slide':
+      return getDefaultSongFirstSlideConfig()
     case 'bible':
     case 'bible_passage':
       return getDefaultBibleConfig()

--- a/app/apps/server/src/service/presentation/screens.ts
+++ b/app/apps/server/src/service/presentation/screens.ts
@@ -170,7 +170,7 @@ function getDefaultSongConfig() {
   }
 }
 
-// Layout for a song's FIRST slide only ("Gama - Strofă"): two elements — the
+// Layout for a song's FIRST slide only ("Cântec - Primul Slide"): two elements — the
 // song key (gama) and the slide lyrics (strofa) — positioned/styled separately
 // from the rest of the song's slides (which keep the `song` config). Defaults
 // mirror the `song` config so there is no visual jump until the operator
@@ -203,7 +203,7 @@ function getDefaultSongFirstSlideConfig() {
   }
 }
 
-// Layout for a song's LAST slide only ("Strofă - Amin"): two elements — the
+// Layout for a song's LAST slide only ("Cântec - Ultimul Slide"): two elements — the
 // slide lyrics (strofa) and the "Amin" — positioned/styled separately from the
 // rest of the song's slides (which keep the `song` config). Defaults mirror the
 // `song` config so there is no visual jump until the operator repositions them.

--- a/app/apps/server/src/service/presentation/screens.ts
+++ b/app/apps/server/src/service/presentation/screens.ts
@@ -139,6 +139,33 @@ function getDefaultSongConfig() {
       animationIn: getDefaultAnimation('in'),
       animationOut: getDefaultAnimation('out'),
     },
+    // Song key ("gama") — shown on the FIRST slide. Separately positionable /
+    // styleable element (like the Bible reference). Top-left by default.
+    songKey: {
+      constraints: constraints(2, 5),
+      size: sizeWithUnits(40, 6),
+      style: getDefaultTextStyle({
+        maxFontSize: 32,
+        autoScale: false,
+        alignment: 'left',
+        bold: true,
+      }),
+      animationIn: getDefaultAnimation('in'),
+      animationOut: getDefaultAnimation('out'),
+    },
+    // "Amin" — shown on the LAST slide. Bottom band, centered, by default.
+    amen: {
+      constraints: constraints(85, 5),
+      size: sizeWithUnits(90, 10),
+      style: getDefaultTextStyle({
+        maxFontSize: 48,
+        autoScale: false,
+        alignment: 'center',
+        italic: true,
+      }),
+      animationIn: getDefaultAnimation('in'),
+      animationOut: getDefaultAnimation('out'),
+    },
     clockEnabled: false,
   }
 }

--- a/app/apps/server/src/service/presentation/screens.ts
+++ b/app/apps/server/src/service/presentation/screens.ts
@@ -203,6 +203,37 @@ function getDefaultSongFirstSlideConfig() {
   }
 }
 
+// Layout for a song's LAST slide only ("Strofă - Amin"): two elements — the
+// slide lyrics (strofa) and the "Amin" — positioned/styled separately from the
+// rest of the song's slides (which keep the `song` config). Defaults mirror the
+// `song` config so there is no visual jump until the operator repositions them.
+function getDefaultSongLastSlideConfig() {
+  return {
+    background: getDefaultBackground(),
+    mainText: {
+      constraints: constraints(10, 5),
+      size: sizeWithUnits(90, 80),
+      style: getDefaultTextStyle({ maxFontSize: 120 }),
+      padding: 20,
+      animationIn: getDefaultAnimation('in'),
+      animationOut: getDefaultAnimation('out'),
+    },
+    amen: {
+      constraints: constraints(85, 5),
+      size: sizeWithUnits(90, 10),
+      style: getDefaultTextStyle({
+        maxFontSize: 48,
+        autoScale: false,
+        alignment: 'center',
+        italic: true,
+      }),
+      animationIn: getDefaultAnimation('in'),
+      animationOut: getDefaultAnimation('out'),
+    },
+    clockEnabled: false,
+  }
+}
+
 function getDefaultBibleConfig() {
   return {
     background: getDefaultBackground(),
@@ -311,6 +342,8 @@ function getDefaultContentConfig(
       return getDefaultSongConfig()
     case 'song_first_slide':
       return getDefaultSongFirstSlideConfig()
+    case 'song_last_slide':
+      return getDefaultSongLastSlideConfig()
     case 'bible':
     case 'bible_passage':
       return getDefaultBibleConfig()

--- a/app/apps/server/src/service/presentation/types.ts
+++ b/app/apps/server/src/service/presentation/types.ts
@@ -368,6 +368,7 @@ export type ScreenType = 'primary' | 'stage' | 'livestream' | 'kiosk'
 export type ContentType =
   | 'song'
   | 'song_first_slide'
+  | 'song_last_slide'
   | 'bible'
   | 'bible_passage'
   | 'announcement'

--- a/app/apps/server/src/service/presentation/types.ts
+++ b/app/apps/server/src/service/presentation/types.ts
@@ -367,6 +367,7 @@ export type ScreenType = 'primary' | 'stage' | 'livestream' | 'kiosk'
  */
 export type ContentType =
   | 'song'
+  | 'song_first_slide'
   | 'bible'
   | 'bible_passage'
   | 'announcement'

--- a/app/apps/server/src/service/songs/categories.ts
+++ b/app/apps/server/src/service/songs/categories.ts
@@ -8,7 +8,6 @@ import type {
 } from './types'
 import { getDatabase, getRawDatabase } from '../../db'
 import { songCategories, songs } from '../../db/schema'
-
 import { createLogger } from '../../utils/logger'
 
 const logger = createLogger('song-categories')
@@ -25,6 +24,7 @@ function toCategory(
     name: record.name,
     priority: record.priority,
     songCount,
+    isHidden: record.isHidden,
     createdAt:
       record.createdAt instanceof Date
         ? Math.floor(record.createdAt.getTime() / 1000)
@@ -58,6 +58,25 @@ export function getAllCategories(): SongCategory[] {
     return records.map((r) => toCategory(r.category, r.songCount))
   } catch (error) {
     logger.error(`Failed to get all categories: ${error}`)
+    return []
+  }
+}
+
+/**
+ * Returns the IDs of all hidden categories. Used to exclude their songs from
+ * the song browser (list + search).
+ */
+export function getHiddenCategoryIds(): number[] {
+  try {
+    const db = getDatabase()
+    const rows = db
+      .select({ id: songCategories.id })
+      .from(songCategories)
+      .where(eq(songCategories.isHidden, 1))
+      .all()
+    return rows.map((r) => r.id)
+  } catch (error) {
+    logger.error(`Failed to get hidden category IDs: ${error}`)
     return []
   }
 }
@@ -115,6 +134,9 @@ export function upsertCategory(
       if (input.priority !== undefined) {
         setClauses.push(`priority = ${input.priority}`)
       }
+      if (input.isHidden !== undefined) {
+        setClauses.push(`is_hidden = ${input.isHidden ? 1 : 0}`)
+      }
 
       // Single efficient query: UPDATE with RETURNING + subquery for song count
       const result = rawDb
@@ -127,6 +149,7 @@ export function upsertCategory(
           id,
           name,
           priority,
+          is_hidden as isHidden,
           created_at as createdAt,
           updated_at as updatedAt,
           (SELECT COUNT(*) FROM songs WHERE category_id = ?) as songCount
@@ -137,6 +160,7 @@ export function upsertCategory(
             id: number
             name: string
             priority: number
+            isHidden: number
             createdAt: number
             updatedAt: number
             songCount: number
@@ -154,6 +178,7 @@ export function upsertCategory(
         name: result.name,
         priority: result.priority,
         songCount: result.songCount,
+        isHidden: result.isHidden,
         createdAt: result.createdAt,
         updatedAt: result.updatedAt,
       }

--- a/app/apps/server/src/service/songs/search.ts
+++ b/app/apps/server/src/service/songs/search.ts
@@ -1,3 +1,4 @@
+import { getHiddenCategoryIds } from './categories'
 import type { SongSearchResult } from './types'
 import { getRawDatabase } from '../../db'
 import { getSetting } from '../settings'
@@ -713,9 +714,7 @@ export function buildSearchQuery(
     clauses.push(`(title:"${titlePhraseTerms.join(' ')}")`)
   }
   clauses.push(`("${effectiveTerms.join(' ')}")`)
-  clauses.push(
-    `(NEAR(${effectiveTerms.map((t) => `"${t}"`).join(' ')}, 10))`,
-  )
+  clauses.push(`(NEAR(${effectiveTerms.map((t) => `"${t}"`).join(' ')}, 10))`)
   if (broadOrTerms.length > 0) {
     clauses.push(`(${broadOrTerms.map((t) => `"${t}"*`).join(' OR ')})`)
   }
@@ -991,9 +990,7 @@ function isMergeableGap(gap: string): boolean {
   const trimmed = gap.trim()
   if (trimmed === '') return true
   return (
-    trimmed.length <= 6 &&
-    trimmed.includes('-') &&
-    /^[\p{L}-]+$/u.test(trimmed)
+    trimmed.length <= 6 && trimmed.includes('-') && /^[\p{L}-]+$/u.test(trimmed)
   )
 }
 
@@ -1019,7 +1016,10 @@ function cleanQueryForHighlight(rawQuery: string): string {
  * single <mark>. Returns null otherwise so callers can fall back to per-
  * term highlighting.
  */
-function tryExactPhraseHighlight(text: string, rawQuery: string): string | null {
+function tryExactPhraseHighlight(
+  text: string,
+  rawQuery: string,
+): string | null {
   const cleaned = cleanQueryForHighlight(rawQuery)
   if (cleaned.length === 0) return null
   // removeDiacritics + toLowerCase preserve character count for the
@@ -1368,6 +1368,12 @@ export function searchSongs(
 
     const db = getRawDatabase()
 
+    // Songs in a hidden category must never surface in search. Exclude them
+    // from every result path below (hymn pre-phase + main phase).
+    const hiddenCategoryIds = new Set(getHiddenCategoryIds())
+    const isVisible = (r: { categoryId: number | null }): boolean =>
+      r.categoryId == null || !hiddenCategoryIds.has(r.categoryId)
+
     // Build extra filter conditions early for hymn number pre-phase
     const prePhaseExtraConditions: string[] = []
     const prePhaseCategoryParams: number[] = []
@@ -1404,7 +1410,6 @@ export function searchSongs(
     if (hymnRows && hymnRows.length > 0) {
       logger.debug(`Hymn number pre-phase: ${hymnRows.length} results`)
       const hymnFinalResults: SongSearchResult[] = hymnRows
-        .slice(0, limit)
         .map((r) => ({
           id: r.id,
           title: r.title,
@@ -1416,6 +1421,8 @@ export function searchSongs(
           presentationCount: r.presentation_count,
           score: 100,
         }))
+        .filter(isVisible)
+        .slice(0, limit)
       setInSearchCache(cacheKey, hymnFinalResults)
       return hymnFinalResults
     }
@@ -1634,10 +1641,7 @@ export function searchSongs(
       // Synonyms broaden FTS recall — they should not be appended to the
       // queryTerms used for phrase / order detection or the joined exact
       // phrase will never match a real title.
-      const titleScore = calculateTitleScoreNormalized(
-        r.fts_title,
-        validTerms,
-      )
+      const titleScore = calculateTitleScoreNormalized(r.fts_title, validTerms)
 
       const contentScore = calculateBestPhraseScoreNormalized(
         r.full_content,
@@ -1740,16 +1744,18 @@ export function searchSongs(
         score: Math.min(100, Math.round(r.boostedScore)),
       }
     })
+    // Drop any songs whose category is hidden.
+    const visibleResults = finalResults.filter(isVisible)
 
     // Cache results for future queries
-    setInSearchCache(cacheKey, finalResults)
+    setInSearchCache(cacheKey, visibleResults)
 
     const elapsed = performance.now() - startTime
     logger.debug(
-      `Search completed: "${query}" → ${finalResults.length} results in ${elapsed.toFixed(1)}ms`,
+      `Search completed: "${query}" → ${visibleResults.length} results in ${elapsed.toFixed(1)}ms`,
     )
 
-    return finalResults
+    return visibleResults
   } catch (error) {
     logger.error(`Failed to search songs with query "${query}": ${error}`)
     return []

--- a/app/apps/server/src/service/songs/song-groups.ts
+++ b/app/apps/server/src/service/songs/song-groups.ts
@@ -1,5 +1,6 @@
 import { eq, inArray, sql } from 'drizzle-orm'
 
+import { getHiddenCategoryIds } from './categories'
 import { searchSongs } from './search'
 import type {
   OperationResult,
@@ -822,6 +823,18 @@ export function getSimilarSongs(
         .where(eq(songs.songGroupId, subject.songGroupId))
         .all()
       for (const m of groupMembers) exclude.add(m.id)
+    }
+
+    // Never suggest songs from a hidden category — a hidden category is meant
+    // to disappear from the song browser AND from version "possible matches".
+    const hiddenCategoryIds = getHiddenCategoryIds()
+    if (hiddenCategoryIds.length > 0) {
+      const hiddenSongs = db
+        .select({ id: songs.id })
+        .from(songs)
+        .where(inArray(songs.categoryId, hiddenCategoryIds))
+        .all()
+      for (const s of hiddenSongs) exclude.add(s.id)
     }
 
     // Subject lyrics — needed for the lyrics-recall query AND the rerank.

--- a/app/apps/server/src/service/songs/songs.ts
+++ b/app/apps/server/src/service/songs/songs.ts
@@ -207,6 +207,13 @@ export function getSongsPaginated(
       conditions.push(`key_line IS NOT NULL AND key_line != ''`)
     }
 
+    // Always exclude songs whose category is hidden (uncategorized songs stay
+    // visible). Hiding a category removes its songs from the browser without
+    // deleting them.
+    conditions.push(
+      `(category_id IS NULL OR category_id NOT IN (SELECT id FROM song_categories WHERE is_hidden = 1))`,
+    )
+
     const whereClause =
       conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : ''
 

--- a/app/apps/server/src/service/songs/types.ts
+++ b/app/apps/server/src/service/songs/types.ts
@@ -13,6 +13,7 @@ export interface SongCategoryRecord {
   id: number
   name: string
   priority: number
+  is_hidden: number
   created_at: number
   updated_at: number
 }
@@ -65,6 +66,8 @@ export interface SongCategory {
   name: string
   priority: number
   songCount: number
+  /** 1 = hidden from the song browser (filters + list + search). */
+  isHidden: number
   createdAt: number
   updatedAt: number
 }
@@ -152,6 +155,8 @@ export interface UpsertCategoryInput {
   id?: number
   name: string
   priority?: number
+  /** 1 = hide the category (and its songs); 0 = show. */
+  isHidden?: number
 }
 
 /**

--- a/app/apps/server/src/service/users/types.ts
+++ b/app/apps/server/src/service/users/types.ts
@@ -55,6 +55,9 @@ export type Permission =
   // Song Key Configuration
   | 'song_key.view'
   | 'song_key.edit'
+  // Application Logs (view the local log files / clear them)
+  | 'logs.view'
+  | 'logs.clear'
 
 /**
  * All available permissions as an array
@@ -110,6 +113,9 @@ export const ALL_PERMISSIONS: Permission[] = [
   // Song Key Configuration
   'song_key.view',
   'song_key.edit',
+  // Application Logs
+  'logs.view',
+  'logs.clear',
 ]
 
 /**
@@ -153,6 +159,7 @@ export const PERMISSION_GROUPS = {
     'users.delete',
   ] as Permission[],
   song_key: ['song_key.view', 'song_key.edit'] as Permission[],
+  logs: ['logs.view', 'logs.clear'] as Permission[],
 } as const
 
 export type PermissionGroup = keyof typeof PERMISSION_GROUPS

--- a/app/apps/server/src/utils/fileLogger.ts
+++ b/app/apps/server/src/utils/fileLogger.ts
@@ -83,3 +83,13 @@ export const wsLogger = {
   error: (message: string, data?: unknown) =>
     log('websocket', 'error', message, data),
 }
+
+// Auth-specific logger (login / logout / account switch — who did what and
+// when, plus failed attempts). Persisted to the daily log so the Logs viewer
+// and bug reports show the authentication trail.
+export const authLogger = {
+  info: (message: string, data?: unknown) => log('auth', 'info', message, data),
+  warn: (message: string, data?: unknown) => log('auth', 'warn', message, data),
+  error: (message: string, data?: unknown) =>
+    log('auth', 'error', message, data),
+}


### PR DESCRIPTION
# Logs viewer & activity logging, permissions, song-category visibility, presenter-remote, desktop auth fix, and configurable song slide layouts

> **Scope (vs current `main`):** 22 commits · 81 files changed · **+3,743 / −159**
> **Branch:** `feat/logs-viewer-and-activity-logging` → `main`
> `origin/main` is merged in; the only conflict (`SongList.tsx`) was resolved by keeping **both** main's `ClearSearchButton` and this branch's hidden-category filtering.

---

### 1. Summary

This branch started as an in-app **Logs viewer + activity logging** effort and grew into a bundle of operator-facing improvements that ship together. It spans six themes:

1. **Observability** — an in-app Logs viewer (colorized, filterable, searchable) backed by richer activity logging, gated behind new `logs.view` / `logs.clear` permissions.
2. **Access control** — enforce the existing `songs.create` permission on the New Song action; backfill `logs.view` for existing settings-editors.
3. **Song-category visibility** — hide/show whole categories (and their songs) without deleting any data, applied instantly and consistently across browse / search / version-matching.
4. **Live presentation control** — first-class presenter-remote (clicker) support and a control-window focus fix when projecting.
5. **Desktop authentication** — fix multi-user login / switch-user on the packaged macOS build (WKWebView cross-site cookie problem).
6. **Song presentation layouts** — the song key (“gama”) and “Amin” become independent, positionable/styleable elements, with dedicated first-slide (“Gama - Strofă”) and last-slide (“Strofă - Amin”) layouts, smart fallbacks, a transition fix, trailing-amin extraction, and a configurable Amin label.

Each theme is independently revertable by commit; they’re grouped here for a single review pass.

---

### 2. Why

#### 2.1 No in-app visibility into what the app was doing
- **Before:** logs lived only on disk; the only in-app access was via the `settings.edit`-gated Developer settings, raw and unfiltered.
- **Why it’s a problem:** church operators are non-technical, on-site, mid-service. “Open the log folder on macOS vs Windows” is not a viable support path. There was also no record of *user actions* (who logged in, who switched account, who triggered what), so post-incident triage was guesswork.
- **Affected flow:** Settings → (nothing useful) → give up / call the developer.

#### 2.2 Logs and song-creation weren’t access-controlled
- **Before:** anyone who could open settings could read logs; the **New Song** button was always visible regardless of permission.
- **Why it’s a problem:** logs can carry operationally sensitive context, and clearing them is destructive. A volunteer with a restricted role could still see the New Song button (even if the API rejected the write, the UI implied capability).

#### 2.3 Categories could only be deleted, not hidden
- **Before:** to remove a seasonal/eparchial category from the browser you had to delete it — which risked its songs.
- **Example:** a “Crăciun” (Christmas) category is irrelevant in July. Deleting it to declutter the picker endangered its songs; keeping it cluttered the UI and polluted version “possible matches”. Earlier hide attempts also lagged before the slashed-eye state appeared, and hidden songs still surfaced in search and in “possible matches”.
- **Affected flow:** the songs browser, song search, and the version-matching dialog all showed content the operator intended to hide.

#### 2.4 Presenter remotes weren’t first-class; projecting stole focus
- **Before:** there was no defined behavior for a presenter remote (Logitech-style clicker). Separately, when projecting, focus jumped to the projector-screen window, so the next clicker press acted on the wrong window.
- **Why it’s a problem:** most churches drive the projector with a clicker from the stage. If focus is on the projector window (which the operator can’t see), navigation breaks. Forward-past-last / back-at-first / black-button semantics need to be deterministic during a live service.

#### 2.5 Multi-user login / switch-user broke on macOS (worked on Windows)
- **Before:** with multiple users, selecting a user from the picker, and the switch-user button, did nothing on the **packaged macOS** build. Windows worked.
- **Root cause:** the session cookie is `SameSite=None; Secure` so it can round-trip cross-site (UI on `tauri.localhost`, sidecar on `localhost`). **macOS WKWebView does not treat plain-http `localhost` as a secure context**, so it silently refuses to store the `Secure` cookie set by `POST /api/auth/login`; the follow-up `GET /api/auth/me` is then unauthenticated and the picker just re-renders. **Windows WebView2 (Chromium)** treats `localhost` as secure, stores the cookie, and works. The single-user auto-login shared the same dropped-cookie failure; it just *looked* like a stuck spinner.

#### 2.6 Song key / Amin were baked into slide HTML; first/last slides had no distinct layout
- **Before:** the song key and the trailing “Amin!” were injected into the slide’s HTML text, so they couldn’t be positioned, styled, animated, or laid out per slide (unlike the Bible reference/verse pair). A trailing “amin” line in the lyrics rendered as plain text, and the “Amin!” label was hard-coded.

---

### 3. What changed

#### Bug fixes
| Area | Commit | Change |
|---|---|---|
| Auth (desktop) | `7658e22e`, `bcb81860` | Login/switch/logout no longer rely on a top-level navigation or a WKWebView-stored cookie; desktop also authenticates via an `X-User-Auth` header. |
| Presentation focus | `abe03ccc`, `171f87b4` | Control window keeps focus on the program slide; focus is only reclaimed when a second monitor is present. |
| Song layouts | `1c0686f7` | First/last layouts only apply when the gama/amin is actually present; removed a ~2s intermediate “first-slide” flash on slide advance. |
| Song layouts | `80e2d676` | A standalone trailing “amin” line is moved out of the lyrics into the Amin element (no duplication). |

#### Backend
- **Logs service** (`server/src/service/logs/`): `readRecentLogs`, `clearLogs`, `openLogsFolder`; two new endpoints wired in `index.ts`.
- **Activity logging** (`index.ts`): structured `authLogger.info` events for **Login success**, **Account switch**, **Logout**, **Logs cleared**, plus user navigation/click actions routed into the same on-disk log; warnings/errors (incl. 4xx/5xx responses) are persisted too.
- **Auth middleware** (`middleware/auth.ts`): resolves the user from the `user_auth` cookie **or** an `X-User-Auth` header (desktop fallback). Cookie attributes are now **engine-aware** (`buildUserAuthCookie`) after merging `main` — see §3 *Auth reconciliation*.
- **Songs categories** (`service/songs/categories.ts`, `search.ts`, `song-groups.ts`, `songs.ts`): `is_hidden` flag, `getHiddenCategoryIds()`, and filtering applied in song listing, search, and version “possible matches”.
- **Content types** (`service/presentation/screens.ts`, `db/schema/presentation.ts`, `openapi/schemas/screens.ts`): `song_first_slide` / `song_last_slide` with default configs and the `getDefaultContentConfig` switch.

#### Frontend
- **Logs feature** (`features/logs/`): `LogsViewer`, `LogsPanel`, `ClearLogs`, `useLogsContent`, `parseLogLines` (colorized by level), level-filter chips, full-width search; settings route `routes/settings/logs.tsx`.
- **Auth components** (`features/auth/components/`): login/switch/logout refresh the permissions context instead of navigating; desktop persists/clears the user token.
- **Presenter remote** (`hooks/useKeyboardShortcuts.ts`, `features/songs/hooks/useSongSlideSelectionKeyboard.ts`): start-from-focused, next/prev, forward-past-last closes, back-at-first stops, black = Escape (only while live).
- **Song-category UI** (`features/songs/components/CategoryManager/`): instant hide/show toggle; `SongList.tsx` renders `visibleCategories`.
- **Screen editor** (`screen-editor/`): two new content-type tabs, draggable gama/amin elements gated per tab, and a **Custom Text** field that persists the Amin label.
- **Presentation rendering** (`rendering/ScreenContent.tsx`, `hooks/usePresentationContent.ts`, `utils/songElements.ts`): per-slide layout selection, value-gated element mounting, single-source chord settings, custom-amin threading.

#### Naming changes
- `0f75e17f` renames the editor tab labels to the agreed wording. **No data-model rename** — the stored content-type keys (`song_first_slide` / `song_last_slide`) are unchanged, so this is label-only and backward compatible.

#### Auth reconciliation (after merging `main`)
`main` independently fixed the same macOS bug at the cookie layer: `buildUserAuthCookie` is **engine-aware** — WebKit (WKWebView/Safari) gets `SameSite=None` **without** `Secure` (which WebKit drops over http), Chromium gets `None; Secure`. After the merge, that is the **primary** fix; this branch’s **`X-User-Auth` header path is retained as a fallback** (the inline `buildAuthCookie` is now a thin wrapper over `buildUserAuthCookie`). Belt-and-suspenders; no behavior regression.

#### Backward compatibility
- New screen-config keys (`song_first_slide`, `song_last_slide`, `amen.text`, `songKey`/`amen` elements) are **merged on read** from defaults, so existing screens gain them transparently with zero migration.
- `amen.text` defaults to unset → existing screens keep the prior “Amin!” / extracted-line behavior.
- The desktop token path is gated to Tauri-desktop; **browser, LAN, and mobile auth paths are unchanged**.

---

### 4. Technical details

| Kind | Name | Purpose |
|---|---|---|
| Endpoint | `GET /api/logs/content` | Returns recent server + Tauri log tails. Gated by `logs.view`. |
| Endpoint | `POST /api/logs/clear` | Empties local log files. Gated by `logs.clear`. |
| Service | `service/logs/{index,clearLogs}.ts` | Read/clear/open log files cross-platform. |
| Helper (server) | `buildUserAuthCookie(req, token, maxAge)` | Engine-aware Set-Cookie builder (WebKit vs Chromium). |
| Middleware | `authMiddleware` + `X-User-Auth` fallback | Resolve user from cookie or header. |
| Helper (server) | `getHiddenCategoryIds()` | Single source for excluding hidden categories from list/search/matching. |
| Helper (client) | `resolveSongSlideContentType(isFirst, isLast, hasKey, hasAmin)` | Picks `song_first_slide` / `song_last_slide` / `song` per slide. |
| Helper (client) | `resolveSongSlideBody(isLast, html, customAmin?)` | Strips a trailing amin line, returns `{ mainText, amen }`, applies the custom label. |
| Helper (client) | `extractTrailingAmin(html)` | Detects/removes a standalone trailing “amin” paragraph (or `<br>`-line). |
| Helper (client) | `getStoredUserToken` / `setStoredUserToken` / `clearStoredUserToken` | Desktop token persistence for `X-User-Auth`. |
| Hook | `useLogsContent` | Polls and parses log content for the viewer. |
| Hook | `useKeyboardShortcuts`, `useSongSlideSelectionKeyboard` | Presenter-remote navigation. |
| Component | `LogsViewer` / `LogsPanel` / `ClearLogs` | Colorized, filterable, searchable logs UI. |
| Content types | `song_first_slide`, `song_last_slide` | First/last-slide layouts, wired end-to-end (types, DB enum, OpenAPI, defaults). |

**Single-source decisions worth noting:**
- Chord display (`displayChords`/`chordFontSize`) and key-line display stay on the `song` config and are read from it for the first/last-slide layouts — toggled in one place.
- The runtime mounts the gama/amin elements **only when the slide has a value** (`contentData.songKey`/`contentData.amen`), so navigating to a slide without them unmounts cleanly (the fix for the ~2s flash) while screen-hide still fades them out.
- A single-slide song (first **and** last) falls back to the `song` config, which keeps both elements, so neither the gama nor the Amin is lost.
- Removed a dead, semantically-wrong content-type normalization from the OBS `getSceneForContentType` (it only ever receives OBS content types).

---

### 5. API changes

#### New endpoints
```http
GET  /api/logs/content     # requires logs.view  → { data: { server, tauri } }
POST /api/logs/clear       # requires logs.clear → { data: { success: true } }
```

#### Auth endpoints (modified)
```http
POST /api/auth/login
# On localhost the response now ALSO returns the user token so the desktop
# client can persist it and send it back as X-User-Auth:
{ "data": { ...currentUser }, "ticket": "<one-time>", "token": "usr_…" }

GET /api/auth/me
# Now authenticates from EITHER the `user_auth` cookie OR an `X-User-Auth`
# request header (desktop fallback).
```
- CORS `Access-Control-Allow-Headers` now includes `X-User-Auth`.
- `token` is returned **only** on localhost (the desktop/cross-site case); remote/LAN clients never receive it.

#### Screen config endpoints (new content types)
```http
PUT /api/screens/:id/config/song_first_slide   # requires displays.edit
PUT /api/screens/:id/config/song_last_slide    # requires displays.edit
# song_last_slide config supports `amen.text` (custom Amin label).
```

#### Permissions required
| Endpoint | Permission |
|---|---|
| `GET /api/logs/content` | `logs.view` |
| `POST /api/logs/clear` | `logs.clear` |
| `POST /api/songs` (create) | `songs.create` *(already existed; now also enforced in the UI)* |
| `PUT /api/screens/:id/config/*` | `displays.edit` |

---

### 6. Database changes

#### New column
| Table | Column | Type | Default | Constraint |
|---|---|---|---|---|
| `song_categories` | `is_hidden` | `INTEGER` | `0` | `NOT NULL` |

`integer('is_hidden').notNull().default(0)` — `1` = the category and its songs are dropped from the song browser.

#### Content-type enum (no schema migration)
`song_first_slide` and `song_last_slide` are added to the `contentTypes` list. `screen_content_configs.content_type` is a plain `TEXT` column with **no DB CHECK constraint**, so the new values store without a migration; configs are merged-on-read against defaults.

#### Permission rows (backfill, not schema)
`add-logs-permissions` inserts `logs.view` rows into `role_permissions` / `user_permissions` (see §9). No new tables, indexes, or foreign keys.

#### Rollback strategy
- `is_hidden`: additive, defaulted `0` (= visible). Rolling back the code leaves the column harmlessly unused; no data loss.
- Permission backfill: additive `INSERT OR IGNORE`. Feature rollback could `DELETE … WHERE permission IN ('logs.view','logs.clear')`, but leaving the rows is safe (the permission simply gates a section that no longer renders).

---

### 7. Permissions / Authorization

#### Permission catalog
| Permission | Status | Grants | Interacts with |
|---|---|---|---|
| `logs.view` | **New** | View the in-app Logs section + `GET /api/logs/content` | Backfilled for holders of `settings.edit` |
| `logs.clear` | **New** | Clear local logs + `POST /api/logs/clear` | **Not** backfilled — explicit grant only |
| `songs.create` | Existing *(3 refs on `main`)* | See & use **New Song**; create songs | Now enforced in the UI, not just the API |

`logs.view` and `logs.clear` are grouped under a `logs` permission group in the catalog (`service/users/types.ts`).

#### Backfill rationale
- `logs.view` is backfilled to everyone who already had `settings.edit`, because the logs folder was previously reachable from the `settings.edit`-gated Developer settings — this **preserves existing access** when logs move behind the dedicated permission.
- `logs.clear` is **deliberately not** backfilled — clearing logs is a new, destructive capability an admin grants explicitly.

#### Authorization matrix
| Role / grant | See Logs section | Clear logs | See New Song |
|---|---|---|---|
| Super-admin | ✅ | ✅ | ✅ |
| Had `settings.edit` (pre-existing) | ✅ (backfilled) | ❌ (until granted) | per `songs.create` |
| Custom role w/o `settings.edit` | ❌ | ❌ | per `songs.create` |
| User without `songs.create` | per `logs.view` | per `logs.clear` | ❌ (button hidden) |

---

### 8. UI / UX changes
- **Settings → Logs** (new): colorized viewer (error = red, warning = amber, info = default), level-filter chips arranged **below** a full-width search input, and a **Clear logs** action (gated by `logs.clear`). Hidden entirely without `logs.view`.
- **New Song** button: hidden for users without `songs.create` (was always visible).
- **Songs browser / search / version matching**: hidden-category songs no longer appear; the hide/show toggle in the Category Manager applies **instantly**.
- **Settings → Screens → Edit**: two new tabs — **“Gama - Strofă”** (first slide) and **“Strofă - Amin”** (last slide) — each with two independently draggable/styleable elements. The gama is editable only in the first-slide tab, the Amin only in the last-slide tab.
- **Custom Amin label**: selecting the Amin element shows a **Custom Text** field; the typed text is saved and drives **both** the editor preview and the projected output. Empty = default behavior.
- **Presenter remote**: deterministic next/prev/start/close + black-as-Escape (only while presenting).

---

### 9. Migration / Backfill strategy

Both migrations run on boot from `db/migrations/index.ts` and are **idempotent**.

#### `add-category-hidden-flag`
- **Does:** `ALTER TABLE song_categories ADD COLUMN is_hidden INTEGER NOT NULL DEFAULT 0`.
- **Safe because:** additive, defaulted to `0` (visible) → no behavior change for existing rows.
- **Idempotent because:** it first reads `PRAGMA table_info(song_categories)` and returns early if `is_hidden` already exists. Re-running is a no-op.

#### `add-logs-permissions`
- **Does:** `INSERT OR IGNORE` `logs.view` into `role_permissions`/`user_permissions` for every role/user that has `settings.edit`.
- **Safe because:** purely additive; preserves prior (settings.edit-derived) log access. `logs.clear` is intentionally excluded.
- **Idempotent because:** `INSERT OR IGNORE` against the unique `(role_id, permission)` / `(user_id, permission)` constraints — re-running inserts nothing and logs “nothing to do.”

> Running either migration again on every boot is expected and harmless.

---

### 10. Commit breakdown

#### Logs viewer & activity logging
- `372dc76b` feat(logs): in-app Logs settings viewer + permissions + richer activity logging
- `668e608c` feat(logs): colorize log viewer + level filters + search
- `8e0ad187` style(logs): full-width search with level filters arranged below it

#### Auth (desktop)
- `bcb81860` fix(auth): login/switch/logout via context refresh, not page navigation
- `7658e22e` fix(auth): authenticate desktop via X-User-Auth header (macOS multi-user login/switch)

#### Song categories
- `33999d7e` feat(songs): hide/show song categories without deleting them
- `6a40b383` perf(songs): make category hide/show instant
- `db1bbe93` feat(songs): exclude hidden-category songs from version possible-matches

#### Songs permission
- `e0d9a42e` feat(songs): gate the New Song button behind songs.create

#### Presenter remote
- `080b56fe` feat(presentation): presenter-remote (clicker) control
- `fd6a2e19` feat(presentation): presenter black button hides like Escape (only while live)

#### Presentation focus
- `abe03ccc` fix(presentation): keep control-window focus when a screen opens on present
- `171f87b4` fix(presentation): only reclaim control-window focus with a second monitor

#### Song slide elements & layouts
- `7b54736a` feat(screens): configurable song key (gama) + amen elements
- `0fb195b1` feat(screens): add “Gama - Strofă” (song_first_slide) first-slide layout
- `0389a91b` feat(screens): add “Strofă - Amin” (song_last_slide) last-slide layout
- `1c0686f7` fix(screens): song first/last layouts only when gama/amin present + no transition flash
- `80e2d676` fix(screens): move a last-slide trailing “amin” line into the amin element
- `0f75e17f` Change song first and last slide to correct words
- `218d2eb6` feat(screens): custom “Amin” text for the song last-slide layout

#### Tooling
- `7bf88a96` chore(skills): add detailed-pr skill for auto-generated PR descriptions

---

### 11. Test plan

#### Happy paths
- [ ] Settings → Logs renders; lines are colorized (error/warning/info); search + level filters work.
- [ ] Clear logs empties the view (as a user with `logs.clear`).
- [ ] Hide a category → its songs vanish from browse, search, and version “possible matches” **immediately**; show it again → they return.
- [ ] Project a song: first slide shows the gama, last slide shows the Amin; advancing is smooth with **no** intermediate flash.
- [ ] In “Strofă - Amin”, select the Amin element, type a custom label in **Custom Text**, save, project → the last slide shows the custom label.
- [ ] Presenter remote: from a focused program item, next starts; next/prev navigate; next past the last slide closes; black hides while live.

#### Edge cases
- [ ] Song with **no** key → first slide uses the normal `song` layout (strofa not shifted).
- [ ] Last slide with **no** amin (lyrics already say “amin” mid-line) → no separate Amin element.
- [ ] Song whose last line is a standalone “Amin” → it’s pulled into the Amin element, not duplicated.
- [ ] **Single-slide** song with both key and amin → both render.
- [ ] Custom Amin label overrides both the default “Amin!” and an extracted trailing amin; blank label falls back to default.

#### Regression
- [ ] Browser/dev login still works (cookie path unchanged).
- [ ] LAN client + mobile auth unchanged.
- [ ] Existing screens (created before this branch) gain the new layouts/elements via merge-on-read with no visual change.
- [ ] Search **clear (X) button** (from merged `main`) still works on the songs search input.

#### Permission matrix
- [ ] User **without** `logs.view`: Logs section hidden; `GET /api/logs/content` → 403.
- [ ] User **with** `logs.view` but **without** `logs.clear`: can read; Clear action / `POST /api/logs/clear` → 403.
- [ ] User **without** `songs.create`: New Song button hidden; `POST /api/songs` → 403.
- [ ] Pre-existing `settings.edit` holder: has `logs.view` after boot (backfill), but **not** `logs.clear`.

#### API validation
- [ ] `GET /api/logs/content` (authorized) → 200 with log tails.
- [ ] `POST /api/auth/login` on localhost returns `token`; on a remote host it does **not**.
- [ ] `GET /api/auth/me` authenticates from `X-User-Auth` header alone.
- [ ] `PUT /api/screens/:id/config/song_last_slide` with `amen.text` round-trips.

#### Database validation
- [ ] `PRAGMA table_info(song_categories)` shows `is_hidden INTEGER NOT NULL DEFAULT 0`.
- [ ] `role_permissions` / `user_permissions` contain `logs.view` for prior `settings.edit` holders; **no** `logs.clear` rows added.
- [ ] A `song_last_slide` config row persists `amen.text`.

#### Migration validation
- [ ] Boot on a fresh DB → both migrations run, app starts.
- [ ] Boot again → migrations report “nothing to do” (no duplicate rows, no error).

#### UI validation
- [ ] Logs: search is full-width; level chips below; reset works.
- [ ] Editor: gama only in the first-slide tab, Amin only in the last-slide tab; Custom Text field shows for the Amin element.

#### ⚠️ Packaged-build validation (cannot be reproduced in browser/e2e)
- [ ] **macOS packaged build, multiple users:** pick a user → logs in; **switch user** works; logout returns to the picker.
- [ ] **Windows packaged build:** same flows still work (regression check).

---

### 12. Risks

| Type | Risk | Mitigation |
|---|---|---|
| **Auth** | Desktop now stores the user token in `localStorage` (like mobile) and sends `X-User-Auth`. | Token already exposed for mobile pairing; packaged webview is controlled. Gated to Tauri-desktop. After merge, the engine-aware cookie is the primary fix — the header is a fallback. |
| **Auth** | WKWebView behavior can’t be reproduced by browser e2e. | Manual packaged-build smoke test required (see §11); browser/LAN/mobile paths unchanged. |
| **Permissions** | Backfilling `logs.view` widens who can read logs (to existing settings-editors). | Intentional — preserves prior access; `logs.clear` withheld. |
| **Data** | New `is_hidden` column / new config keys. | Additive + defaulted + merged-on-read; idempotent migrations; no destructive ops. |
| **UX** | Operators who customize the first/last-slide strofa position will see a transition between differing layouts. | Defaults mirror the `song` layout, so there’s no jump until they intentionally reposition. |
| **Performance** | Hidden-category filtering adds a predicate to song list/search. | Backed by a small `is_hidden` lookup; negligible. |

---

### 13. Out of scope
- **Removing the dead `LivePreviewRenderer` / `ContentRenderer`** — unused (already stale before this branch); a separate cleanup PR can delete them.
- **Serving the sidecar over HTTPS / same-origin (custom protocol/proxy)** — the desktop auth fix uses cookie attributes + a header instead.
- **Removing the now-redundant `X-User-Auth` path** — kept as a fallback after `main`’s engine-aware cookie fix; can be simplified later.
- **Log shipping / remote aggregation / retention** — the viewer reads local files only.
- **Configurable *gama* (song key) text** — the key is data-driven from the song; only the Amin label is customizable.
- **i18n beyond EN/RO** — new strings are added for English and Romanian only.
