### PR TITLE
fix(e2e): exclude disabled buttons from song-slide selector

### DIFF
--- a/app/apps/client/e2e/keyboard-shortcuts.spec.ts
+++ b/app/apps/client/e2e/keyboard-shortcuts.spec.ts
@@ -18,8 +18,11 @@ test.describe('Keyboard Shortcuts - Song Navigation', () => {
     await page.waitForLoadState('networkidle')
     await page.waitForTimeout(1000)
 
-    // Click a slide to start presentation
-    const slides = page.locator('button.rounded-lg')
+    // Click a slide to start presentation. Exclude disabled buttons: the
+    // always-mounted (but closed) ServerConnectionModal contributes a hidden,
+    // disabled "Reconnect" button that also matches `button.rounded-lg` and
+    // would otherwise pollute the slide set and be picked by `.nth()`.
+    const slides = page.locator('button.rounded-lg:not([disabled])')
     if (
       !(await slides
         .first()
@@ -64,7 +67,10 @@ test.describe('Keyboard Shortcuts - Song Navigation', () => {
     await page.waitForLoadState('networkidle')
     await page.waitForTimeout(1000)
 
-    const slides = page.locator('button.rounded-lg')
+    // Exclude disabled buttons so the hidden ServerConnectionModal "Reconnect"
+    // button doesn't inflate the slide count or get selected by `.nth(1)` —
+    // clicking that disabled button is what flaked this test in CI.
+    const slides = page.locator('button.rounded-lg:not([disabled])')
     const slideCount = await slides.count()
 
     if (slideCount < 2) {


### PR DESCRIPTION
## Problem

The \`v0.1.77\` release build's **Run E2E tests** step failed on a single test (1 of 294):

\`\`\`
[chromium] › e2e/keyboard-shortcuts.spec.ts:50 › ArrowUp navigates to previous slide in song
Error: locator.click: Test timeout of 30000ms exceeded.
  - waiting for locator('button.rounded-lg').nth(1)
  - locator resolved to <button disabled ...>Reconectează</button>
\`\`\`

## Root cause

[keyboard-shortcuts.spec.ts](app/apps/client/e2e/keyboard-shortcuts.spec.ts) selected song slides with a bare \`button.rounded-lg\`.

The always-mounted \`ServerConnectionModal\` (the kiosk reconnect dialog, in \`KioskScreenDimManager\`) renders a **hidden, disabled** "Reconnect" / "Reconectează" button that also carries the \`rounded-lg\` class. It joined the slide match set. When the opened song happened to have a single real slide, \`slideCount\` was 2, the \`< 2\` skip-guard passed, and \`.nth(1)\` resolved to that **disabled** button — the click then spun for 30s and failed.

This is data-dependent (which song is first, how many slides it has), which is why it passed for \`v0.1.76\` and flaked now. The modal never actually opens in e2e (it needs a kiosk-mode tap on the disconnection message), so the button is pure DOM pollution — not a blocking top-layer dialog.

## Fix

Scope the locator with \`:not([disabled])\`. Real slide buttons are never disabled, so only genuine, enabled slides are counted and clicked.

## Test plan

- [x] Logic verified: real slides are never \`disabled\`; the only disabled \`rounded-lg\` button on the page is the closed modal's reconnect button.
- [x] Not run against the live shared dev server to avoid disturbing it — validated by the re-tagged release build's full E2E job.