### PR TITLE
fix(test): wait for the real server, not the boot 503, in api.test.ts

### DIFF
--- a/app/apps/server/src/__tests__/api.test.ts
+++ b/app/apps/server/src/__tests__/api.test.ts
@@ -44,13 +44,23 @@ async function waitForServer(url: string, maxAttempts = 360): Promise<void> {
     const controller = new AbortController()
     const timeoutId = setTimeout(() => controller.abort(), 2000)
     try {
-      await fetch(url, { signal: controller.signal })
-      clearTimeout(timeoutId)
-      return
+      const res = await fetch(url, { signal: controller.signal })
+      // Only a 200 means the REAL server is up. The boot server binds the
+      // port first and answers every non-health route with a 503 while
+      // migrations/FTS rebuild run, then hands the port off to the real
+      // server (a brief window where the socket refuses connections). If we
+      // returned on any response, we'd resolve against that 503 and the very
+      // next request would race the boot→real handoff and hit ECONNREFUSED.
+      // Requiring res.ok keeps us retrying through both the 503s and the gap.
+      if (res.ok) {
+        clearTimeout(timeoutId)
+        return
+      }
     } catch {
-      clearTimeout(timeoutId)
-      await new Promise((r) => setTimeout(r, 500))
+      // not ready yet — fall through to the retry delay
     }
+    clearTimeout(timeoutId)
+    await new Promise((r) => setTimeout(r, 500))
   }
   throw new Error(`Server did not start within ${maxAttempts * 500}ms`)
 }


### PR DESCRIPTION
## Problem

The \`v0.1.77\` release build went red on the **Run server integration tests** step, which blocked the artifacts from ever building. The failure:

\`\`\`
error: Unable to connect. Is the computer able to access the url?
  at app/apps/server/src/__tests__/api.test.ts:89:26
(fail) (unnamed) [8382.32ms]
\`\`\`

## Root cause

[api.test.ts](app/apps/server/src/__tests__/api.test.ts) spawns the full server and waits for it with \`waitForServer\`, which returned on **any** HTTP response.

The server binds a **boot server** on the port first (so the Tauri shell's \`/ping\` answers instantly), and that boot server replies to every non-health route with a **503** while migrations and the ~5s FTS rebuild run. It then \`stop()\`s and hands the port off to the real server — a brief window where the socket refuses connections.

So \`waitForServer\` resolved against the boot server's 503, and the very next request in \`beforeAll\` (\`GET /api/auth/local-users\`, line 89) raced the boot to real handoff and hit \`ECONNREFUSED\`, failing the whole suite.

This is timing-dependent, which is why it only surfaced now on the slower CI runner.

## Fix

Require \`res.ok\` (200) before resolving — the 503s and the brief handoff gap now keep retrying until the real server is bound. This mirrors the already-correct pattern in \`compiled-sidecar.test.ts\`.

## Test plan

- [x] \`bun run --filter server test\` → **257 pass, 0 fail** locally (was 1 fail in CI)
- [x] No production code touched — test-only change