### PR TITLE
feat(songs): discover & import new songs from external sources

### DIFF
--- a/app/apps/client/e2e/song-discovery.spec.ts
+++ b/app/apps/client/e2e/song-discovery.spec.ts
@@ -1,0 +1,203 @@
+import JSZip from 'jszip'
+import { expect, test } from '@playwright/test'
+
+/**
+ * Song discovery: importing NEW songs from external sources. Covers the new
+ * /api/songs/discovery/match endpoint (verdict classification) and the
+ * /songs/discover staging UI end-to-end, with the external download mocked.
+ */
+
+function openSongXml(title: string, lyrics: string): string {
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<song>
+  <title>${title}</title>
+  <lyrics>[V1]
+ ${lyrics}
+</lyrics>
+</song>`
+}
+
+test.describe('Song Discovery — match API', () => {
+  const createdSongIds: number[] = []
+  const ts = Date.now()
+  const seededTitle = `Discovery Izvorul Mantuirii ${ts}`
+  const seededFilename = `discovery-seed-${ts}.xml`
+  const seededLyrics =
+    'izvorul mantuirii curge limpede peste inima mea cant de bucurie negraita'
+
+  test.afterAll(async ({ request }) => {
+    for (const id of createdSongIds) {
+      await request.delete(`/api/songs/${id}`)
+    }
+  })
+
+  test('classifies candidates by filename, title, similarity and novelty', async ({
+    request,
+  }) => {
+    const seedRes = await request.post('/api/songs', {
+      data: {
+        title: seededTitle,
+        sourceFilename: seededFilename,
+        slides: [{ content: `<p>${seededLyrics}</p>`, sortOrder: 0 }],
+      },
+    })
+    expect([201, 409]).toContain(seedRes.status())
+    if (seedRes.status() === 409) {
+      test.skip(true, 'Duplicate seed title detected')
+      return
+    }
+    createdSongIds.push((await seedRes.json()).data.id)
+
+    const res = await request.post('/api/songs/discovery/match', {
+      data: {
+        candidates: [
+          {
+            tempId: 'by-filename',
+            title: `Whatever ${ts}`,
+            lyrics: 'unrelated',
+            sourceFilename: seededFilename,
+          },
+          {
+            tempId: 'by-title',
+            title: seededTitle,
+            lyrics: 'different lyrics',
+            sourceFilename: `other-${ts}.xml`,
+          },
+          {
+            tempId: 'by-similarity',
+            title: 'Cantarea Izvorului Celui Viu',
+            lyrics: seededLyrics,
+            sourceFilename: `sim-${ts}.xml`,
+          },
+          {
+            tempId: 'brand-new',
+            title: `Zymologica Quixotique Novum ${ts}`,
+            lyrics: 'zymologica quixotique novum verba singularia distincta',
+            sourceFilename: `new-${ts}.xml`,
+          },
+        ],
+      },
+    })
+    expect(res.status()).toBe(200)
+    const byTempId: Record<string, { verdict: string }> = Object.fromEntries(
+      (await res.json()).data.map((r: { tempId: string }) => [r.tempId, r]),
+    )
+    expect(byTempId['by-filename'].verdict).toBe('exact-filename')
+    expect(byTempId['by-title'].verdict).toBe('exact-title')
+    expect(byTempId['by-similarity'].verdict).toBe('similar')
+    expect(byTempId['brand-new'].verdict).toBe('new')
+  })
+
+  test('rejects batches larger than 500 candidates', async ({ request }) => {
+    const candidates = Array.from({ length: 501 }, (_, i) => ({
+      tempId: `c${i}`,
+      title: `T${i}`,
+      lyrics: 'x',
+      sourceFilename: null,
+    }))
+    const res = await request.post('/api/songs/discovery/match', {
+      data: { candidates },
+    })
+    expect(res.status()).toBe(400)
+  })
+})
+
+test.describe('Song Discovery — staging UI', () => {
+  const createdSongIds: number[] = []
+  const ts = Date.now()
+  const newTitle = `UI New Discovery Song ${ts}`
+
+  test.afterAll(async ({ request }) => {
+    for (const id of createdSongIds) {
+      await request.delete(`/api/songs/${id}`)
+    }
+    // Clean up the song the UI import created (look it up by its unique title).
+    const search = await request.get(
+      `/api/songs/search?q=${encodeURIComponent(newTitle)}`,
+    )
+    if (search.ok()) {
+      const hits = (await search.json()).data as { id: number; title: string }[]
+      for (const hit of hits) {
+        if (hit.title === newTitle) {
+          await request.delete(`/api/songs/${hit.id}`)
+        }
+      }
+    }
+  })
+
+  test('shows only new songs, lets the user import an approved candidate', async ({
+    page,
+    request,
+  }) => {
+    // Seed a library song whose filename matches one catalog entry → that entry
+    // must be hidden from the staging list as already-present.
+    const dupFilename = `ui-dup-${ts}.xml`
+    const seedRes = await request.post('/api/songs', {
+      data: {
+        title: `UI Existing Song ${ts}`,
+        sourceFilename: dupFilename,
+        slides: [{ content: '<p>existing library content here</p>', sortOrder: 0 }],
+      },
+    })
+    expect([201, 409]).toContain(seedRes.status())
+    if (seedRes.status() === 201) {
+      createdSongIds.push((await seedRes.json()).data.id)
+    }
+
+    // Build a tiny OpenSong ZIP: one duplicate (by filename) + one brand-new.
+    const zip = new JSZip()
+    zip.file(dupFilename, openSongXml(`UI Existing Song ${ts}`, 'existing content'))
+    zip.file(
+      `ui-new-${ts}.xml`,
+      openSongXml(newTitle, 'a fresh unseen verse never imported before today'),
+    )
+    const zipBuffer = await zip.generateAsync({ type: 'nodebuffer' })
+
+    // Mock the external download (browser mode proxies through /api/proxy/download).
+    await page.route('**/api/proxy/download**', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/zip',
+        body: zipBuffer,
+      }),
+    )
+    // The background sync issues a cheap HEAD change-check — stub it too so the
+    // test never reaches the real external host.
+    await page.route('**/api/proxy/head**', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          data: { lastModified: 'test', etag: null, contentLength: '1' },
+        }),
+      }),
+    )
+
+    // The screen auto-fetches on open (reusing the mocked download) — no click.
+    await page.goto('/songs/discover')
+    await expect(
+      page.getByRole('heading', { name: /Discover new songs|Descoperă/ }),
+    ).toBeVisible()
+
+    // Wait for the diff to stream in and surface the new song.
+    await expect(page.getByText(newTitle)).toBeVisible({ timeout: 30_000 })
+
+    // The duplicate-by-filename entry must NOT appear in staging.
+    await expect(page.getByText(`UI Existing Song ${ts}`)).toHaveCount(0)
+
+    // Approve the new candidate and import it.
+    await page.getByRole('button', { name: /^(Import|Importă)$/ }).first().click()
+    await page
+      .getByRole('button', { name: /Import selected|Importă selecția/ })
+      .click()
+
+    // It now exists in the library.
+    await expect(async () => {
+      const search = await request.get(
+        `/api/songs/search?q=${encodeURIComponent(newTitle)}`,
+      )
+      const hits = (await search.json()).data as { title: string }[]
+      expect(hits.some((h) => h.title === newTitle)).toBe(true)
+    }).toPass({ timeout: 15_000 })
+  })
+})

--- a/app/apps/client/e2e/song-discovery.spec.ts
+++ b/app/apps/client/e2e/song-discovery.spec.ts
@@ -7,9 +7,11 @@ import { expect, test } from '@playwright/test'
  * /songs/discover staging UI end-to-end, with the external download mocked.
  */
 
+// Must start with "<song" (no XML declaration) — the importer's OpenSong
+// detection (isOpenSongContent) requires it, and the real Resurse Crestine
+// files are shaped this way.
 function openSongXml(title: string, lyrics: string): string {
-  return `<?xml version="1.0" encoding="UTF-8"?>
-<song>
+  return `<song>
   <title>${title}</title>
   <lyrics>[V1]
  ${lyrics}
@@ -105,7 +107,11 @@ test.describe('Song Discovery — match API', () => {
 test.describe('Song Discovery — staging UI', () => {
   const createdSongIds: number[] = []
   const ts = Date.now()
-  const newTitle = `UI New Discovery Song ${ts}`
+  // sanitizeSongTitle strips digits, so a numeric timestamp would vanish from
+  // the displayed/saved title. Encode the timestamp as letters for a unique,
+  // sanitize-stable title token; the numeric ts is fine for filenames.
+  const alphaId = String(ts).replace(/\d/g, (d) => 'abcdefghij'[Number(d)])
+  const newTitle = `UI New Discovery Song ${alphaId}`
 
   test.afterAll(async ({ request }) => {
     for (const id of createdSongIds) {

--- a/app/apps/client/src/features/presentation/hooks/useReopenScreensOnPresentation.ts
+++ b/app/apps/client/src/features/presentation/hooks/useReopenScreensOnPresentation.ts
@@ -1,13 +1,14 @@
 import { useEffect, useRef } from 'react'
 
+import { usePresentationState } from './usePresentationState'
+import { useScreens } from './useScreens'
 import { createLogger } from '../../../utils/logger'
 import type { PresentationState } from '../types'
 import {
   isTauri,
+  reclaimControlWindowFocus,
   reopenMissingActiveScreens,
 } from '../utils/openDisplayWindow'
-import { usePresentationState } from './usePresentationState'
-import { useScreens } from './useScreens'
 
 const logger = createLogger('app:screen')
 
@@ -41,11 +42,17 @@ export function useReopenScreensOnPresentation(): void {
 
     if (!shouldReopen(presentationState)) return
 
-    reopenMissingActiveScreens(screens).catch((error) => {
-      logger.error(
-        'Failed to reopen screen windows on presentation change:',
-        error,
-      )
-    })
+    reopenMissingActiveScreens(screens)
+      .catch((error) => {
+        logger.error(
+          'Failed to reopen screen windows on presentation change:',
+          error,
+        )
+      })
+      // Keep the keyboard live in the control window after presenting (the
+      // projector can grab focus when it appears / updates). Multi-monitor only.
+      .finally(() => {
+        void reclaimControlWindowFocus()
+      })
   }, [presentationState, screens])
 }

--- a/app/apps/client/src/features/presentation/utils/openDisplayWindow.ts
+++ b/app/apps/client/src/features/presentation/utils/openDisplayWindow.ts
@@ -546,3 +546,41 @@ export async function reopenMissingActiveScreens(
     )
   }
 }
+
+/**
+ * Brings keyboard focus back to the control (main) window after presenting, so
+ * the operator can keep advancing slides/verses from the keyboard without
+ * clicking back into the app. macOS / some WMs hand focus to the projector
+ * window when it appears or its content changes; this re-claims it.
+ *
+ * MULTI-MONITOR ONLY — on a single screen, raising the control window would
+ * cover the projection (it shares the monitor with it), so we leave focus on
+ * the projector there. On a second monitor the projection is elsewhere, so
+ * refocusing control is invisible to the audience and keeps the keyboard live.
+ * (Mirrors the same guard in `openInNativeWindow`.) A few re-asserts win the
+ * focus race against a window that finishes appearing slightly later.
+ */
+export async function reclaimControlWindowFocus(): Promise<void> {
+  if (!isTauri()) return
+  try {
+    const { getCurrentWindow, availableMonitors } = await import(
+      '@tauri-apps/api/window'
+    )
+    if ((await availableMonitors()).length <= 1) return
+
+    const control = getCurrentWindow()
+    const reclaim = async () => {
+      try {
+        await control.setFocus()
+      } catch {
+        // best-effort; the window may be mid-transition
+      }
+    }
+    await reclaim()
+    for (const delay of [200, 500]) {
+      setTimeout(reclaim, delay)
+    }
+  } catch {
+    // best-effort focus restoration; never throw into the presentation flow
+  }
+}

--- a/app/apps/client/src/features/song-discovery/components/CandidateEditorPanel.tsx
+++ b/app/apps/client/src/features/song-discovery/components/CandidateEditorPanel.tsx
@@ -1,0 +1,66 @@
+import { useTranslation } from 'react-i18next'
+
+import {
+  SongDetailsSection,
+  type SongMetadata,
+} from '~/features/songs/components/SongDetailsSection'
+import type { LocalSlide } from '~/features/songs/components/SongSlideList'
+import { SongSlidesSection } from '~/features/songs/components/SongSlidesSection'
+import { SimilarInLibraryPanel } from './SimilarInLibraryPanel'
+import type { CandidateDraft, StagingItem } from '../types'
+
+interface CandidateEditorPanelProps {
+  item: StagingItem
+  onDraftChange: (tempId: string, draft: CandidateDraft) => void
+}
+
+/**
+ * Edits a not-yet-imported candidate using the SAME building blocks as the
+ * real song editor (`SongDetailsSection` + `SongSlidesSection`), driven purely
+ * by the staging item's in-memory draft. Nothing touches the DB until the user
+ * imports the approved set. The "similar in library" panel sits on top so the
+ * operator sees potential duplicates while editing.
+ */
+export function CandidateEditorPanel({
+  item,
+  onDraftChange,
+}: CandidateEditorPanelProps) {
+  const { t } = useTranslation('songDiscovery')
+  const { draft } = item
+
+  const patch = (changes: Partial<CandidateDraft>) => {
+    onDraftChange(item.tempId, { ...draft, ...changes })
+  }
+
+  return (
+    <div className="space-y-4">
+      <SimilarInLibraryPanel similar={item.similar} />
+
+      <SongDetailsSection
+        title={draft.title}
+        categoryId={draft.categoryId}
+        tagIds={[]}
+        metadata={draft.metadata}
+        isNew
+        idPrefix={`discovery-${item.tempId}-`}
+        onTitleChange={(title) => patch({ title })}
+        onCategoryChange={(categoryId) => patch({ categoryId })}
+        onTagsChange={() => {
+          /* tags aren't part of the batch-import payload yet */
+        }}
+        onMetadataChange={(field: keyof SongMetadata, value) =>
+          patch({ metadata: { ...draft.metadata, [field]: value } })
+        }
+      />
+
+      <SongSlidesSection
+        slides={draft.slides}
+        onSlidesChange={(slides: LocalSlide[]) => patch({ slides })}
+      />
+
+      <p className="text-xs text-gray-500 dark:text-gray-400">
+        {t('editorHint')}
+      </p>
+    </div>
+  )
+}

--- a/app/apps/client/src/features/song-discovery/components/CandidateEditorPanel.tsx
+++ b/app/apps/client/src/features/song-discovery/components/CandidateEditorPanel.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import {
@@ -8,6 +9,7 @@ import type { LocalSlide } from '~/features/songs/components/SongSlideList'
 import { SongSlidesSection } from '~/features/songs/components/SongSlidesSection'
 import { SimilarInLibraryPanel } from './SimilarInLibraryPanel'
 import type { CandidateDraft, StagingItem } from '../types'
+import { slidesToLines } from '../utils/lyricsDiff'
 
 interface CandidateEditorPanelProps {
   item: StagingItem
@@ -32,9 +34,18 @@ export function CandidateEditorPanel({
     onDraftChange(item.tempId, { ...draft, ...changes })
   }
 
+  // The candidate's current (edited) lyric lines, for the similar-songs diff.
+  const candidateLines = useMemo(
+    () => slidesToLines(draft.slides),
+    [draft.slides],
+  )
+
   return (
     <div className="space-y-4">
-      <SimilarInLibraryPanel similar={item.similar} />
+      <SimilarInLibraryPanel
+        similar={item.similar}
+        candidateLines={candidateLines}
+      />
 
       <SongDetailsSection
         title={draft.title}

--- a/app/apps/client/src/features/song-discovery/components/CandidateList.tsx
+++ b/app/apps/client/src/features/song-discovery/components/CandidateList.tsx
@@ -1,0 +1,118 @@
+import { useVirtualizer } from '@tanstack/react-virtual'
+import { Check, X } from 'lucide-react'
+import { useRef } from 'react'
+import { useTranslation } from 'react-i18next'
+
+import { VerdictBadge } from './VerdictBadge'
+import type { StagingItem } from '../types'
+
+const ESTIMATED_ROW_HEIGHT = 76
+
+interface CandidateListProps {
+  items: StagingItem[]
+  selectedTempId: string | null
+  onSelect: (tempId: string) => void
+  onDecide: (tempId: string, decision: 'approve' | 'skip') => void
+}
+
+/**
+ * Virtualized list of staged candidates (the songs the user lacks). Only the
+ * on-screen rows mount, so a multi-thousand-song catalog never floods the DOM.
+ * Each row shows the verdict badge + quick approve/skip toggles.
+ */
+export function CandidateList({
+  items,
+  selectedTempId,
+  onSelect,
+  onDecide,
+}: CandidateListProps) {
+  const { t } = useTranslation('songDiscovery')
+  const scrollRef = useRef<HTMLDivElement>(null)
+
+  const virtualizer = useVirtualizer({
+    count: items.length,
+    getScrollElement: () => scrollRef.current,
+    estimateSize: () => ESTIMATED_ROW_HEIGHT,
+    overscan: 8,
+  })
+
+  if (items.length === 0) {
+    return (
+      <div className="flex items-center justify-center h-full p-6 text-center text-sm text-gray-500 dark:text-gray-400">
+        {t('emptyStaging')}
+      </div>
+    )
+  }
+
+  return (
+    <div ref={scrollRef} className="h-full overflow-y-auto">
+      <div
+        style={{ height: `${virtualizer.getTotalSize()}px` }}
+        className="relative w-full"
+      >
+        {virtualizer.getVirtualItems().map((virtualRow) => {
+          const item = items[virtualRow.index]
+          const isSelected = item.tempId === selectedTempId
+          return (
+            <div
+              key={item.tempId}
+              data-index={virtualRow.index}
+              ref={virtualizer.measureElement}
+              className="absolute top-0 left-0 w-full"
+              style={{ transform: `translateY(${virtualRow.start}px)` }}
+            >
+              <button
+                type="button"
+                onClick={() => onSelect(item.tempId)}
+                className={`w-full text-left px-4 py-3 border-b border-gray-200 dark:border-gray-700 transition-colors ${
+                  isSelected
+                    ? 'bg-indigo-50 dark:bg-indigo-900/30'
+                    : 'hover:bg-gray-50 dark:hover:bg-gray-800/50'
+                } ${item.decision === 'skip' ? 'opacity-50' : ''}`}
+              >
+                <div className="flex items-center gap-2">
+                  <span className="flex-1 truncate font-medium text-gray-900 dark:text-white">
+                    {item.draft.title || t('untitled')}
+                  </span>
+                  <VerdictBadge verdict={item.verdict} />
+                </div>
+                <div className="mt-2 flex items-center gap-2">
+                  <button
+                    type="button"
+                    onClick={(e) => {
+                      e.stopPropagation()
+                      onDecide(item.tempId, 'approve')
+                    }}
+                    className={`inline-flex items-center gap-1 px-2 py-1 rounded text-xs font-medium transition-colors ${
+                      item.decision === 'approve'
+                        ? 'bg-green-600 text-white'
+                        : 'bg-gray-100 text-gray-700 hover:bg-green-100 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-green-900/40'
+                    }`}
+                  >
+                    <Check className="w-3 h-3" />
+                    {t('actions.approve')}
+                  </button>
+                  <button
+                    type="button"
+                    onClick={(e) => {
+                      e.stopPropagation()
+                      onDecide(item.tempId, 'skip')
+                    }}
+                    className={`inline-flex items-center gap-1 px-2 py-1 rounded text-xs font-medium transition-colors ${
+                      item.decision === 'skip'
+                        ? 'bg-gray-500 text-white'
+                        : 'bg-gray-100 text-gray-700 hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600'
+                    }`}
+                  >
+                    <X className="w-3 h-3" />
+                    {t('actions.skip')}
+                  </button>
+                </div>
+              </button>
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/app/apps/client/src/features/song-discovery/components/DiscoverButton.tsx
+++ b/app/apps/client/src/features/song-discovery/components/DiscoverButton.tsx
@@ -1,0 +1,58 @@
+import { useNavigate } from '@tanstack/react-router'
+import { useTranslation } from 'react-i18next'
+
+import { useSongDiscovery } from '../context/SongDiscoveryContext'
+
+/**
+ * The exact lucide "sparkles" icon (same one in the discovery screen header) as
+ * a CSS mask, so the animated gradient behind it shows through the icon shape —
+ * giving the icon the same moving gradient as the button border.
+ */
+const SPARKLES_MASK =
+  "url(\"data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%23fff' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M9.937 15.5A2 2 0 0 0 8.5 14.063l-6.135-1.582a.5.5 0 0 1 0-.962L8.5 9.936A2 2 0 0 0 9.937 8.5l1.582-6.135a.5.5 0 0 1 .963 0L14.063 8.5A2 2 0 0 0 15.5 9.937l6.135 1.581a.5.5 0 0 1 0 .964L15.5 14.063a2 2 0 0 0-1.437 1.437l-1.582 6.135a.5.5 0 0 1-.963 0z'/%3E%3Cpath d='M20 3v4'/%3E%3Cpath d='M22 5h-4'/%3E%3Cpath d='M4 17v2'/%3E%3Cpath d='M5 18H3'/%3E%3C/svg%3E\") center / contain no-repeat"
+
+/**
+ * Header entry point to the discovery screen. The border and the star share one
+ * animated gradient (it drifts faster while the background catalog check runs),
+ * and a red count badge appears once new songs are found.
+ */
+export function DiscoverButton() {
+  const { t } = useTranslation('songDiscovery')
+  const navigate = useNavigate()
+  const { isChecking, badgeCount } = useSongDiscovery()
+
+  const hasNew = badgeCount > 0
+  const gradient = `discover-gradient${isChecking ? ' discover-gradient-active' : ''}`
+
+  return (
+    <button
+      type="button"
+      onClick={() => navigate({ to: '/songs/discover' })}
+      title={isChecking ? t('button.searching') : t('button.discover')}
+      className={`group relative mt-1 inline-flex shrink-0 rounded-lg p-[1.5px] shadow-sm transition-transform hover:scale-[1.03] ${gradient}`}
+    >
+      <span className="flex items-center gap-2 whitespace-nowrap rounded-[6.5px] bg-white px-5 py-1.5 text-sm font-medium text-gray-800 dark:bg-gray-900 dark:text-gray-100">
+        <span
+          aria-hidden="true"
+          className={`h-4 w-4 shrink-0 ${gradient}`}
+          style={{ WebkitMask: SPARKLES_MASK, mask: SPARKLES_MASK }}
+        />
+        <span className="whitespace-nowrap">
+          {isChecking ? t('button.searching') : t('button.discover')}
+          {isChecking && (
+            <span className="discover-dots" aria-hidden="true">
+              <span>.</span>
+              <span>.</span>
+              <span>.</span>
+            </span>
+          )}
+        </span>
+      </span>
+      {hasNew && (
+        <span className="absolute -right-1.5 -top-1.5 z-10 flex h-[18px] min-w-[18px] items-center justify-center rounded-full bg-red-500 px-1 text-[10px] font-semibold text-white ring-2 ring-white dark:ring-gray-900">
+          {badgeCount > 99 ? '99+' : badgeCount}
+        </span>
+      )}
+    </button>
+  )
+}

--- a/app/apps/client/src/features/song-discovery/components/DiscoveryProgress.tsx
+++ b/app/apps/client/src/features/song-discovery/components/DiscoveryProgress.tsx
@@ -1,0 +1,59 @@
+import { Loader2 } from 'lucide-react'
+
+interface DiscoveryProgressProps {
+  label: string
+  /** 0..1 fill ratio, or null for an indeterminate (animated) bar. */
+  ratio: number | null
+  /** Right-aligned detail next to the label, e.g. "28%". */
+  detail?: string
+  /** Secondary line under the bar, e.g. "1,240 / 4,500 analyzed · 32 new found". */
+  meta?: string
+}
+
+/**
+ * Progress band for the download/parse and analyze phases. A highlight sweeps
+ * across the indigo fill so it always reads as active — even between the
+ * chunked value updates — and a secondary line carries the live counts.
+ */
+export function DiscoveryProgress({
+  label,
+  ratio,
+  detail,
+  meta,
+}: DiscoveryProgressProps) {
+  const pct =
+    ratio == null ? null : Math.max(0, Math.min(100, Math.round(ratio * 100)))
+
+  return (
+    <div className="rounded-xl border border-gray-200 bg-white p-4 dark:border-gray-800 dark:bg-gray-900">
+      <div className="mb-2 flex items-center justify-between gap-3">
+        <span className="flex items-center gap-2 text-sm font-medium text-gray-700 dark:text-gray-200">
+          <Loader2 className="h-4 w-4 animate-spin text-indigo-500" />
+          {label}
+        </span>
+        {detail && (
+          <span className="text-xs font-medium tabular-nums text-gray-500 dark:text-gray-400">
+            {detail}
+          </span>
+        )}
+      </div>
+      <div className="relative h-2 w-full overflow-hidden rounded-full bg-gray-100 dark:bg-gray-800">
+        {pct == null ? (
+          <div className="discover-indeterminate absolute inset-y-0 left-0 w-2/5 rounded-full bg-indigo-500/70" />
+        ) : (
+          <div
+            className="relative h-full overflow-hidden rounded-full bg-indigo-600 transition-[width] duration-300 ease-out"
+            style={{ width: `${pct}%` }}
+          >
+            <div className="discover-shimmer absolute inset-y-0 left-0 w-1/3 bg-gradient-to-r from-transparent via-white/50 to-transparent" />
+          </div>
+        )}
+      </div>
+      {meta && (
+        <p className="mt-2 text-xs tabular-nums text-gray-500 dark:text-gray-400">
+          {meta}
+        </p>
+      )}
+    </div>
+  )
+}

--- a/app/apps/client/src/features/song-discovery/components/DiscoverySyncSettings.tsx
+++ b/app/apps/client/src/features/song-discovery/components/DiscoverySyncSettings.tsx
@@ -1,0 +1,63 @@
+import { Loader2, RefreshCw } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+
+import { Switch } from '~/ui/switch/Switch'
+import { useSongDiscovery } from '../context/SongDiscoveryContext'
+
+/**
+ * Settings card to toggle the background "new songs" check on/off and trigger
+ * an immediate check. Lives in the Songs settings panel.
+ */
+export function DiscoverySyncSettings() {
+  const { t } = useTranslation('songDiscovery')
+  const { enabled, setEnabled, isChecking, checkNow, newCount } =
+    useSongDiscovery()
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <h3 className="text-lg font-semibold text-gray-900 dark:text-white">
+          {t('settings.title')}
+        </h3>
+        <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">
+          {t('settings.description')}
+        </p>
+      </div>
+
+      <div className="flex items-center justify-between gap-4">
+        <label
+          htmlFor="discovery-sync-enabled"
+          className="text-sm font-medium text-gray-700 dark:text-gray-300"
+        >
+          {t('settings.enableLabel')}
+        </label>
+        <Switch
+          id="discovery-sync-enabled"
+          checked={enabled}
+          onCheckedChange={setEnabled}
+        />
+      </div>
+
+      <div className="flex items-center gap-3">
+        <button
+          type="button"
+          onClick={() => checkNow({ force: true })}
+          disabled={!enabled || isChecking}
+          className="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium bg-gray-100 hover:bg-gray-200 text-gray-800 dark:bg-gray-700 dark:hover:bg-gray-600 dark:text-gray-100 rounded-lg transition-colors disabled:opacity-50"
+        >
+          {isChecking ? (
+            <Loader2 className="w-4 h-4 animate-spin" />
+          ) : (
+            <RefreshCw className="w-4 h-4" />
+          )}
+          {t('settings.checkNow')}
+        </button>
+        {newCount > 0 && (
+          <span className="text-sm text-gray-600 dark:text-gray-300">
+            {t('settings.newCount', { count: newCount })}
+          </span>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/app/apps/client/src/features/song-discovery/components/DiscoveryToolbar.tsx
+++ b/app/apps/client/src/features/song-discovery/components/DiscoveryToolbar.tsx
@@ -1,0 +1,55 @@
+import { CheckCheck, Loader2, Upload } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+
+interface DiscoveryToolbarProps {
+  totalCount: number
+  approvedCount: number
+  onApproveAllNew: () => void
+  onImport: () => void
+  isImporting: boolean
+}
+
+/** Summary + bulk actions above the candidate list. */
+export function DiscoveryToolbar({
+  totalCount,
+  approvedCount,
+  onApproveAllNew,
+  onImport,
+  isImporting,
+}: DiscoveryToolbarProps) {
+  const { t } = useTranslation('songDiscovery')
+
+  return (
+    <div className="flex flex-wrap items-center justify-between gap-3">
+      <span className="text-sm text-gray-600 dark:text-gray-300">
+        {t('toolbar.summary', { total: totalCount, approved: approvedCount })}
+      </span>
+
+      <div className="flex items-center gap-2">
+        <button
+          type="button"
+          onClick={onApproveAllNew}
+          disabled={totalCount === 0 || isImporting}
+          className="inline-flex items-center gap-2 px-3 py-2 text-sm font-medium bg-gray-100 hover:bg-gray-200 text-gray-800 dark:bg-gray-700 dark:hover:bg-gray-600 dark:text-gray-100 rounded-lg transition-colors disabled:opacity-50"
+        >
+          <CheckCheck className="w-4 h-4" />
+          {t('toolbar.approveAllNew')}
+        </button>
+
+        <button
+          type="button"
+          onClick={onImport}
+          disabled={approvedCount === 0 || isImporting}
+          className="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium bg-indigo-600 hover:bg-indigo-700 text-white rounded-lg transition-colors disabled:opacity-50"
+        >
+          {isImporting ? (
+            <Loader2 className="w-4 h-4 animate-spin" />
+          ) : (
+            <Upload className="w-4 h-4" />
+          )}
+          {t('toolbar.importApproved', { count: approvedCount })}
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/app/apps/client/src/features/song-discovery/components/LyricsDiffView.tsx
+++ b/app/apps/client/src/features/song-discovery/components/LyricsDiffView.tsx
@@ -1,0 +1,79 @@
+import { useMemo } from 'react'
+import { useTranslation } from 'react-i18next'
+
+import { type DiffLine, diffLines, hasChanges } from '../utils/lyricsDiff'
+
+interface LyricsDiffViewProps {
+  /** Lyric lines of the existing library song (the diff "base"). */
+  libraryLines: string[]
+  /** Lyric lines of the candidate being imported (the diff "head"). */
+  candidateLines: string[]
+}
+
+const ROW_STYLES: Record<DiffLine['type'], string> = {
+  added: 'bg-green-50 text-green-800 dark:bg-green-950/40 dark:text-green-300',
+  removed: 'bg-red-50 text-red-800 dark:bg-red-950/40 dark:text-red-300',
+  context: 'text-gray-600 dark:text-gray-400',
+}
+
+const ROW_SIGN: Record<DiffLine['type'], string> = {
+  added: '+',
+  removed: '-',
+  context: ' ',
+}
+
+/**
+ * GitHub-style unified diff between an existing library song and the candidate
+ * being imported: red lines are dropped from the existing version, green lines
+ * are new in the catalog song. Lets the operator see exactly which verses
+ * changed before deciding to import.
+ */
+export function LyricsDiffView({
+  libraryLines,
+  candidateLines,
+}: LyricsDiffViewProps) {
+  const { t } = useTranslation('songDiscovery')
+  const diff = useMemo(
+    () => diffLines(libraryLines, candidateLines),
+    [libraryLines, candidateLines],
+  )
+
+  if (!hasChanges(diff)) {
+    return (
+      <p className="mt-2 text-xs text-gray-500 dark:text-gray-400">
+        {t('diff.identical')}
+      </p>
+    )
+  }
+
+  return (
+    <div className="mt-2 overflow-hidden rounded-md border border-gray-200 dark:border-gray-700">
+      <div className="flex items-center gap-3 border-b border-gray-200 bg-gray-50 px-3 py-1.5 text-[11px] text-gray-500 dark:border-gray-700 dark:bg-gray-800/60 dark:text-gray-400">
+        <span className="flex items-center gap-1">
+          <span className="inline-block h-2 w-2 rounded-sm bg-red-400" />
+          {t('diff.inLibrary')}
+        </span>
+        <span className="flex items-center gap-1">
+          <span className="inline-block h-2 w-2 rounded-sm bg-green-400" />
+          {t('diff.inCatalog')}
+        </span>
+      </div>
+      <div className="max-h-72 overflow-y-auto bg-white font-mono text-xs leading-relaxed dark:bg-gray-900">
+        {diff.map((line, index) => (
+          <div
+            // biome-ignore lint/suspicious/noArrayIndexKey: positional diff rows
+            key={index}
+            className={`flex gap-2 px-3 py-0.5 ${ROW_STYLES[line.type]}`}
+          >
+            <span className="select-none opacity-60">
+              {ROW_SIGN[line.type]}
+            </span>
+            <span className="whitespace-pre-wrap break-words">
+              {line.text || ' '}
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/app/apps/client/src/features/song-discovery/components/SimilarInLibraryPanel.tsx
+++ b/app/apps/client/src/features/song-discovery/components/SimilarInLibraryPanel.tsx
@@ -1,0 +1,48 @@
+import { useTranslation } from 'react-i18next'
+
+import type { SongVersionSuggestion } from '~/features/songs/types'
+
+interface SimilarInLibraryPanelProps {
+  similar: SongVersionSuggestion[]
+}
+
+/**
+ * Shows the existing library songs that look like the selected candidate, so
+ * the operator can decide whether they're about to import a duplicate. Reuses
+ * the same `SongVersionSuggestion` shape as the Versions feature.
+ */
+export function SimilarInLibraryPanel({ similar }: SimilarInLibraryPanelProps) {
+  const { t } = useTranslation('songDiscovery')
+
+  if (similar.length === 0) return null
+
+  return (
+    <div className="bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 rounded-lg p-4">
+      <h3 className="text-sm font-semibold text-amber-900 dark:text-amber-200 mb-2">
+        {t('similar.title', { count: similar.length })}
+      </h3>
+      <ul className="space-y-2">
+        {similar.map((s) => (
+          <li
+            key={s.songId}
+            className="flex items-center justify-between gap-2 text-sm"
+          >
+            <div className="min-w-0">
+              <span className="block truncate text-gray-900 dark:text-white">
+                {s.title}
+              </span>
+              {(s.author || s.categoryName) && (
+                <span className="block truncate text-xs text-gray-500 dark:text-gray-400">
+                  {[s.author, s.categoryName].filter(Boolean).join(' · ')}
+                </span>
+              )}
+            </div>
+            <span className="shrink-0 text-xs font-medium text-amber-700 dark:text-amber-300">
+              {Math.round(s.score * 100)}%
+            </span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}

--- a/app/apps/client/src/features/song-discovery/components/SimilarInLibraryPanel.tsx
+++ b/app/apps/client/src/features/song-discovery/components/SimilarInLibraryPanel.tsx
@@ -1,46 +1,110 @@
+import { ChevronDown, ChevronRight, GitCompare, Loader2 } from 'lucide-react'
+import { useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
+import { useSong } from '~/features/songs/hooks'
 import type { SongVersionSuggestion } from '~/features/songs/types'
+import { LyricsDiffView } from './LyricsDiffView'
+import { slidesToLines } from '../utils/lyricsDiff'
 
 interface SimilarInLibraryPanelProps {
   similar: SongVersionSuggestion[]
+  /** The candidate's (edited) lyric lines, for the GitHub-style diff. */
+  candidateLines: string[]
+}
+
+/** One similar-library-song row with an expandable lyrics diff. */
+function SimilarRow({
+  suggestion,
+  candidateLines,
+}: {
+  suggestion: SongVersionSuggestion
+  candidateLines: string[]
+}) {
+  const { t } = useTranslation('songDiscovery')
+  const [open, setOpen] = useState(false)
+  // Fetch the library song's slides only when the diff is opened.
+  const { data: song, isLoading } = useSong(open ? suggestion.songId : null)
+  const libraryLines = useMemo(
+    () => (song ? slidesToLines(song.slides) : []),
+    [song],
+  )
+
+  return (
+    <li className="rounded-md bg-white/60 px-2 py-1.5 dark:bg-gray-900/40">
+      <div className="flex items-center justify-between gap-2 text-sm">
+        <div className="min-w-0">
+          <span className="block truncate text-gray-900 dark:text-white">
+            {suggestion.title}
+          </span>
+          {(suggestion.author || suggestion.categoryName) && (
+            <span className="block truncate text-xs text-gray-500 dark:text-gray-400">
+              {[suggestion.author, suggestion.categoryName]
+                .filter(Boolean)
+                .join(' · ')}
+            </span>
+          )}
+        </div>
+        <div className="flex shrink-0 items-center gap-2">
+          <span className="text-xs font-medium text-amber-700 dark:text-amber-300">
+            {Math.round(suggestion.score * 100)}%
+          </span>
+          <button
+            type="button"
+            onClick={() => setOpen((v) => !v)}
+            className="inline-flex items-center gap-1 rounded px-2 py-1 text-xs font-medium text-amber-800 transition-colors hover:bg-amber-100 dark:text-amber-300 dark:hover:bg-amber-900/40"
+          >
+            {open ? (
+              <ChevronDown className="h-3 w-3" />
+            ) : (
+              <ChevronRight className="h-3 w-3" />
+            )}
+            <GitCompare className="h-3 w-3" />
+            {open ? t('diff.hide') : t('diff.show')}
+          </button>
+        </div>
+      </div>
+      {open &&
+        (isLoading || !song ? (
+          <div className="mt-2 flex items-center gap-2 text-xs text-gray-500 dark:text-gray-400">
+            <Loader2 className="h-3 w-3 animate-spin" />
+            {t('diff.loading')}
+          </div>
+        ) : (
+          <LyricsDiffView
+            libraryLines={libraryLines}
+            candidateLines={candidateLines}
+          />
+        ))}
+    </li>
+  )
 }
 
 /**
  * Shows the existing library songs that look like the selected candidate, so
- * the operator can decide whether they're about to import a duplicate. Reuses
- * the same `SongVersionSuggestion` shape as the Versions feature.
+ * the operator can decide whether they're about to import a duplicate. Each row
+ * expands into a GitHub-style lyrics diff (existing vs. catalog version).
  */
-export function SimilarInLibraryPanel({ similar }: SimilarInLibraryPanelProps) {
+export function SimilarInLibraryPanel({
+  similar,
+  candidateLines,
+}: SimilarInLibraryPanelProps) {
   const { t } = useTranslation('songDiscovery')
 
   if (similar.length === 0) return null
 
   return (
-    <div className="bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 rounded-lg p-4">
-      <h3 className="text-sm font-semibold text-amber-900 dark:text-amber-200 mb-2">
+    <div className="rounded-lg border border-amber-200 bg-amber-50 p-4 dark:border-amber-800 dark:bg-amber-900/20">
+      <h3 className="mb-2 text-sm font-semibold text-amber-900 dark:text-amber-200">
         {t('similar.title', { count: similar.length })}
       </h3>
-      <ul className="space-y-2">
+      <ul className="space-y-1.5">
         {similar.map((s) => (
-          <li
+          <SimilarRow
             key={s.songId}
-            className="flex items-center justify-between gap-2 text-sm"
-          >
-            <div className="min-w-0">
-              <span className="block truncate text-gray-900 dark:text-white">
-                {s.title}
-              </span>
-              {(s.author || s.categoryName) && (
-                <span className="block truncate text-xs text-gray-500 dark:text-gray-400">
-                  {[s.author, s.categoryName].filter(Boolean).join(' · ')}
-                </span>
-              )}
-            </div>
-            <span className="shrink-0 text-xs font-medium text-amber-700 dark:text-amber-300">
-              {Math.round(s.score * 100)}%
-            </span>
-          </li>
+            suggestion={s}
+            candidateLines={candidateLines}
+          />
         ))}
       </ul>
     </div>

--- a/app/apps/client/src/features/song-discovery/components/SongDiscoveryScreen.tsx
+++ b/app/apps/client/src/features/song-discovery/components/SongDiscoveryScreen.tsx
@@ -1,0 +1,467 @@
+import { useQueryClient } from '@tanstack/react-query'
+import { AlertTriangle, ArrowLeft, RefreshCw, Sparkles } from 'lucide-react'
+import { useEffect, useMemo, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+
+import { defaultSongMetadata } from '~/features/songs/components/SongDetailsSection'
+import { useCategories, useUpsertCategory } from '~/features/songs/hooks'
+import { useToast } from '~/ui/toast'
+import { CandidateEditorPanel } from './CandidateEditorPanel'
+import { CandidateList } from './CandidateList'
+import { DiscoveryProgress } from './DiscoveryProgress'
+import { DiscoveryToolbar } from './DiscoveryToolbar'
+import { useFetchCatalog } from '../hooks/useFetchCatalog'
+import { useImportApproved } from '../hooks/useImportApproved'
+import { useMatchCandidates } from '../hooks/useMatchCandidates'
+import { getProvider, PROVIDERS } from '../providers'
+import type { CandidateDraft, DiscoveryCandidate, StagingItem } from '../types'
+
+interface SongDiscoveryScreenProps {
+  onBack?: () => void
+}
+
+/** Seeds an editable draft from a parsed external candidate. */
+function buildDraft(
+  candidate: DiscoveryCandidate,
+  defaultCategoryId: number | null,
+): CandidateDraft {
+  const m = candidate.parsed.metadata
+  return {
+    title: candidate.parsed.title,
+    categoryId: defaultCategoryId,
+    slides: candidate.parsed.slides.map((slide, idx) => ({
+      id: `${candidate.tempId}-slide-${idx}`,
+      content: slide.htmlContent,
+      sortOrder: idx,
+      label: slide.label ?? null,
+    })),
+    metadata: {
+      ...defaultSongMetadata,
+      sourceFilename: candidate.sourceFilename,
+      author: m?.author ?? null,
+      copyright: m?.copyright ?? null,
+      ccli: m?.ccli ?? null,
+      tempo: m?.tempo ?? null,
+      timeSignature: m?.timeSignature ?? null,
+      theme: m?.theme ?? null,
+      altTheme: m?.altTheme ?? null,
+      hymnNumber: m?.hymnNumber ?? null,
+      keyLine: m?.keyLine ?? null,
+      presentationOrder: m?.presentationOrder ?? null,
+    },
+  }
+}
+
+/** A compact count chip for the stats strip. */
+function StatChip({
+  value,
+  label,
+  accent = false,
+}: {
+  value: number
+  label: string
+  accent?: boolean
+}) {
+  return (
+    <div
+      className={`flex items-baseline gap-1.5 rounded-lg px-3 py-1.5 ${
+        accent
+          ? 'bg-indigo-50 text-indigo-700 dark:bg-indigo-950/50 dark:text-indigo-300'
+          : 'bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-300'
+      }`}
+    >
+      <span className="text-sm font-semibold tabular-nums">{value}</span>
+      <span className="text-xs">{label}</span>
+    </div>
+  )
+}
+
+/**
+ * Staging screen for importing new songs from external sources. Reuses the
+ * catalog the background sync already downloaded (so it appears instantly),
+ * streams the library diff with a live progress indicator, and lets the
+ * operator edit + approve/skip each new song before a single batch import.
+ */
+export function SongDiscoveryScreen({ onBack }: SongDiscoveryScreenProps) {
+  const { t } = useTranslation('songDiscovery')
+  const { showToast } = useToast()
+  const queryClient = useQueryClient()
+
+  // Single source today; the provider registry stays extensible for more.
+  const providerId = PROVIDERS[0]?.id ?? ''
+  const [selectedTempId, setSelectedTempId] = useState<string | null>(null)
+  // Per-candidate edits/decisions, keyed by tempId, preserved across re-diffs.
+  const [items, setItems] = useState<Record<string, StagingItem>>({})
+  // tempIds already imported this session — permanently dropped from the list so
+  // they never reappear, without re-running the whole diff.
+  const [importedTempIds, setImportedTempIds] = useState<Set<string>>(
+    () => new Set(),
+  )
+  // Bumped only by the explicit "Refresh catalog" action to re-analyze.
+  const [refreshNonce, setRefreshNonce] = useState(0)
+
+  const { data: categories } = useCategories()
+  const { mutateAsync: upsertCategory } = useUpsertCategory()
+  // Auto-starts on mount — the background sync usually primed the cache, so the
+  // catalog (and the diff) appear immediately with no extra click.
+  const {
+    candidates,
+    isFetching,
+    progress,
+    refetch,
+    error: fetchError,
+  } = useFetchCatalog(providerId)
+
+  const {
+    results,
+    isMatching,
+    progress: matchProgress,
+    error: matchError,
+  } = useMatchCandidates(providerId, candidates, refreshNonce)
+
+  const defaultCategoryId = useMemo(() => {
+    const provider = getProvider(providerId)
+    if (!provider) return null
+    return (
+      categories?.find((c) => c.name === provider.defaultCategoryName)?.id ??
+      null
+    )
+  }, [categories, providerId])
+
+  // Reconcile match results into staging items, keeping only songs the user
+  // lacks (verdict similar/new), excluding ones already imported this session,
+  // and preserving any in-flight edits/decisions. Runs as results stream in, so
+  // the list grows progressively.
+  useEffect(() => {
+    if (results.length === 0) {
+      setItems({})
+      return
+    }
+    const candidatesByTempId = new Map(candidates.map((c) => [c.tempId, c]))
+
+    setItems((prev) => {
+      const next: Record<string, StagingItem> = {}
+      for (const result of results) {
+        if (
+          result.verdict === 'exact-filename' ||
+          result.verdict === 'exact-title'
+        ) {
+          continue // already in the library — hide it
+        }
+        if (importedTempIds.has(result.tempId)) {
+          continue // imported this session — don't bring it back
+        }
+        const candidate = candidatesByTempId.get(result.tempId)
+        if (!candidate) continue
+
+        const existing = prev[result.tempId]
+        next[result.tempId] = {
+          tempId: result.tempId,
+          candidate,
+          verdict: result.verdict,
+          similar: result.similar,
+          draft: existing?.draft ?? buildDraft(candidate, defaultCategoryId),
+          decision: existing?.decision ?? 'pending',
+        }
+      }
+      return next
+    })
+  }, [results, defaultCategoryId, importedTempIds])
+
+  const stagingItems = useMemo(
+    () => Object.values(items).sort((a, b) => a.tempId.localeCompare(b.tempId)),
+    [items],
+  )
+
+  const approvedItems = useMemo(
+    () => stagingItems.filter((i) => i.decision === 'approve'),
+    [stagingItems],
+  )
+
+  const selectedItem = selectedTempId ? items[selectedTempId] : null
+
+  const { importApproved, isPending: isImporting } = useImportApproved()
+
+  const handleDecide = (tempId: string, decision: 'approve' | 'skip') => {
+    setItems((prev) => {
+      const item = prev[tempId]
+      if (!item) return prev
+      // Toggle off when re-clicking the active decision.
+      const nextDecision = item.decision === decision ? 'pending' : decision
+      return { ...prev, [tempId]: { ...item, decision: nextDecision } }
+    })
+  }
+
+  const handleDraftChange = (tempId: string, draft: CandidateDraft) => {
+    setItems((prev) => {
+      const item = prev[tempId]
+      if (!item) return prev
+      return { ...prev, [tempId]: { ...item, draft } }
+    })
+  }
+
+  const handleApproveAllNew = () => {
+    setItems((prev) => {
+      const next = { ...prev }
+      for (const tempId of Object.keys(next)) {
+        next[tempId] = { ...next[tempId], decision: 'approve' }
+      }
+      return next
+    })
+  }
+
+  const handleImport = async () => {
+    if (approvedItems.length === 0) return
+
+    // Ensure the provider's default category exists for items that still point
+    // at it by id-less default (categoryId null seeded from a missing category).
+    let resolvedCategoryId = defaultCategoryId
+    const provider = getProvider(providerId)
+    if (resolvedCategoryId == null && provider) {
+      const created = await upsertCategory({
+        name: provider.defaultCategoryName,
+      })
+      if (created.success && created.category) {
+        resolvedCategoryId = created.category.id
+      }
+    }
+
+    const toImport = approvedItems.map((item) =>
+      item.draft.categoryId == null && resolvedCategoryId != null
+        ? { ...item, draft: { ...item.draft, categoryId: resolvedCategoryId } }
+        : item,
+    )
+
+    try {
+      const importedIds = await importApproved(toImport)
+      // Permanently drop the imported rows and KEEP the rest of the list as-is —
+      // no automatic re-analyze. Tracking the tempIds also stops the streaming
+      // reconcile from bringing them back. The main song list still refreshes.
+      const justImported = approvedItems.map((i) => i.tempId)
+      setImportedTempIds((prev) => {
+        const next = new Set(prev)
+        for (const id of justImported) next.add(id)
+        return next
+      })
+      setItems((prev) => {
+        const next: Record<string, StagingItem> = {}
+        for (const [tempId, item] of Object.entries(prev)) {
+          if (!justImported.includes(tempId)) next[tempId] = item
+        }
+        return next
+      })
+      if (selectedTempId && justImported.includes(selectedTempId)) {
+        setSelectedTempId(null)
+      }
+      queryClient.invalidateQueries({ queryKey: ['songs'] })
+      showToast(t('toast.imported', { count: importedIds.length }), 'success')
+    } catch (error) {
+      showToast(t('toast.importFailed', { error: String(error) }), 'error')
+    }
+  }
+
+  // Explicit, user-initiated re-analyze: re-download the catalog and re-run the
+  // diff from scratch (clears the session's imported set).
+  const handleRefresh = () => {
+    setItems({})
+    setImportedTempIds(new Set())
+    setSelectedTempId(null)
+    setRefreshNonce((n) => n + 1)
+    refetch()
+  }
+
+  // Phase booleans for the progress / empty states.
+  const fetchRatio =
+    progress && progress.total ? progress.current / progress.total : null
+  const analyzePct =
+    matchProgress.total > 0
+      ? Math.round((matchProgress.analyzed / matchProgress.total) * 100)
+      : 0
+  const isBusy = isFetching || isMatching
+
+  // Rich progress detail so the bar visibly reports what's happening.
+  const toMb = (bytes: number) => Math.round((bytes / 1024 / 1024) * 10) / 10
+  const fetchLabel = progress
+    ? t(`status.phase.${progress.phase}`, {
+        defaultValue: t('status.fetching'),
+      })
+    : t('status.fetching')
+  const fetchDetail =
+    fetchRatio != null ? `${Math.round(fetchRatio * 100)}%` : undefined
+  const fetchMeta = !progress
+    ? undefined
+    : progress.phase === 'downloading'
+      ? progress.total
+        ? `${toMb(progress.current)} / ${toMb(progress.total)} MB`
+        : progress.current > 0
+          ? `${toMb(progress.current)} MB`
+          : undefined
+      : progress.total
+        ? t('status.filesMeta', {
+            current: progress.current,
+            total: progress.total,
+          })
+        : (progress.currentFile ?? undefined)
+  const analyzeMeta = t('status.analyzeMeta', {
+    analyzed: matchProgress.analyzed.toLocaleString(),
+    total: matchProgress.total.toLocaleString(),
+    found: stagingItems.length,
+  })
+  const loadError = fetchError ?? matchError
+  const showAllPresent =
+    !isBusy && candidates.length > 0 && stagingItems.length === 0
+  const showResults = stagingItems.length > 0
+
+  return (
+    <div className="flex h-full flex-col gap-4 p-4 lg:p-6">
+      {/* Header */}
+      <div className="flex flex-wrap items-center gap-3">
+        {onBack && (
+          <button
+            type="button"
+            onClick={onBack}
+            className="rounded-lg p-2 text-gray-600 transition-colors hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-800"
+            aria-label={t('back')}
+          >
+            <ArrowLeft className="h-5 w-5" />
+          </button>
+        )}
+        <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-xl bg-gradient-to-br from-indigo-500 to-violet-600 text-white shadow-sm">
+          <Sparkles className="h-5 w-5" />
+        </div>
+        <div className="min-w-0 flex-1">
+          <h1 className="truncate text-xl font-semibold text-gray-900 dark:text-white">
+            {t('title')}
+          </h1>
+          <p className="truncate text-sm text-gray-500 dark:text-gray-400">
+            {t('description')}
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={handleRefresh}
+          disabled={isBusy}
+          className="inline-flex items-center gap-2 rounded-lg bg-gray-100 px-4 py-2 text-sm font-medium text-gray-800 transition-colors hover:bg-gray-200 disabled:opacity-50 dark:bg-gray-800 dark:text-gray-100 dark:hover:bg-gray-700"
+        >
+          <RefreshCw className={`h-4 w-4 ${isBusy ? 'animate-spin' : ''}`} />
+          {t('source.refresh')}
+        </button>
+      </div>
+
+      {/* Progress band — download/parse, then analyze, with live counts. */}
+      {isFetching && (
+        <DiscoveryProgress
+          label={fetchLabel}
+          ratio={fetchRatio}
+          detail={fetchDetail}
+          meta={fetchMeta}
+        />
+      )}
+      {!isFetching && isMatching && (
+        <DiscoveryProgress
+          label={t('status.analyzing')}
+          ratio={matchProgress.total > 0 ? analyzePct / 100 : null}
+          detail={matchProgress.total > 0 ? `${analyzePct}%` : undefined}
+          meta={matchProgress.total > 0 ? analyzeMeta : undefined}
+        />
+      )}
+
+      {/* Stats strip */}
+      {(showResults || (!isBusy && candidates.length > 0)) && (
+        <div className="flex flex-wrap items-center gap-2">
+          <StatChip value={candidates.length} label={t('stats.online')} />
+          <StatChip value={stagingItems.length} label={t('stats.new')} accent />
+          {approvedItems.length > 0 && (
+            <StatChip
+              value={approvedItems.length}
+              label={t('stats.selected')}
+            />
+          )}
+        </div>
+      )}
+
+      {loadError && !isBusy && !showResults ? (
+        <div className="flex flex-1 flex-col items-center justify-center gap-3 text-center">
+          <div className="flex h-14 w-14 items-center justify-center rounded-full bg-red-50 text-red-600 dark:bg-red-950/40 dark:text-red-400">
+            <AlertTriangle className="h-6 w-6" />
+          </div>
+          <p className="max-w-sm text-sm text-gray-500 dark:text-gray-400">
+            {t('error.failed')}
+          </p>
+          <button
+            type="button"
+            onClick={handleRefresh}
+            className="inline-flex items-center gap-2 rounded-lg bg-indigo-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-indigo-700"
+          >
+            <RefreshCw className="h-4 w-4" />
+            {t('error.retry')}
+          </button>
+        </div>
+      ) : showAllPresent ? (
+        <div className="flex flex-1 flex-col items-center justify-center gap-3 text-center">
+          <div className="flex h-14 w-14 items-center justify-center rounded-full bg-green-50 text-green-600 dark:bg-green-950/40 dark:text-green-400">
+            <Sparkles className="h-6 w-6" />
+          </div>
+          <p className="max-w-sm text-sm text-gray-500 dark:text-gray-400">
+            {importedTempIds.size > 0 ? t('allDone') : t('allPresent')}
+          </p>
+          {/* Re-analyzing the catalog is now opt-in: offer it here once the list
+              is empty, instead of forcing it after every import. */}
+          <button
+            type="button"
+            onClick={handleRefresh}
+            className="inline-flex items-center gap-2 rounded-lg bg-gray-100 px-4 py-2 text-sm font-medium text-gray-800 transition-colors hover:bg-gray-200 dark:bg-gray-800 dark:text-gray-100 dark:hover:bg-gray-700"
+          >
+            <RefreshCw className="h-4 w-4" />
+            {t('source.refresh')}
+          </button>
+        </div>
+      ) : !showResults && isBusy ? (
+        // Skeleton placeholder while the first results stream in.
+        <div className="flex flex-1 flex-col gap-2">
+          {['a', 'b', 'c', 'd', 'e'].map((k) => (
+            <div
+              key={k}
+              className="h-16 animate-pulse rounded-xl bg-gray-100 dark:bg-gray-800/60"
+            />
+          ))}
+        </div>
+      ) : showResults ? (
+        <>
+          <DiscoveryToolbar
+            totalCount={stagingItems.length}
+            approvedCount={approvedItems.length}
+            onApproveAllNew={handleApproveAllNew}
+            onImport={handleImport}
+            isImporting={isImporting}
+          />
+
+          <div className="flex min-h-0 flex-1 flex-col gap-4 lg:flex-row">
+            <div className="w-full shrink-0 overflow-hidden rounded-xl border border-gray-200 bg-white dark:border-gray-800 dark:bg-gray-900 lg:max-w-sm">
+              <CandidateList
+                items={stagingItems}
+                selectedTempId={selectedTempId}
+                onSelect={setSelectedTempId}
+                onDecide={handleDecide}
+              />
+            </div>
+
+            <div className="min-h-0 flex-1 overflow-y-auto">
+              {selectedItem ? (
+                <CandidateEditorPanel
+                  item={selectedItem}
+                  onDraftChange={handleDraftChange}
+                />
+              ) : (
+                <div className="flex h-full flex-col items-center justify-center gap-2 rounded-xl border border-dashed border-gray-200 p-6 text-center text-sm text-gray-500 dark:border-gray-700 dark:text-gray-400">
+                  <Sparkles className="h-6 w-6 text-gray-300 dark:text-gray-600" />
+                  {t('selectPrompt')}
+                </div>
+              )}
+            </div>
+          </div>
+        </>
+      ) : null}
+    </div>
+  )
+}

--- a/app/apps/client/src/features/song-discovery/components/VerdictBadge.tsx
+++ b/app/apps/client/src/features/song-discovery/components/VerdictBadge.tsx
@@ -1,0 +1,30 @@
+import { useTranslation } from 'react-i18next'
+
+import type { DiscoveryMatchVerdict } from '../types'
+
+/**
+ * Small pill describing how a candidate relates to the library. Only `similar`
+ * and `new` ever reach the staging screen (exact duplicates are filtered out),
+ * but the component handles every verdict for safety.
+ */
+export function VerdictBadge({ verdict }: { verdict: DiscoveryMatchVerdict }) {
+  const { t } = useTranslation('songDiscovery')
+
+  const styles: Record<DiscoveryMatchVerdict, string> = {
+    new: 'bg-green-100 text-green-800 dark:bg-green-900/40 dark:text-green-300',
+    similar:
+      'bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-300',
+    'exact-title':
+      'bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-300',
+    'exact-filename':
+      'bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-300',
+  }
+
+  return (
+    <span
+      className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${styles[verdict]}`}
+    >
+      {t(`verdict.${verdict}`)}
+    </span>
+  )
+}

--- a/app/apps/client/src/features/song-discovery/context/SongDiscoveryContext.tsx
+++ b/app/apps/client/src/features/song-discovery/context/SongDiscoveryContext.tsx
@@ -1,0 +1,97 @@
+import { useNavigate } from '@tanstack/react-router'
+import {
+  createContext,
+  type ReactNode,
+  useContext,
+  useEffect,
+  useRef,
+} from 'react'
+import { useTranslation } from 'react-i18next'
+
+import { usePermissions } from '~/provider/permissions-provider'
+import { useToast } from '~/ui/toast'
+import {
+  type UseSongDiscoverySyncResult,
+  useSongDiscoverySync,
+} from '../hooks/useSongDiscoverySync'
+
+/** Signature already toasted for — one toast per distinct catalog change, ever. */
+const TOASTED_SIGNATURE_KEY = 'song-discovery-toasted-signature'
+
+/** How long the "new songs" toast stays up (the badge is the lingering reminder). */
+const TOAST_DURATION_MS = 15_000
+
+const SongDiscoveryContext = createContext<UseSongDiscoverySyncResult | null>(
+  null,
+)
+
+/**
+ * App-level provider that runs the background catalog sync ONCE (not per
+ * consumer), fires a one-time toast when a fresh batch of new songs appears,
+ * and exposes the badge count + dismiss to the sidebar and other consumers.
+ *
+ * Gated on `songs.create` — users who can't import shouldn't be pinged. Must be
+ * mounted inside the Router, ToastProvider and PermissionsProvider.
+ */
+export function SongDiscoveryProvider({ children }: { children: ReactNode }) {
+  const { t } = useTranslation('songDiscovery')
+  const { showToast } = useToast()
+  const navigate = useNavigate()
+  const { hasPermission } = usePermissions()
+
+  const canImport = hasPermission('songs.create')
+  const sync = useSongDiscoverySync(canImport)
+
+  const { hasUnacknowledgedNew, newCount } = sync
+
+  // Toast exactly once per distinct catalog signature (persisted across
+  // sessions) so the user isn't re-pinged for songs they've already seen.
+  const lastToastedRef = useRef<string | null>(null)
+  useEffect(() => {
+    if (!hasUnacknowledgedNew || newCount <= 0) return
+
+    const currentSignature = localStorage.getItem('song-discovery-signature')
+    if (!currentSignature) return
+
+    const alreadyToasted =
+      localStorage.getItem(TOASTED_SIGNATURE_KEY) === currentSignature
+    if (alreadyToasted || lastToastedRef.current === currentSignature) return
+
+    lastToastedRef.current = currentSignature
+    localStorage.setItem(TOASTED_SIGNATURE_KEY, currentSignature)
+
+    showToast(t('toast.newSongs', { count: newCount }), 'info', {
+      duration: TOAST_DURATION_MS,
+      action: {
+        label: t('toast.view'),
+        onClick: () => navigate({ to: '/songs/discover' }),
+      },
+    })
+  }, [hasUnacknowledgedNew, newCount, showToast, navigate, t])
+
+  return (
+    <SongDiscoveryContext.Provider value={sync}>
+      {children}
+    </SongDiscoveryContext.Provider>
+  )
+}
+
+/**
+ * Consumes the background discovery state (badge count, dismiss, enable
+ * toggle). Returns a safe no-op shape when used outside the provider (e.g. on
+ * screen-only windows that don't mount it).
+ */
+export function useSongDiscovery(): UseSongDiscoverySyncResult {
+  const ctx = useContext(SongDiscoveryContext)
+  if (ctx) return ctx
+  return {
+    badgeCount: 0,
+    enabled: false,
+    setEnabled: () => {},
+    isChecking: false,
+    dismiss: () => {},
+    checkNow: async () => {},
+    hasUnacknowledgedNew: false,
+    newCount: 0,
+  }
+}

--- a/app/apps/client/src/features/song-discovery/hooks/useFetchCatalog.ts
+++ b/app/apps/client/src/features/song-discovery/hooks/useFetchCatalog.ts
@@ -1,0 +1,41 @@
+import { useQuery } from '@tanstack/react-query'
+import { useState } from 'react'
+
+import type { ImportProgress } from '~/features/song-import'
+import { getProvider } from '../providers'
+import type { DiscoveryCandidate } from '../types'
+
+/**
+ * Downloads + parses a source provider's catalog, cached in React Query for an
+ * hour so revisiting the screen (or re-running the diff) doesn't re-download
+ * the multi-MB archive. `progress` tracks the in-flight download/parse phases;
+ * `refetch` forces a fresh pull ("Refresh catalog").
+ */
+export function useFetchCatalog(providerId: string | null) {
+  const [progress, setProgress] = useState<ImportProgress | null>(null)
+
+  const query = useQuery<DiscoveryCandidate[]>({
+    queryKey: ['discovery-catalog', providerId],
+    enabled: providerId != null,
+    staleTime: 1000 * 60 * 60, // 1h — external catalogs change rarely
+    gcTime: 1000 * 60 * 60,
+    retry: false,
+    queryFn: async () => {
+      const provider = providerId ? getProvider(providerId) : undefined
+      if (!provider) throw new Error(`Unknown source provider: ${providerId}`)
+      try {
+        return await provider.fetchCatalog(setProgress)
+      } finally {
+        setProgress(null)
+      }
+    },
+  })
+
+  return {
+    candidates: query.data ?? [],
+    isFetching: query.isFetching,
+    error: query.error,
+    progress,
+    refetch: query.refetch,
+  }
+}

--- a/app/apps/client/src/features/song-discovery/hooks/useImportApproved.ts
+++ b/app/apps/client/src/features/song-discovery/hooks/useImportApproved.ts
@@ -1,0 +1,63 @@
+import { useBatchImportSongs } from '~/features/song-import'
+import type { StagingItem } from '../types'
+
+/** Maps an approved staging item's edited draft to a batch-import song. */
+function draftToBatchSong(item: StagingItem) {
+  const { draft, candidate } = item
+  return {
+    title: draft.title.trim(),
+    slides: draft.slides.map((slide, idx) => ({
+      content: slide.content,
+      sortOrder: idx,
+      label: slide.label ?? null,
+    })),
+    sourceFilename: candidate.sourceFilename,
+    author: draft.metadata.author,
+    copyright: draft.metadata.copyright,
+    ccli: draft.metadata.ccli,
+    tempo: draft.metadata.tempo,
+    timeSignature: draft.metadata.timeSignature,
+    theme: draft.metadata.theme,
+    altTheme: draft.metadata.altTheme,
+    hymnNumber: draft.metadata.hymnNumber,
+    keyLine: draft.metadata.keyLine,
+    presentationOrder: draft.metadata.presentationOrder,
+  }
+}
+
+/**
+ * Imports the approved staging items by reusing the existing batch-import
+ * pipeline. Items are grouped by their (possibly edited) target category so a
+ * single approve set can span categories. `overwriteDuplicates` stays false —
+ * discovery already filtered out everything already in the library, so the
+ * server's insert/skip dedup is just a harmless safety net.
+ */
+export function useImportApproved() {
+  const { batchImport, isPending, progress } = useBatchImportSongs()
+
+  const importApproved = async (approved: StagingItem[]): Promise<number[]> => {
+    if (approved.length === 0) return []
+
+    // Group by target category — batchImport takes one categoryId per call.
+    const byCategory = new Map<number | null, StagingItem[]>()
+    for (const item of approved) {
+      const key = item.draft.categoryId
+      const bucket = byCategory.get(key)
+      if (bucket) bucket.push(item)
+      else byCategory.set(key, [item])
+    }
+
+    const importedIds: number[] = []
+    for (const [categoryId, items] of byCategory) {
+      const result = await batchImport(
+        { songs: items.map(draftToBatchSong), categoryId },
+        { overwriteDuplicates: false, skipManuallyEdited: false },
+      )
+      importedIds.push(...result.songIds)
+    }
+
+    return importedIds
+  }
+
+  return { importApproved, isPending, progress }
+}

--- a/app/apps/client/src/features/song-discovery/hooks/useMatchCandidates.ts
+++ b/app/apps/client/src/features/song-discovery/hooks/useMatchCandidates.ts
@@ -1,0 +1,68 @@
+import { useEffect, useState } from 'react'
+
+import { matchCandidates } from '../service/discoveryApi'
+import type { DiscoveryCandidate, DiscoveryMatchResult } from '../types'
+
+export interface MatchProgress {
+  analyzed: number
+  total: number
+}
+
+/**
+ * Diffs the fetched catalog against the local library, streaming results as
+ * each chunk comes back so the list populates progressively and a progress
+ * indicator can show how much of the catalog has been analyzed.
+ *
+ * Re-runs only when the provider, the candidate set, or `refreshNonce` changes
+ * — NOT when the library changes. Importing a song must not silently re-run the
+ * whole diff; the screen just drops the imported row and the rest of the list
+ * stays put. Bumping `refreshNonce` (the manual "Refresh catalog" action) is the
+ * one explicit way to re-analyze. A run guard prevents a stale run from
+ * committing results after the inputs change.
+ */
+export function useMatchCandidates(
+  providerId: string | null,
+  candidates: DiscoveryCandidate[],
+  refreshNonce: number,
+) {
+  const [results, setResults] = useState<DiscoveryMatchResult[]>([])
+  const [progress, setProgress] = useState<MatchProgress>({
+    analyzed: 0,
+    total: 0,
+  })
+  const [isMatching, setIsMatching] = useState(false)
+  const [error, setError] = useState<unknown>(null)
+
+  useEffect(() => {
+    if (candidates.length === 0) {
+      setResults([])
+      setProgress({ analyzed: 0, total: 0 })
+      setIsMatching(false)
+      return
+    }
+
+    let cancelled = false
+    setIsMatching(true)
+    setError(null)
+    setResults([])
+    setProgress({ analyzed: 0, total: candidates.length })
+
+    matchCandidates(candidates, ({ chunk, analyzed, total }) => {
+      if (cancelled) return
+      setResults((prev) => [...prev, ...chunk])
+      setProgress({ analyzed, total })
+    })
+      .catch((err) => {
+        if (!cancelled) setError(err)
+      })
+      .finally(() => {
+        if (!cancelled) setIsMatching(false)
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [providerId, candidates, refreshNonce])
+
+  return { results, isMatching, progress, error }
+}

--- a/app/apps/client/src/features/song-discovery/hooks/useSongDiscoverySync.ts
+++ b/app/apps/client/src/features/song-discovery/hooks/useSongDiscoverySync.ts
@@ -163,6 +163,12 @@ export function useSongDiscoverySync(
   useEffect(() => {
     if (!enabledExternally || !enabled) return
 
+    // Skip the heavy background catalog check under automated browsers (e2e):
+    // every test runs in a fresh context (empty localStorage), so this would
+    // re-download + re-parse the multi-MB catalog on every test, hammering the
+    // server and the main thread. Tests drive the discovery screen directly.
+    if (typeof navigator !== 'undefined' && navigator.webdriver) return
+
     // Run on every program open regardless of the daily gap — the HEAD check
     // makes an unchanged catalog nearly free, and it lets the Discover button
     // show its "searching" animation right away.

--- a/app/apps/client/src/features/song-discovery/hooks/useSongDiscoverySync.ts
+++ b/app/apps/client/src/features/song-discovery/hooks/useSongDiscoverySync.ts
@@ -1,0 +1,206 @@
+import { useQueryClient } from '@tanstack/react-query'
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+import { PROVIDERS } from '../providers'
+import {
+  countNewCandidates,
+  fetchCatalogSignature,
+} from '../service/discoveryApi'
+
+const ENABLED_KEY = 'song-discovery-enabled'
+const LAST_CHECKED_KEY = 'song-discovery-last-checked'
+const SIGNATURE_KEY = 'song-discovery-signature'
+const NEW_COUNT_KEY = 'song-discovery-new-count'
+const DISMISSED_SIGNATURE_KEY = 'song-discovery-dismissed-signature'
+
+/** Minimum gap between real catalog checks — the user asked for a daily cadence. */
+const MIN_CHECK_GAP_MS = 1000 * 60 * 60 * 24
+
+/** How often the timer re-evaluates (the daily gap above gates the real work). */
+const REEVALUATE_INTERVAL_MS = 1000 * 60 * 60 * 6
+
+/** Let the app settle (render first) before the on-open catalog check fires. */
+const INITIAL_DELAY_MS = 1000 * 2.5
+
+function readNumber(key: string): number {
+  const raw = localStorage.getItem(key)
+  const n = raw ? Number(raw) : 0
+  return Number.isFinite(n) ? n : 0
+}
+
+export interface UseSongDiscoverySyncResult {
+  /** New songs the user lacks, surfaced only while unacknowledged for the badge. */
+  badgeCount: number
+  /** Whether the operator turned the background check off. */
+  enabled: boolean
+  setEnabled: (value: boolean) => void
+  isChecking: boolean
+  /** Mark the current catalog signature seen → hides the badge/toast. */
+  dismiss: () => void
+  /**
+   * Run a check now. `force` re-downloads even when the catalog is unchanged
+   * (manual "Check now"); `ignoreThrottle` runs despite the daily gap but still
+   * skips the download when the HEAD signature is unchanged (on-open check).
+   */
+  checkNow: (opts?: {
+    force?: boolean
+    ignoreThrottle?: boolean
+  }) => Promise<void>
+  /** True the moment a fresh, unacknowledged batch of new songs is detected. */
+  hasUnacknowledgedNew: boolean
+  newCount: number
+}
+
+/**
+ * Background catalog sync: periodically (daily) checks the external source for
+ * songs the library lacks and surfaces a count for a badge + a one-time toast.
+ *
+ * Cheap by design: a HEAD-based signature check skips the multi-MB download
+ * entirely when the catalog hasn't changed since the last check; only a changed
+ * (or first-seen) catalog is downloaded, parsed and counted via the lightweight
+ * /discovery/count endpoint. Results persist in localStorage so the badge
+ * survives reloads without re-checking.
+ *
+ * `enabledExternally` lets the caller gate the whole thing on permission/auth.
+ */
+export function useSongDiscoverySync(
+  enabledExternally: boolean,
+): UseSongDiscoverySyncResult {
+  const queryClient = useQueryClient()
+
+  const [enabled, setEnabledState] = useState<boolean>(
+    () => localStorage.getItem(ENABLED_KEY) !== 'false',
+  )
+  const [newCount, setNewCount] = useState<number>(() =>
+    readNumber(NEW_COUNT_KEY),
+  )
+  const [signature, setSignature] = useState<string>(
+    () => localStorage.getItem(SIGNATURE_KEY) ?? '',
+  )
+  const [dismissedSignature, setDismissedSignature] = useState<string>(
+    () => localStorage.getItem(DISMISSED_SIGNATURE_KEY) ?? '',
+  )
+  const [isChecking, setIsChecking] = useState(false)
+
+  // Guards against overlapping checks (timer + manual + focus).
+  const inFlightRef = useRef(false)
+
+  const setEnabled = useCallback((value: boolean) => {
+    localStorage.setItem(ENABLED_KEY, String(value))
+    setEnabledState(value)
+  }, [])
+
+  const dismiss = useCallback(() => {
+    const current = localStorage.getItem(SIGNATURE_KEY) ?? ''
+    localStorage.setItem(DISMISSED_SIGNATURE_KEY, current)
+    setDismissedSignature(current)
+  }, [])
+
+  const checkNow = useCallback(
+    async (opts?: { force?: boolean; ignoreThrottle?: boolean }) => {
+      const force = opts?.force ?? false
+      const ignoreThrottle = force || (opts?.ignoreThrottle ?? false)
+
+      if (inFlightRef.current) return
+      if (!force && !enabled) return
+      if (
+        !ignoreThrottle &&
+        Date.now() - readNumber(LAST_CHECKED_KEY) < MIN_CHECK_GAP_MS
+      ) {
+        return
+      }
+
+      const provider = PROVIDERS[0]
+      if (!provider) return
+
+      inFlightRef.current = true
+      setIsChecking(true)
+      try {
+        const nextSignature = await fetchCatalogSignature(provider.catalogUrl)
+        const storedSignature = localStorage.getItem(SIGNATURE_KEY) ?? ''
+        const lastChecked = readNumber(LAST_CHECKED_KEY)
+        const dueByTime = Date.now() - lastChecked >= MIN_CHECK_GAP_MS
+
+        if (!force) {
+          // Reliable "unchanged" via the HTTP validator → cheap skip, no download.
+          if (nextSignature && nextSignature === storedSignature) {
+            localStorage.setItem(LAST_CHECKED_KEY, String(Date.now()))
+            return
+          }
+          // No upstream validator to compare against: we can't tell cheaply if
+          // the catalog changed. Don't re-download the whole thing on every open
+          // (it competes with the screen and burns bandwidth) — fall back to the
+          // daily cadence once we've checked at least once.
+          if (!nextSignature && lastChecked > 0 && !dueByTime) {
+            return
+          }
+        }
+
+        const candidates = await provider.fetchCatalog()
+        const count = await countNewCandidates(candidates)
+
+        // Prime the discover screen's cache so opening it doesn't re-download.
+        queryClient.setQueryData(['discovery-catalog', provider.id], candidates)
+
+        localStorage.setItem(SIGNATURE_KEY, nextSignature)
+        localStorage.setItem(NEW_COUNT_KEY, String(count))
+        localStorage.setItem(LAST_CHECKED_KEY, String(Date.now()))
+        setSignature(nextSignature)
+        setNewCount(count)
+      } catch {
+        // Network/permission failure — leave the prior state untouched and try
+        // again on the next tick. No user-facing error for a background job.
+      } finally {
+        inFlightRef.current = false
+        setIsChecking(false)
+      }
+    },
+    [enabled, queryClient],
+  )
+
+  // On-open check (shortly after launch) + periodic re-evaluation. Disabled
+  // entirely when the caller withholds permission or the operator turned it off.
+  useEffect(() => {
+    if (!enabledExternally || !enabled) return
+
+    // Run on every program open regardless of the daily gap — the HEAD check
+    // makes an unchanged catalog nearly free, and it lets the Discover button
+    // show its "searching" animation right away.
+    const initialId = window.setTimeout(() => {
+      void checkNow({ ignoreThrottle: true })
+    }, INITIAL_DELAY_MS)
+
+    const intervalId = window.setInterval(() => {
+      void checkNow()
+    }, REEVALUATE_INTERVAL_MS)
+
+    // A returning user (window focus) gets a fresh check, still daily-throttled.
+    const onFocus = () => {
+      void checkNow()
+    }
+    window.addEventListener('focus', onFocus)
+
+    return () => {
+      window.clearTimeout(initialId)
+      window.clearInterval(intervalId)
+      window.removeEventListener('focus', onFocus)
+    }
+  }, [enabledExternally, enabled, checkNow])
+
+  const hasUnacknowledgedNew =
+    enabled &&
+    newCount > 0 &&
+    signature !== '' &&
+    signature !== dismissedSignature
+
+  return {
+    badgeCount: hasUnacknowledgedNew ? newCount : 0,
+    enabled,
+    setEnabled,
+    isChecking,
+    dismiss,
+    checkNow,
+    hasUnacknowledgedNew,
+    newCount,
+  }
+}

--- a/app/apps/client/src/features/song-discovery/index.ts
+++ b/app/apps/client/src/features/song-discovery/index.ts
@@ -1,0 +1,17 @@
+export { DiscoverButton } from './components/DiscoverButton'
+export { DiscoverySyncSettings } from './components/DiscoverySyncSettings'
+export { SongDiscoveryScreen } from './components/SongDiscoveryScreen'
+export {
+  SongDiscoveryProvider,
+  useSongDiscovery,
+} from './context/SongDiscoveryContext'
+export { PROVIDERS } from './providers'
+export type { SourceProvider } from './providers/types'
+export type {
+  CandidateDraft,
+  DiscoveryCandidate,
+  DiscoveryDecision,
+  DiscoveryMatchResult,
+  DiscoveryMatchVerdict,
+  StagingItem,
+} from './types'

--- a/app/apps/client/src/features/song-discovery/providers/index.ts
+++ b/app/apps/client/src/features/song-discovery/providers/index.ts
@@ -1,0 +1,14 @@
+import { resurseCrestineProvider } from './resurseCrestine'
+import type { SourceProvider } from './types'
+
+/**
+ * Registry of external song sources. Adding a source = append its provider
+ * here. Order is the order shown in the source picker.
+ */
+export const PROVIDERS: SourceProvider[] = [resurseCrestineProvider]
+
+export function getProvider(id: string): SourceProvider | undefined {
+  return PROVIDERS.find((p) => p.id === id)
+}
+
+export type { SourceProvider }

--- a/app/apps/client/src/features/song-discovery/providers/resurseCrestine.ts
+++ b/app/apps/client/src/features/song-discovery/providers/resurseCrestine.ts
@@ -1,0 +1,92 @@
+import {
+  downloadFromUrl,
+  type ParsedSong,
+  processZipFromBuffer,
+  sanitizeSongTitle,
+} from '~/features/song-import'
+import type { SourceProvider } from './types'
+import type { DiscoveryCandidate } from '../types'
+
+const RESURSE_CRESTINE_URL =
+  'https://download.resursecrestine.ro/programe-crestine/cantece-resurse-crestine-opensong-standard.zip'
+const RESURSE_CRESTINE_CATEGORY_NAME = 'Resurse Crestine'
+
+/** A title is "junk" when the OpenSong file had no <title> — the parser then
+ * falls back to the filename, which for untitled entries is "[unnamed] - NNNN"
+ * and sanitizes down to "unnamed" / "Untitled Song". */
+function isJunkTitle(title: string): boolean {
+  const t = title.trim().toLowerCase()
+  return t === '' || t === 'unnamed' || t === 'untitled song'
+}
+
+/** Uses the first non-empty lyric line as the title when the parsed title is
+ * junk — same idea as the one-shot importer's "use first verse as title". */
+function deriveTitle(parsed: ParsedSong): string {
+  if (!isJunkTitle(parsed.title)) return parsed.title
+  for (const slide of parsed.slides) {
+    const firstLine = slide.text
+      ?.split('\n')
+      .map((line) => line.trim())
+      .find(Boolean)
+    if (firstLine) {
+      const derived = sanitizeSongTitle(firstLine)
+      if (!isJunkTitle(derived)) return derived
+    }
+  }
+  return parsed.title
+}
+
+/**
+ * The Resurse Crestine source: a ZIP of OpenSong XML files downloaded from
+ * resursecrestine.ro (proxied through the server for CORS). Reuses the exact
+ * download + parse pipeline the one-shot importer uses; the only difference is
+ * we hand back per-song candidates for review instead of importing in bulk.
+ */
+export const resurseCrestineProvider: SourceProvider = {
+  id: 'resurse-crestine',
+  labelKey: 'sources.resurseCrestine',
+  catalogUrl: RESURSE_CRESTINE_URL,
+  defaultCategoryName: RESURSE_CRESTINE_CATEGORY_NAME,
+
+  async fetchCatalog(onProgress): Promise<DiscoveryCandidate[]> {
+    onProgress?.({
+      phase: 'downloading',
+      current: 0,
+      total: null,
+      currentFile: RESURSE_CRESTINE_CATEGORY_NAME,
+    })
+
+    const zipData = await downloadFromUrl(
+      RESURSE_CRESTINE_URL,
+      (downloaded, total) => {
+        onProgress?.({
+          phase: 'downloading',
+          current: downloaded,
+          total,
+          currentFile: RESURSE_CRESTINE_CATEGORY_NAME,
+        })
+      },
+    )
+
+    const result = await processZipFromBuffer(zipData, onProgress)
+
+    // Only OpenSong files carry the structured metadata (author, hymn number,
+    // key line) the discovery flow surfaces; PPTX entries in this archive are
+    // ignored here to keep candidates uniform.
+    return result.songs
+      .filter((s) => s.sourceFormat === 'opensong')
+      .map((s, index) => {
+        const parsed = s.parsed as ParsedSong
+        // Replace a missing/"unnamed" title with the first lyric line so the
+        // review list reads sensibly and dedup doesn't collapse every untitled
+        // song onto the same "unnamed" title.
+        const title = deriveTitle(parsed)
+        return {
+          tempId: s.sourceFilename ?? `resurse-crestine-${index}`,
+          parsed: title === parsed.title ? parsed : { ...parsed, title },
+          sourceFilename: s.sourceFilename,
+          sourceFormat: 'opensong' as const,
+        }
+      })
+  },
+}

--- a/app/apps/client/src/features/song-discovery/providers/types.ts
+++ b/app/apps/client/src/features/song-discovery/providers/types.ts
@@ -1,0 +1,32 @@
+import type { ImportProgress } from '~/features/song-import'
+import type { DiscoveryCandidate } from '../types'
+
+/**
+ * A source of external songs the discovery flow can pull from. Adding a new
+ * source = implement this interface in one file and register it in
+ * `providers/index.ts` — no other wiring required.
+ *
+ * NB: providers that download from the web must use a domain already present
+ * in the server's `/api/proxy/download` allowlist (apps/server/src/index.ts).
+ */
+export interface SourceProvider {
+  /** Stable id, used as the React Query cache key and provider selector. */
+  id: string
+  /** i18n key (songDiscovery namespace) for the human-readable source name. */
+  labelKey: string
+  /**
+   * URL of the catalog archive. Used by the background sync's cheap HEAD
+   * change-check (skip re-download when unchanged). Its domain must be in the
+   * server's `/api/proxy/download` + `/api/proxy/head` allowlist.
+   */
+  catalogUrl: string
+  /** Downloads + parses the source catalog into comparable candidates. */
+  fetchCatalog(
+    onProgress?: (progress: ImportProgress) => void,
+  ): Promise<DiscoveryCandidate[]>
+  /**
+   * Default category name new songs from this source land in (created on
+   * import if missing). Mirrors the legacy one-shot Resurse Crestine flow.
+   */
+  defaultCategoryName: string
+}

--- a/app/apps/client/src/features/song-discovery/service/discoveryApi.ts
+++ b/app/apps/client/src/features/song-discovery/service/discoveryApi.ts
@@ -1,0 +1,157 @@
+import { fetch as tauriFetch } from '@tauri-apps/plugin-http'
+
+import { getApiUrl } from '~/config'
+import type { DiscoveryCandidate, DiscoveryMatchResult } from '../types'
+
+const isTauri = typeof window !== 'undefined' && '__TAURI_INTERNALS__' in window
+
+/**
+ * Server caps a single match request at 500, but we chunk smaller so the diff
+ * streams in more frequently — the progress bar advances in finer steps instead
+ * of long static pauses between big jumps.
+ */
+const MATCH_CHUNK_SIZE = 150
+
+/** The count endpoint is cheap (no FTS) — larger chunks mean fewer round-trips. */
+const COUNT_CHUNK_SIZE = 5000
+
+/** Joins a candidate's slide HTML into the plain-ish lyrics the matcher needs. */
+function candidateLyrics(candidate: DiscoveryCandidate): string {
+  return candidate.parsed.slides.map((s) => s.htmlContent).join(' ')
+}
+
+/** Progress + freshly-classified results emitted after each match chunk. */
+export interface MatchChunkProgress {
+  /** New chunk verdicts (append to accumulate). */
+  chunk: DiscoveryMatchResult[]
+  /** Candidates classified so far. */
+  analyzed: number
+  /** Total candidates to classify. */
+  total: number
+}
+
+/**
+ * Classifies external candidates against the local library via
+ * POST /api/songs/discovery/match, chunked to respect the server's batch cap.
+ * Returns one verdict per candidate, keyed by `tempId`. `onChunk` fires after
+ * each chunk so the UI can populate the list progressively and show how much of
+ * the catalog has been analyzed.
+ */
+export async function matchCandidates(
+  candidates: DiscoveryCandidate[],
+  onChunk?: (progress: MatchChunkProgress) => void,
+): Promise<DiscoveryMatchResult[]> {
+  const results: DiscoveryMatchResult[] = []
+  const total = candidates.length
+
+  for (let i = 0; i < candidates.length; i += MATCH_CHUNK_SIZE) {
+    const chunk = candidates.slice(i, i + MATCH_CHUNK_SIZE)
+    const response = await fetch(`${getApiUrl()}/api/songs/discovery/match`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        candidates: chunk.map((c) => ({
+          tempId: c.tempId,
+          title: c.parsed.title,
+          lyrics: candidateLyrics(c),
+          sourceFilename: c.sourceFilename,
+        })),
+      }),
+    })
+
+    if (!response.ok) {
+      const errorData = await response.json().catch(() => ({}))
+      throw new Error(errorData.error || `Match failed: ${response.statusText}`)
+    }
+
+    const json = (await response.json()) as { data: DiscoveryMatchResult[] }
+    results.push(...json.data)
+    onChunk?.({
+      chunk: json.data,
+      analyzed: Math.min(i + MATCH_CHUNK_SIZE, total),
+      total,
+    })
+  }
+
+  return results
+}
+
+/**
+ * Counts how many catalog candidates the library lacks via the cheap
+ * POST /api/songs/discovery/count (filename + title only, no FTS). Chunked at
+ * a high cap since the per-candidate cost is just hash lookups. Drives the
+ * background sync's badge/toast without paying for full similarity.
+ */
+export async function countNewCandidates(
+  candidates: DiscoveryCandidate[],
+): Promise<number> {
+  let total = 0
+
+  for (let i = 0; i < candidates.length; i += COUNT_CHUNK_SIZE) {
+    const chunk = candidates.slice(i, i + COUNT_CHUNK_SIZE)
+    const response = await fetch(`${getApiUrl()}/api/songs/discovery/count`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        candidates: chunk.map((c) => ({
+          title: c.parsed.title,
+          sourceFilename: c.sourceFilename,
+        })),
+      }),
+    })
+
+    if (!response.ok) {
+      const errorData = await response.json().catch(() => ({}))
+      throw new Error(errorData.error || `Count failed: ${response.statusText}`)
+    }
+
+    const json = (await response.json()) as { data: { newCount: number } }
+    total += json.data.newCount
+  }
+
+  return total
+}
+
+/**
+ * Cheap change-detector for a catalog URL: returns a signature built from the
+ * archive's HTTP validators (Last-Modified / ETag / Content-Length). The
+ * background sync compares it against the stored value to skip re-downloading
+ * an unchanged catalog. Returns '' when no validator is available (forcing a
+ * download — correctness over efficiency).
+ *
+ * Mirrors `downloadFromUrl`'s transport split: Tauri does a direct HEAD (no
+ * CORS); the browser proxies through the server's `/api/proxy/head`.
+ */
+export async function fetchCatalogSignature(url: string): Promise<string> {
+  try {
+    if (isTauri) {
+      const response = await tauriFetch(url, {
+        method: 'HEAD',
+        redirect: 'follow',
+      })
+      return [
+        response.headers.get('last-modified'),
+        response.headers.get('etag'),
+        response.headers.get('content-length'),
+      ]
+        .filter(Boolean)
+        .join('|')
+    }
+
+    const proxyUrl = `${getApiUrl()}/api/proxy/head?url=${encodeURIComponent(url)}`
+    const response = await fetch(proxyUrl)
+    if (!response.ok) return ''
+    const json = (await response.json()) as {
+      data: {
+        lastModified: string | null
+        etag: string | null
+        contentLength: string | null
+      }
+    }
+    return [json.data.lastModified, json.data.etag, json.data.contentLength]
+      .filter(Boolean)
+      .join('|')
+  } catch {
+    return ''
+  }
+}

--- a/app/apps/client/src/features/song-discovery/types.ts
+++ b/app/apps/client/src/features/song-discovery/types.ts
@@ -1,0 +1,56 @@
+import type { ParsedSong } from '~/features/song-import'
+import type { SongMetadata } from '~/features/songs/components/SongDetailsSection'
+import type { LocalSlide } from '~/features/songs/components/SongSlideList'
+import type { SongVersionSuggestion } from '~/features/songs/types'
+
+/**
+ * One external song parsed from a source provider's catalog, before any
+ * library comparison. `tempId` is a stable client-side correlation id used to
+ * match the server's per-candidate verdict back to this item.
+ */
+export interface DiscoveryCandidate {
+  tempId: string
+  parsed: ParsedSong
+  sourceFilename: string | null
+  sourceFormat: 'opensong' | 'pptx'
+}
+
+/** Mirrors the server's `DiscoveryMatchVerdict`. */
+export type DiscoveryMatchVerdict =
+  | 'exact-filename'
+  | 'exact-title'
+  | 'similar'
+  | 'new'
+
+/** Mirrors the server's `DiscoveryMatchResult` (POST /api/songs/discovery/match). */
+export interface DiscoveryMatchResult {
+  tempId: string
+  verdict: DiscoveryMatchVerdict
+  exactSongId: number | null
+  similar: SongVersionSuggestion[]
+}
+
+/** The operator's per-candidate decision in the staging screen. */
+export type DiscoveryDecision = 'pending' | 'approve' | 'skip'
+
+/** Editable draft of a candidate — seeded from `parsed`, committed on import. */
+export interface CandidateDraft {
+  title: string
+  categoryId: number | null
+  slides: LocalSlide[]
+  metadata: SongMetadata
+}
+
+/**
+ * A candidate the user lacks (verdict `similar` or `new`), enriched with its
+ * library-match verdict and an editable draft. Exact-filename / exact-title
+ * candidates are filtered out before staging — the user already has them.
+ */
+export interface StagingItem {
+  tempId: string
+  candidate: DiscoveryCandidate
+  verdict: DiscoveryMatchVerdict
+  similar: SongVersionSuggestion[]
+  draft: CandidateDraft
+  decision: DiscoveryDecision
+}

--- a/app/apps/client/src/features/song-discovery/utils/__tests__/lyricsDiff.test.ts
+++ b/app/apps/client/src/features/song-discovery/utils/__tests__/lyricsDiff.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+
+import { diffLines, hasChanges, slidesToLines } from '../lyricsDiff'
+
+describe('slidesToLines', () => {
+  it('strips HTML to trimmed lyric lines, blank-separating slides', () => {
+    const lines = slidesToLines([
+      { content: '<p>Line one</p><p>Line two</p>' },
+      { content: '<p>Verse two</p>' },
+    ])
+    expect(lines).toEqual(['Line one', 'Line two', '', 'Verse two'])
+  })
+
+  it('handles <br> and collapses whitespace', () => {
+    expect(slidesToLines([{ content: '<p>a<br>b</p><p>  c  d </p>' }])).toEqual(
+      ['a', 'b', 'c d'],
+    )
+  })
+})
+
+describe('diffLines', () => {
+  it('marks added/removed/context lines (library = base, candidate = head)', () => {
+    const library = ['Lauda pe Domnul', 'Refren vechi', 'Final']
+    const candidate = ['Lauda pe Domnul', 'Refren nou', 'Final']
+    const diff = diffLines(library, candidate)
+    expect(diff).toEqual([
+      { type: 'context', text: 'Lauda pe Domnul' },
+      { type: 'removed', text: 'Refren vechi' },
+      { type: 'added', text: 'Refren nou' },
+      { type: 'context', text: 'Final' },
+    ])
+  })
+
+  it('reports no changes for identical lyrics', () => {
+    const same = ['a', 'b', 'c']
+    expect(hasChanges(diffLines(same, same))).toBe(false)
+  })
+
+  it('detects pure additions', () => {
+    const diff = diffLines(['a'], ['a', 'b'])
+    expect(diff).toEqual([
+      { type: 'context', text: 'a' },
+      { type: 'added', text: 'b' },
+    ])
+    expect(hasChanges(diff)).toBe(true)
+  })
+})

--- a/app/apps/client/src/features/song-discovery/utils/lyricsDiff.ts
+++ b/app/apps/client/src/features/song-discovery/utils/lyricsDiff.ts
@@ -1,0 +1,94 @@
+export type DiffLineType = 'context' | 'added' | 'removed'
+
+export interface DiffLine {
+  type: DiffLineType
+  text: string
+}
+
+/** Converts a slide's HTML content to trimmed, non-empty lyric lines. */
+function htmlToLines(html: string): string[] {
+  // Turn block boundaries into newlines, then read the text.
+  const withBreaks = html
+    .replace(/<br\s*\/?>/gi, '\n')
+    .replace(/<\/(p|div|h[1-6]|li)>/gi, '\n')
+
+  let text: string
+  if (typeof document !== 'undefined') {
+    const tmp = document.createElement('div')
+    tmp.innerHTML = withBreaks
+    text = tmp.textContent ?? ''
+  } else {
+    // SSR / non-DOM fallback: strip tags crudely.
+    text = withBreaks.replace(/<[^>]+>/g, ' ')
+  }
+
+  return text
+    .split('\n')
+    .map((line) => line.replace(/\s+/g, ' ').trim())
+    .filter((line) => line.length > 0)
+}
+
+/**
+ * Flattens HTML slides (a candidate draft or a library song — both store slide
+ * `content` as HTML) into a single list of lyric lines, with a blank separator
+ * between slides so the diff reads block-by-block.
+ */
+export function slidesToLines(slides: Array<{ content: string }>): string[] {
+  const out: string[] = []
+  slides.forEach((slide, index) => {
+    if (index > 0) out.push('')
+    out.push(...htmlToLines(slide.content))
+  })
+  return out
+}
+
+/**
+ * GitHub-style line diff via the classic LCS. `oldLines` is the existing library
+ * song, `newLines` the candidate being imported — so `removed` lines are in the
+ * library but not the new song, and `added` lines are new. O(n·m), which is
+ * trivial for song lyrics (tens of lines).
+ */
+export function diffLines(
+  oldLines: readonly string[],
+  newLines: readonly string[],
+): DiffLine[] {
+  const n = oldLines.length
+  const m = newLines.length
+  // dp[i][j] = LCS length of oldLines[i..] and newLines[j..]
+  const dp: number[][] = Array.from({ length: n + 1 }, () =>
+    new Array(m + 1).fill(0),
+  )
+  for (let i = n - 1; i >= 0; i--) {
+    for (let j = m - 1; j >= 0; j--) {
+      dp[i][j] =
+        oldLines[i] === newLines[j]
+          ? dp[i + 1][j + 1] + 1
+          : Math.max(dp[i + 1][j], dp[i][j + 1])
+    }
+  }
+
+  const out: DiffLine[] = []
+  let i = 0
+  let j = 0
+  while (i < n && j < m) {
+    if (oldLines[i] === newLines[j]) {
+      out.push({ type: 'context', text: oldLines[i] })
+      i++
+      j++
+    } else if (dp[i + 1][j] >= dp[i][j + 1]) {
+      out.push({ type: 'removed', text: oldLines[i] })
+      i++
+    } else {
+      out.push({ type: 'added', text: newLines[j] })
+      j++
+    }
+  }
+  while (i < n) out.push({ type: 'removed', text: oldLines[i++] })
+  while (j < m) out.push({ type: 'added', text: newLines[j++] })
+  return out
+}
+
+/** Whether the two line lists differ at all (drives "identical" messaging). */
+export function hasChanges(diff: readonly DiffLine[]): boolean {
+  return diff.some((line) => line.type !== 'context')
+}

--- a/app/apps/client/src/features/song-import/utils/downloadFromUrl.ts
+++ b/app/apps/client/src/features/song-import/utils/downloadFromUrl.ts
@@ -1,56 +1,122 @@
-import { fetch as tauriFetch } from '@tauri-apps/plugin-http'
-
 import { getApiUrl } from '~/config'
 
-const isTauri = typeof window !== 'undefined' && '__TAURI_INTERNALS__' in window
+/** Bytes per ranged request. Small enough to give frequent progress, big enough
+ * to keep the number of round-trips low (an ~18MB file ≈ 9 requests). */
+const CHUNK_SIZE = 2 * 1024 * 1024
+
+/** Per-request timeout — a single chunk should arrive well within this. */
+const REQUEST_TIMEOUT_MS = 60_000
+
+type ProgressFn = (downloaded: number, total: number | null) => void
 
 /**
- * Downloads a file from a URL and returns it as an ArrayBuffer
- * Uses Tauri fetch when available (no CORS), otherwise proxies through the server
+ * Fetches one byte range through the server proxy. We always go via the proxy
+ * (even in Tauri, where `getApiUrl()` points at the local sidecar) because the
+ * Tauri HTTP plugin's direct streaming proved unreliable — it buffered the body
+ * and the download sat at 0%. The proxy does the ranged fetch server-side, which
+ * is verified to work, and it's the same path every other API call already uses.
+ */
+async function fetchRange(
+  url: string,
+  start: number,
+  end: number,
+): Promise<Response> {
+  const headers = { Range: `bytes=${start}-${end}` }
+  const signal = AbortSignal.timeout(REQUEST_TIMEOUT_MS)
+  const base = getApiUrl() ?? ''
+  const proxyUrl = `${base}/api/proxy/download?url=${encodeURIComponent(url)}`
+  return fetch(proxyUrl, { method: 'GET', headers, signal })
+}
+
+/** Parses the total file size from Content-Range ("bytes a-b/total") or, failing
+ * that, the (full) Content-Length / X-Content-Length headers. */
+function parseTotalBytes(res: Response): number | null {
+  const contentRange = res.headers.get('content-range')
+  if (contentRange) {
+    const match = contentRange.match(/\/(\d+)\s*$/)
+    if (match) return parseInt(match[1], 10)
+  }
+  const len =
+    res.headers.get('content-length') || res.headers.get('x-content-length')
+  return len ? parseInt(len, 10) : null
+}
+
+/** Fallback for servers that ignore Range (200 instead of 206): stream the whole
+ * body, reporting progress per chunk. */
+async function readWholeBody(
+  res: Response,
+  total: number | null,
+  onProgress?: ProgressFn,
+): Promise<ArrayBuffer> {
+  const reader = res.body?.getReader()
+  if (!reader) return res.arrayBuffer()
+
+  const chunks: Uint8Array[] = []
+  let downloaded = 0
+  onProgress?.(0, total)
+  while (true) {
+    const { done, value } = await reader.read()
+    if (done) break
+    chunks.push(value)
+    downloaded += value.length
+    onProgress?.(downloaded, total)
+  }
+  const out = new Uint8Array(downloaded)
+  let offset = 0
+  for (const c of chunks) {
+    out.set(c, offset)
+    offset += c.length
+  }
+  return out.buffer
+}
+
+/**
+ * Downloads a file as an ArrayBuffer using HTTP Range requests so progress is
+ * reliable — each chunk is a small, complete request that returns quickly, and
+ * we report progress after every one. (Single-stream downloads proved
+ * unreliable across the Tauri HTTP plugin and the Bun proxy: the body buffered
+ * and the bar sat at 0% even though the source was fast.) Falls back to a plain
+ * streamed read if the server doesn't honour ranges.
  */
 export async function downloadFromUrl(
   url: string,
-  onProgress?: (downloaded: number, total: number | null) => void,
+  onProgress?: ProgressFn,
 ): Promise<ArrayBuffer> {
-  let response: Response
-
-  if (isTauri) {
-    // Tauri mode: direct fetch (no CORS issues)
-    response = await tauriFetch(url, {
-      method: 'GET',
-      redirect: 'follow',
-    })
-  } else {
-    // Browser mode: use server proxy to bypass CORS
-    const proxyUrl = `${getApiUrl()}/api/proxy/download?url=${encodeURIComponent(url)}`
-    response = await fetch(proxyUrl, {
-      method: 'GET',
-    })
+  // First chunk — also tells us the total size and whether ranges are honoured.
+  const first = await fetchRange(url, 0, CHUNK_SIZE - 1)
+  if (!first.ok) {
+    throw new Error(`Failed to download: ${first.status} ${first.statusText}`)
   }
 
-  if (!response.ok) {
-    throw new Error(
-      `Failed to download: ${response.status} ${response.statusText}`,
-    )
-  }
+  const total = parseTotalBytes(first)
 
-  const contentLength = response.headers.get('content-length')
-  const total = contentLength ? parseInt(contentLength, 10) : null
-
-  const reader = response.body?.getReader()
-  if (!reader) {
-    throw new Error('Failed to get response reader')
+  // No range support (full 200) or unknown size → stream the body we already got.
+  if (first.status !== 206 || total == null) {
+    return readWholeBody(first, total, onProgress)
   }
 
   const chunks: Uint8Array[] = []
   let downloaded = 0
+  onProgress?.(0, total)
 
-  while (true) {
-    const { done, value } = await reader.read()
-    if (done) break
+  const firstBuf = new Uint8Array(await first.arrayBuffer())
+  chunks.push(firstBuf)
+  downloaded += firstBuf.length
+  onProgress?.(downloaded, total)
 
-    chunks.push(value)
-    downloaded += value.length
+  while (downloaded < total) {
+    const start = downloaded
+    const end = Math.min(start + CHUNK_SIZE - 1, total - 1)
+    const res = await fetchRange(url, start, end)
+    if (!res.ok) {
+      throw new Error(
+        `Download failed at ${start} bytes: ${res.status} ${res.statusText}`,
+      )
+    }
+    const buf = new Uint8Array(await res.arrayBuffer())
+    if (buf.length === 0) break // defensive: avoid an infinite loop
+    chunks.push(buf)
+    downloaded += buf.length
     onProgress?.(downloaded, total)
   }
 
@@ -60,6 +126,5 @@ export async function downloadFromUrl(
     result.set(chunk, offset)
     offset += chunk.length
   }
-
   return result.buffer
 }

--- a/app/apps/client/src/features/songs/components/SongBookmarksPanel.tsx
+++ b/app/apps/client/src/features/songs/components/SongBookmarksPanel.tsx
@@ -130,6 +130,18 @@ function SortableBookmarkItem({
             )}
           </div>
         )}
+        {bookmark.songTagNames?.length > 0 && (
+          <div className="flex flex-wrap items-center gap-1 mt-1">
+            {bookmark.songTagNames.map((name) => (
+              <span
+                key={name}
+                className="inline-flex items-center px-1.5 py-0.5 text-[10px] font-medium leading-none bg-indigo-100 dark:bg-indigo-900/40 text-indigo-700 dark:text-indigo-300 rounded"
+              >
+                {name}
+              </span>
+            ))}
+          </div>
+        )}
       </button>
 
       <button
@@ -357,7 +369,8 @@ export function SongBookmarksPanel({
       return (
         b?.songTitle.toLowerCase().includes(q) ||
         b?.songCategoryName?.toLowerCase().includes(q) ||
-        b?.songKeyLine?.toLowerCase().includes(q)
+        b?.songKeyLine?.toLowerCase().includes(q) ||
+        b?.songTagNames?.some((name) => name.toLowerCase().includes(q))
       )
     })
   }, [unifiedItems, searchQuery])

--- a/app/apps/client/src/features/songs/components/SongSlidesPanel.tsx
+++ b/app/apps/client/src/features/songs/components/SongSlidesPanel.tsx
@@ -1,7 +1,16 @@
-import { Check, Loader2, Pencil, Play, X } from 'lucide-react'
+import {
+  AArrowDown,
+  AArrowUp,
+  Check,
+  Loader2,
+  Pencil,
+  Play,
+  X,
+} from 'lucide-react'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
+import { useDividerPosition } from '../../../hooks/useDividerPosition'
 import type { SongSlide, SongWithSlides } from '../types'
 import { expandSongSlidesWithChoruses } from '../utils/expandSongSlides'
 import {
@@ -51,6 +60,22 @@ const TEXTAREA_PADDING_TOP_PX = 8
 
 const SCROLL_OFFSET_TOP = 100
 
+// Reader-controlled font size for the view-mode lyrics list. The base matches
+// Tailwind's `text-sm` (0.875rem); the operator can scale it up/down so the
+// whole-song view stays legible at any panel width. Persisted per-device.
+const SLIDE_FONT_BASE_REM = 0.875
+const SLIDE_FONT_MIN_SCALE = 0.8
+const SLIDE_FONT_MAX_SCALE = 2.2
+const SLIDE_FONT_STEP = 0.1
+const SLIDE_FONT_SCALE_KEY = 'song-slides-font-scale'
+
+function clampFontScale(scale: number): number {
+  return Math.min(
+    SLIDE_FONT_MAX_SCALE,
+    Math.max(SLIDE_FONT_MIN_SCALE, Math.round(scale * 100) / 100),
+  )
+}
+
 // Decode HTML entities the same way the live preview does, so the slide list
 // shows real characters (e.g. an apostrophe) instead of raw codes like
 // `&#039;`. Setting `textContent` does NOT decode entities, which is why the
@@ -92,6 +117,26 @@ export function SongSlidesPanel({
   onApplyText,
 }: SongSlidesPanelProps) {
   const { t } = useTranslation('songs')
+  const [fontScaleRaw, setFontScale] = useDividerPosition(
+    SLIDE_FONT_SCALE_KEY,
+    1,
+  )
+  const fontScale = clampFontScale(fontScaleRaw)
+  const slideTextStyle = useMemo(
+    () => ({
+      fontSize: `${SLIDE_FONT_BASE_REM * fontScale}rem`,
+      lineHeight: 1.4,
+    }),
+    [fontScale],
+  )
+  const decreaseFontSize = useCallback(
+    () => setFontScale(clampFontScale(fontScale - SLIDE_FONT_STEP)),
+    [fontScale, setFontScale],
+  )
+  const increaseFontSize = useCallback(
+    () => setFontScale(clampFontScale(fontScale + SLIDE_FONT_STEP)),
+    [fontScale, setFontScale],
+  )
   const highlightedRef = useRef<HTMLButtonElement>(null)
   const selectedRef = useRef<HTMLButtonElement>(null)
   const containerRef = useRef<HTMLDivElement>(null)
@@ -223,6 +268,30 @@ export function SongSlidesPanel({
               <Pencil size={14} />
               <span>{t('preview.editMode')}</span>
             </button>
+          )}
+          {!isEditMode && (
+            <div className="flex items-center gap-0.5">
+              <button
+                type="button"
+                onClick={decreaseFontSize}
+                disabled={fontScale <= SLIDE_FONT_MIN_SCALE}
+                title={t('preview.decreaseFontSize')}
+                aria-label={t('preview.decreaseFontSize')}
+                className="flex items-center justify-center p-1.5 rounded-lg border border-gray-300 dark:border-gray-600 text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+              >
+                <AArrowDown size={16} />
+              </button>
+              <button
+                type="button"
+                onClick={increaseFontSize}
+                disabled={fontScale >= SLIDE_FONT_MAX_SCALE}
+                title={t('preview.increaseFontSize')}
+                aria-label={t('preview.increaseFontSize')}
+                className="flex items-center justify-center p-1.5 rounded-lg border border-gray-300 dark:border-gray-600 text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+              >
+                <AArrowUp size={18} />
+              </button>
+            </div>
           )}
         </div>
         {isEditMode && (
@@ -375,12 +444,14 @@ export function SongSlidesPanel({
                 >
                   <div className="flex items-start gap-2">
                     <span
-                      className={`font-semibold text-sm min-w-[24px] ${getNumberClass()}`}
+                      style={slideTextStyle}
+                      className={`font-semibold min-w-[24px] ${getNumberClass()}`}
                     >
                       {index + 1}
                     </span>
                     <span
-                      className={`text-sm whitespace-pre-line flex-1 ${getTextClass()}`}
+                      style={slideTextStyle}
+                      className={`whitespace-pre-line flex-1 ${getTextClass()}`}
                     >
                       {plainText}
                     </span>

--- a/app/apps/client/src/features/songs/components/SongsSettingsPanel.tsx
+++ b/app/apps/client/src/features/songs/components/SongsSettingsPanel.tsx
@@ -1,5 +1,6 @@
 import { AISearchSettings } from '~/features/ai-search'
 import { SynonymManager } from '~/features/search'
+import { DiscoverySyncSettings } from '~/features/song-discovery'
 import { ImportExportManager } from '~/features/song-export'
 import { CategoryManager } from './CategoryManager'
 import { TagManager } from './TagManager'
@@ -23,6 +24,9 @@ export function SongsSettingsPanel() {
       </div>
       <div className={cardClass}>
         <ImportExportManager />
+      </div>
+      <div className={cardClass}>
+        <DiscoverySyncSettings />
       </div>
       <div className={cardClass}>
         <SynonymManager />

--- a/app/apps/client/src/features/songs/service/bookmarks.ts
+++ b/app/apps/client/src/features/songs/service/bookmarks.ts
@@ -6,6 +6,7 @@ export interface SongBookmark {
   songTitle: string
   songCategoryName: string | null
   songKeyLine: string | null
+  songTagNames: string[]
   sortOrder: number
   createdAt: number
 }

--- a/app/apps/client/src/i18n/config.ts
+++ b/app/apps/client/src/i18n/config.ts
@@ -15,6 +15,7 @@ import releaseNotesEN from './locales/en/releaseNotes.json'
 import schedulesEN from './locales/en/schedules.json'
 import settingsEN from './locales/en/settings.json'
 import sidebarEN from './locales/en/sidebar.json'
+import songDiscoveryEN from './locales/en/songDiscovery.json'
 import songKeyEN from './locales/en/songKey.json'
 import songsEN from './locales/en/songs.json'
 import usersEN from './locales/en/users.json'
@@ -30,6 +31,7 @@ import releaseNotesRO from './locales/ro/releaseNotes.json'
 import schedulesRO from './locales/ro/schedules.json'
 import settingsRO from './locales/ro/settings.json'
 import sidebarRO from './locales/ro/sidebar.json'
+import songDiscoveryRO from './locales/ro/songDiscovery.json'
 import songKeyRO from './locales/ro/songKey.json'
 import songsRO from './locales/ro/songs.json'
 import usersRO from './locales/ro/users.json'
@@ -48,6 +50,7 @@ export const resources = {
     schedules: schedulesEN,
     sidebar: sidebarEN,
     settings: settingsEN,
+    songDiscovery: songDiscoveryEN,
     songKey: songKeyEN,
     songs: songsEN,
     users: usersEN,
@@ -65,6 +68,7 @@ export const resources = {
     schedules: schedulesRO,
     sidebar: sidebarRO,
     settings: settingsRO,
+    songDiscovery: songDiscoveryRO,
     songKey: songKeyRO,
     songs: songsRO,
     users: usersRO,
@@ -92,6 +96,7 @@ i18n
       'schedules',
       'sidebar',
       'settings',
+      'songDiscovery',
       'songKey',
       'songs',
       'users',

--- a/app/apps/client/src/i18n/locales/en/songDiscovery.json
+++ b/app/apps/client/src/i18n/locales/en/songDiscovery.json
@@ -1,0 +1,77 @@
+{
+  "title": "Discover new songs",
+  "description": "Find songs from external sources that aren't in your library yet, review them, and import only what you want.",
+  "button": {
+    "discover": "Discover",
+    "searching": "Searching"
+  },
+  "back": "Back to songs",
+  "selectPrompt": "Select a song on the left to review and edit it before importing.",
+  "allPresent": "Your library already contains every song from this source.",
+  "allDone": "You've reviewed all the new songs. Refresh the catalog to check for more.",
+  "emptyStaging": "No new songs to review.",
+  "error": {
+    "failed": "Couldn't load the catalog. Check your connection and try again.",
+    "retry": "Try again"
+  },
+  "untitled": "(untitled)",
+  "editorHint": "Edits here apply only to the imported copy. Nothing is saved until you import.",
+  "source": {
+    "label": "Source",
+    "fetch": "Fetch catalog",
+    "refresh": "Refresh catalog"
+  },
+  "sources": {
+    "resurseCrestine": "Resurse Crestine"
+  },
+  "status": {
+    "fetching": "Downloading and parsing the catalog…",
+    "matching": "Comparing against your library…",
+    "analyzing": "Analyzing songs against your library…",
+    "analyzeMeta": "{{analyzed}} of {{total}} analyzed · {{found}} new found",
+    "filesMeta": "{{current}} / {{total}} songs",
+    "phase": {
+      "downloading": "Downloading the catalog…",
+      "extracting": "Extracting the archive…",
+      "converting": "Converting files…",
+      "parsing": "Reading the songs…",
+      "saving": "Saving…"
+    }
+  },
+  "stats": {
+    "online": "online",
+    "new": "new",
+    "selected": "selected"
+  },
+  "verdict": {
+    "new": "New",
+    "similar": "Similar exists",
+    "exact-title": "Already in library",
+    "exact-filename": "Already in library"
+  },
+  "similar": {
+    "title": "Similar in your library ({{count}})"
+  },
+  "actions": {
+    "approve": "Import",
+    "skip": "Skip"
+  },
+  "toolbar": {
+    "summary": "{{total}} new · {{approved}} selected",
+    "approveAllNew": "Select all",
+    "importApproved": "Import selected ({{count}})"
+  },
+  "toast": {
+    "imported": "Imported {{count}} song(s)",
+    "importFailed": "Import failed: {{error}}",
+    "newSongs": "{{count}} new song(s) available to import",
+    "view": "View"
+  },
+  "settings": {
+    "title": "Background check for new songs",
+    "description": "Periodically check the external source in the background and notify you when new songs are available to import.",
+    "enableLabel": "Check for new songs automatically",
+    "checkNow": "Check now",
+    "newCount": "{{count}} new song(s) found"
+  }
+}

--- a/app/apps/client/src/i18n/locales/en/songDiscovery.json
+++ b/app/apps/client/src/i18n/locales/en/songDiscovery.json
@@ -1,8 +1,8 @@
 {
-  "title": "Discover new songs",
-  "description": "Find songs from external sources that aren't in your library yet, review them, and import only what you want.",
+  "title": "Download the latest songs from Resurse Crestine",
+  "description": "Brings the newest songs from Resurse Crestine that aren't in your library yet, lets you review them, and import only what you want.",
   "button": {
-    "discover": "Discover",
+    "discover": "Download songs",
     "searching": "Searching"
   },
   "back": "Back to songs",

--- a/app/apps/client/src/i18n/locales/en/songDiscovery.json
+++ b/app/apps/client/src/i18n/locales/en/songDiscovery.json
@@ -52,6 +52,14 @@
   "similar": {
     "title": "Similar in your library ({{count}})"
   },
+  "diff": {
+    "show": "Compare",
+    "hide": "Hide",
+    "loading": "Loading the library song…",
+    "identical": "The lyrics are identical.",
+    "inLibrary": "in your library",
+    "inCatalog": "in the catalog"
+  },
   "actions": {
     "approve": "Import",
     "skip": "Skip"

--- a/app/apps/client/src/i18n/locales/en/songs.json
+++ b/app/apps/client/src/i18n/locales/en/songs.json
@@ -197,7 +197,9 @@
     "chorusRepeat": "Auto-inserted chorus",
     "editAsText": "Edit as Text",
     "slideAdded": "Slide added",
-    "presentSlide": "Present this slide"
+    "presentSlide": "Present this slide",
+    "increaseFontSize": "Increase text size",
+    "decreaseFontSize": "Decrease text size"
   },
   "metadata": {
     "detailsSection": "Details",

--- a/app/apps/client/src/i18n/locales/en/songs.json
+++ b/app/apps/client/src/i18n/locales/en/songs.json
@@ -2,6 +2,7 @@
   "title": "Songs",
   "actions": {
     "create": "New Song",
+    "discover": "Discover",
     "save": "Save",
     "delete": "Delete",
     "back": "Back to Songs",

--- a/app/apps/client/src/i18n/locales/en/songs.json
+++ b/app/apps/client/src/i18n/locales/en/songs.json
@@ -1,5 +1,9 @@
 {
   "title": "Songs",
+  "layout": {
+    "hidePanel": "Hide side panel",
+    "showPanel": "Show side panel"
+  },
   "actions": {
     "create": "New Song",
     "discover": "Discover",

--- a/app/apps/client/src/i18n/locales/ro/songDiscovery.json
+++ b/app/apps/client/src/i18n/locales/ro/songDiscovery.json
@@ -1,0 +1,77 @@
+{
+  "title": "Descoperă cântări noi",
+  "description": "Găsește cântări din surse externe care nu sunt încă în biblioteca ta, verifică-le și importă doar ce dorești.",
+  "button": {
+    "discover": "Descoperă",
+    "searching": "Caut"
+  },
+  "back": "Înapoi la cântări",
+  "selectPrompt": "Selectează o cântare din stânga pentru a o verifica și edita înainte de import.",
+  "allPresent": "Biblioteca ta conține deja toate cântările din această sursă.",
+  "allDone": "Ai verificat toate cântările noi. Reîmprospătează catalogul ca să cauți altele.",
+  "emptyStaging": "Nu sunt cântări noi de verificat.",
+  "error": {
+    "failed": "Catalogul nu a putut fi încărcat. Verifică conexiunea și încearcă din nou.",
+    "retry": "Încearcă din nou"
+  },
+  "untitled": "(fără titlu)",
+  "editorHint": "Modificările de aici se aplică doar copiei importate. Nimic nu se salvează până la import.",
+  "source": {
+    "label": "Sursă",
+    "fetch": "Descarcă catalogul",
+    "refresh": "Reîmprospătează catalogul"
+  },
+  "sources": {
+    "resurseCrestine": "Resurse Creștine"
+  },
+  "status": {
+    "fetching": "Se descarcă și se prelucrează catalogul…",
+    "matching": "Se compară cu biblioteca ta…",
+    "analyzing": "Se analizează cântările față de biblioteca ta…",
+    "analyzeMeta": "{{analyzed}} din {{total}} analizate · {{found}} noi găsite",
+    "filesMeta": "{{current}} / {{total}} cântări",
+    "phase": {
+      "downloading": "Se descarcă catalogul…",
+      "extracting": "Se extrage arhiva…",
+      "converting": "Se convertesc fișierele…",
+      "parsing": "Se citesc cântările…",
+      "saving": "Se salvează…"
+    }
+  },
+  "stats": {
+    "online": "online",
+    "new": "noi",
+    "selected": "selectate"
+  },
+  "verdict": {
+    "new": "Nouă",
+    "similar": "Există ceva similar",
+    "exact-title": "Deja în bibliotecă",
+    "exact-filename": "Deja în bibliotecă"
+  },
+  "similar": {
+    "title": "Similare în biblioteca ta ({{count}})"
+  },
+  "actions": {
+    "approve": "Importă",
+    "skip": "Omite"
+  },
+  "toolbar": {
+    "summary": "{{total}} noi · {{approved}} selectate",
+    "approveAllNew": "Selectează tot",
+    "importApproved": "Importă selecția ({{count}})"
+  },
+  "toast": {
+    "imported": "Au fost importate {{count}} cântări",
+    "importFailed": "Importul a eșuat: {{error}}",
+    "newSongs": "{{count}} cântări noi disponibile pentru import",
+    "view": "Vezi"
+  },
+  "settings": {
+    "title": "Verificare în fundal pentru cântări noi",
+    "description": "Verifică periodic sursa externă în fundal și te anunță când sunt cântări noi disponibile pentru import.",
+    "enableLabel": "Verifică automat cântările noi",
+    "checkNow": "Verifică acum",
+    "newCount": "{{count}} cântări noi găsite"
+  }
+}

--- a/app/apps/client/src/i18n/locales/ro/songDiscovery.json
+++ b/app/apps/client/src/i18n/locales/ro/songDiscovery.json
@@ -1,8 +1,8 @@
 {
-  "title": "Descoperă cântări noi",
-  "description": "Găsește cântări din surse externe care nu sunt încă în biblioteca ta, verifică-le și importă doar ce dorești.",
+  "title": "Descarcă ultimele cântări de pe Resurse Creștine",
+  "description": "Aduce cele mai noi cântări de pe Resurse Creștine care nu sunt încă în biblioteca ta, le verifică și importă doar ce dorești.",
   "button": {
-    "discover": "Descoperă",
+    "discover": "Descarcă cântări",
     "searching": "Caut"
   },
   "back": "Înapoi la cântări",

--- a/app/apps/client/src/i18n/locales/ro/songDiscovery.json
+++ b/app/apps/client/src/i18n/locales/ro/songDiscovery.json
@@ -52,6 +52,14 @@
   "similar": {
     "title": "Similare în biblioteca ta ({{count}})"
   },
+  "diff": {
+    "show": "Compară",
+    "hide": "Ascunde",
+    "loading": "Se încarcă cântarea din bibliotecă…",
+    "identical": "Versurile sunt identice.",
+    "inLibrary": "în biblioteca ta",
+    "inCatalog": "în catalog"
+  },
   "actions": {
     "approve": "Importă",
     "skip": "Omite"

--- a/app/apps/client/src/i18n/locales/ro/songs.json
+++ b/app/apps/client/src/i18n/locales/ro/songs.json
@@ -1,5 +1,9 @@
 {
   "title": "Cântări",
+  "layout": {
+    "hidePanel": "Ascunde panoul lateral",
+    "showPanel": "Afișează panoul lateral"
+  },
   "actions": {
     "create": "Cântare nouă",
     "discover": "Descoperă",

--- a/app/apps/client/src/i18n/locales/ro/songs.json
+++ b/app/apps/client/src/i18n/locales/ro/songs.json
@@ -2,6 +2,7 @@
   "title": "Cântări",
   "actions": {
     "create": "Cântare nouă",
+    "discover": "Descoperă",
     "save": "Salvează",
     "delete": "Șterge",
     "back": "Înapoi la cântări",

--- a/app/apps/client/src/i18n/locales/ro/songs.json
+++ b/app/apps/client/src/i18n/locales/ro/songs.json
@@ -197,7 +197,9 @@
     "chorusRepeat": "Refren inserat automat",
     "editAsText": "Editează ca text",
     "slideAdded": "Slide adăugat",
-    "presentSlide": "Afișează acest slide"
+    "presentSlide": "Afișează acest slide",
+    "increaseFontSize": "Mărește textul",
+    "decreaseFontSize": "Micșorează textul"
   },
   "metadata": {
     "detailsSection": "Detalii",

--- a/app/apps/client/src/routeTree.gen.ts
+++ b/app/apps/client/src/routeTree.gen.ts
@@ -21,6 +21,7 @@ import { Route as LiveTranslationIndexRouteImport } from './routes/live-translat
 import { Route as DashboardIndexRouteImport } from './routes/dashboard/index'
 import { Route as BibleIndexRouteImport } from './routes/bible/index'
 import { Route as rootIndexRouteImport } from './routes/(root)/index'
+import { Route as SongsDiscoverRouteImport } from './routes/songs/discover'
 import { Route as SettingsUsersRouteImport } from './routes/settings/users'
 import { Route as SettingsSongsRouteImport } from './routes/settings/songs'
 import { Route as SettingsSidebarRouteImport } from './routes/settings/sidebar'
@@ -101,6 +102,11 @@ const BibleIndexRoute = BibleIndexRouteImport.update({
 const rootIndexRoute = rootIndexRouteImport.update({
   id: '/(root)/',
   path: '/',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const SongsDiscoverRoute = SongsDiscoverRouteImport.update({
+  id: '/songs/discover',
+  path: '/songs/discover',
   getParentRoute: () => rootRouteImport,
 } as any)
 const SettingsUsersRoute = SettingsUsersRouteImport.update({
@@ -229,6 +235,7 @@ export interface FileRoutesByFullPath {
   '/settings/sidebar': typeof SettingsSidebarRoute
   '/settings/songs': typeof SettingsSongsRoute
   '/settings/users': typeof SettingsUsersRoute
+  '/songs/discover': typeof SongsDiscoverRoute
   '/': typeof rootIndexRoute
   '/bible/': typeof BibleIndexRoute
   '/dashboard/': typeof DashboardIndexRoute
@@ -263,6 +270,7 @@ export interface FileRoutesByTo {
   '/settings/sidebar': typeof SettingsSidebarRoute
   '/settings/songs': typeof SettingsSongsRoute
   '/settings/users': typeof SettingsUsersRoute
+  '/songs/discover': typeof SongsDiscoverRoute
   '/': typeof rootIndexRoute
   '/bible': typeof BibleIndexRoute
   '/dashboard': typeof DashboardIndexRoute
@@ -299,6 +307,7 @@ export interface FileRoutesById {
   '/settings/sidebar': typeof SettingsSidebarRoute
   '/settings/songs': typeof SettingsSongsRoute
   '/settings/users': typeof SettingsUsersRoute
+  '/songs/discover': typeof SongsDiscoverRoute
   '/(root)/': typeof rootIndexRoute
   '/bible/': typeof BibleIndexRoute
   '/dashboard/': typeof DashboardIndexRoute
@@ -336,6 +345,7 @@ export interface FileRouteTypes {
     | '/settings/sidebar'
     | '/settings/songs'
     | '/settings/users'
+    | '/songs/discover'
     | '/'
     | '/bible/'
     | '/dashboard/'
@@ -370,6 +380,7 @@ export interface FileRouteTypes {
     | '/settings/sidebar'
     | '/settings/songs'
     | '/settings/users'
+    | '/songs/discover'
     | '/'
     | '/bible'
     | '/dashboard'
@@ -405,6 +416,7 @@ export interface FileRouteTypes {
     | '/settings/sidebar'
     | '/settings/songs'
     | '/settings/users'
+    | '/songs/discover'
     | '/(root)/'
     | '/bible/'
     | '/dashboard/'
@@ -426,6 +438,7 @@ export interface RootRouteChildren {
   CustomPagePageIdRoute: typeof CustomPagePageIdRoute
   SchedulesScheduleIdRoute: typeof SchedulesScheduleIdRoute
   ScreenScreenIdRoute: typeof ScreenScreenIdRoute
+  SongsDiscoverRoute: typeof SongsDiscoverRoute
   rootIndexRoute: typeof rootIndexRoute
   BibleIndexRoute: typeof BibleIndexRoute
   DashboardIndexRoute: typeof DashboardIndexRoute
@@ -525,6 +538,13 @@ declare module '@tanstack/react-router' {
       path: '/'
       fullPath: '/'
       preLoaderRoute: typeof rootIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/songs/discover': {
+      id: '/songs/discover'
+      path: '/songs/discover'
+      fullPath: '/songs/discover'
+      preLoaderRoute: typeof SongsDiscoverRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/settings/users': {
@@ -724,6 +744,7 @@ const rootRouteChildren: RootRouteChildren = {
   CustomPagePageIdRoute: CustomPagePageIdRoute,
   SchedulesScheduleIdRoute: SchedulesScheduleIdRoute,
   ScreenScreenIdRoute: ScreenScreenIdRoute,
+  SongsDiscoverRoute: SongsDiscoverRoute,
   rootIndexRoute: rootIndexRoute,
   BibleIndexRoute: BibleIndexRoute,
   DashboardIndexRoute: DashboardIndexRoute,

--- a/app/apps/client/src/routes/__root.tsx
+++ b/app/apps/client/src/routes/__root.tsx
@@ -31,6 +31,7 @@ import {
   useReopenScreensOnPresentation,
 } from '~/features/presentation/hooks'
 import { useAutoOpenPageWindows } from '~/features/sidebar-config/hooks'
+import { SongDiscoveryProvider } from '~/features/song-discovery'
 import { FileDropZoneProvider } from '~/features/song-import'
 import { I18nProvider } from '~/provider/i18n-provider'
 import { PermissionsProvider } from '~/provider/permissions-provider'
@@ -170,9 +171,11 @@ function MainLayout() {
                               <AutoOpenPageWindows />
                               <SidebarNavigationListener />
                               <GlobalAppShortcutManager />
-                              <AppLayout>
-                                <Outlet />
-                              </AppLayout>
+                              <SongDiscoveryProvider>
+                                <AppLayout>
+                                  <Outlet />
+                                </AppLayout>
+                              </SongDiscoveryProvider>
                             </FileDropZoneProvider>
                           </ShortcutRecordingProvider>
                         </MIDISettingsProvider>

--- a/app/apps/client/src/routes/songs/$songId/index.tsx
+++ b/app/apps/client/src/routes/songs/$songId/index.tsx
@@ -16,6 +16,8 @@ import {
   Loader2,
   Music,
   Music2,
+  PanelRightClose,
+  PanelRightOpen,
   Pencil,
   Tag,
 } from 'lucide-react'
@@ -206,6 +208,26 @@ function SongPreviewPage() {
     setVersionsOpenRaw(next)
     try {
       localStorage.setItem('song-detail:versions-open', String(next))
+    } catch {
+      // Ignore quota errors — non-critical UI state.
+    }
+  }, [])
+  // Whether the entire right column (Marcaje + Versiuni) is shown. When hidden
+  // the Control panel takes the full width of its area, leaving only a slim
+  // rail to bring the column back. Desktop-only; persisted across sessions.
+  const [accordionColumnVisible, setAccordionColumnVisibleRaw] =
+    useState<boolean>(() => {
+      try {
+        const raw = localStorage.getItem('song-detail:accordion-column-visible')
+        return raw === null ? true : raw === 'true'
+      } catch {
+        return true
+      }
+    })
+  const setAccordionColumnVisible = useCallback((next: boolean) => {
+    setAccordionColumnVisibleRaw(next)
+    try {
+      localStorage.setItem('song-detail:accordion-column-visible', String(next))
     } catch {
       // Ignore quota errors — non-critical UI state.
     }
@@ -601,10 +623,16 @@ function SongPreviewPage() {
   // Marcaje takes the whole height).
   const accordionSplitActive =
     isLargeScreen &&
+    accordionColumnVisible &&
     bookmarksOpen &&
     versionsOpen &&
     Boolean(song) &&
     canViewSongVersions
+
+  // The right column can be hidden entirely on desktop to give the Slides and
+  // Stage columns more room. On mobile it always renders (Versiuni is the only
+  // visible section there).
+  const showAccordionColumn = !isLargeScreen || accordionColumnVisible
 
   return (
     <div className="flex flex-col h-full lg:overflow-hidden lg:h-[calc(100vh-3rem)] overflow-auto scrollbar-thin">
@@ -780,12 +808,14 @@ function SongPreviewPage() {
               : undefined
           }
         >
-          {/* Control Panel column (now owns the full height of its column). */}
+          {/* Control Panel column (now owns the full height of its column).
+              When the right column is hidden it grows to fill the row, leaving
+              only the slim rail below for bringing the column back. */}
           <div
             className="h-full overflow-hidden"
             style={
-              isLargeScreen
-                ? { width: `calc(${rightDividerPosition}% - 4px)` }
+              isLargeScreen && accordionColumnVisible
+                ? { width: `calc(${rightDividerPosition}% - 12px)` }
                 : { flex: 1, minWidth: 0 }
             }
           >
@@ -798,27 +828,57 @@ function SongPreviewPage() {
             />
           </div>
 
-          {/* Vertical Divider */}
-          <div
-            className="hidden lg:flex items-center justify-center w-2 cursor-col-resize hover:bg-indigo-100 dark:hover:bg-indigo-900/30 rounded transition-colors group"
-            onMouseDown={handleRightDividerMouseDown}
-          >
-            <GripVertical
-              size={16}
-              className="text-gray-400 group-hover:text-indigo-500 transition-colors"
-            />
+          {/* Boundary bar — hosts the show/hide toggle for the whole right
+              column plus the drag grip that resizes it. Desktop only; the bar
+              stays put when collapsed so the rail toggle is always reachable. */}
+          <div className="hidden lg:flex w-6 shrink-0 flex-col items-center">
+            <button
+              type="button"
+              onClick={() => setAccordionColumnVisible(!accordionColumnVisible)}
+              aria-expanded={accordionColumnVisible}
+              aria-label={
+                accordionColumnVisible
+                  ? t('layout.hidePanel')
+                  : t('layout.showPanel')
+              }
+              title={
+                accordionColumnVisible
+                  ? t('layout.hidePanel')
+                  : t('layout.showPanel')
+              }
+              className="mt-1 flex h-6 w-6 shrink-0 items-center justify-center rounded text-gray-400 transition-colors hover:bg-indigo-100 hover:text-indigo-500 dark:hover:bg-indigo-900/30"
+            >
+              {accordionColumnVisible ? (
+                <PanelRightClose size={16} />
+              ) : (
+                <PanelRightOpen size={16} />
+              )}
+            </button>
+            {accordionColumnVisible ? (
+              <div
+                className="group mt-1 flex flex-1 w-full cursor-col-resize items-center justify-center rounded transition-colors hover:bg-indigo-100 dark:hover:bg-indigo-900/30"
+                onMouseDown={handleRightDividerMouseDown}
+              >
+                <GripVertical
+                  size={16}
+                  className="text-gray-400 group-hover:text-indigo-500 transition-colors"
+                />
+              </div>
+            ) : null}
           </div>
 
           {/* Accordion column — Marcaje on top, Versiuni below.
               Bookmarks were previously hidden on mobile (the page is
               too tight); we preserve that. Versions ride along on
-              mobile because they were already visible there before. */}
+              mobile because they were already visible there before.
+              Hidden entirely on desktop when the operator collapses it. */}
+          {showAccordionColumn ? (
           <div
             ref={accordionColumnRef}
             className={`overflow-hidden h-full flex flex-col ${accordionSplitActive ? '' : 'gap-2'}`}
             style={
               isLargeScreen
-                ? { width: `calc(${100 - rightDividerPosition}% - 4px)` }
+                ? { width: `calc(${100 - rightDividerPosition}% - 12px)` }
                 : undefined
             }
           >
@@ -898,6 +958,7 @@ function SongPreviewPage() {
               </div>
             ) : null}
           </div>
+          ) : null}
         </div>
       </div>
 

--- a/app/apps/client/src/routes/songs/discover.tsx
+++ b/app/apps/client/src/routes/songs/discover.tsx
@@ -1,0 +1,29 @@
+import { createFileRoute, useNavigate } from '@tanstack/react-router'
+import { useEffect } from 'react'
+
+import {
+  SongDiscoveryScreen,
+  useSongDiscovery,
+} from '~/features/song-discovery'
+import { PagePermissionGuard } from '~/ui/PagePermissionGuard'
+
+export const Route = createFileRoute('/songs/discover')({
+  component: SongDiscoverPage,
+})
+
+function SongDiscoverPage() {
+  const navigate = useNavigate()
+  const { dismiss } = useSongDiscovery()
+
+  // Opening this screen is the "I've seen it" signal — clear the sidebar badge.
+  useEffect(() => {
+    dismiss()
+  }, [dismiss])
+
+  // Discovering + importing songs is a create operation — gate on songs.create.
+  return (
+    <PagePermissionGuard permission="songs.create">
+      <SongDiscoveryScreen onBack={() => navigate({ to: '/songs' })} />
+    </PagePermissionGuard>
+  )
+}

--- a/app/apps/client/src/routes/songs/index.tsx
+++ b/app/apps/client/src/routes/songs/index.tsx
@@ -7,6 +7,7 @@ import { useFocusSearchEvent } from '~/features/keyboard-shortcuts/utils'
 import { getSongsLastVisited } from '~/features/navigation'
 import { usePresentationState } from '~/features/presentation'
 import { AddSongToScheduleModal } from '~/features/schedules'
+import { DiscoverButton } from '~/features/song-discovery'
 import { SongBookmarksPanel, SongList } from '~/features/songs/components'
 import { useSearchHistoryById } from '~/features/songs/hooks'
 import { openSongWindow } from '~/features/songs/utils/openSongWindow'
@@ -288,6 +289,13 @@ function SongsPage() {
                 </span>
               </button>
             )}
+            {/* Discovering + importing from external sources is a create
+                operation — same gate as the create button, same route guard.
+                The button animates while the background catalog check runs and
+                shows a count once new songs are found. */}
+            <PermissionGate permission="songs.create">
+              <DiscoverButton />
+            </PermissionGate>
             {/* Creating songs requires songs.create — hide the button entirely
                 for users without it (the /songs/new route is guarded too). */}
             <PermissionGate permission="songs.create">

--- a/app/apps/client/src/styles.css
+++ b/app/apps/client/src/styles.css
@@ -286,3 +286,139 @@ button {
     animation: none;
   }
 }
+
+/* Discover button: one living gradient shared by the border + the star icon,
+   so the colours visibly drift across both in sync. --------------------- */
+@keyframes discover-gradient-pan {
+  0% {
+    background-position: 0% 50%;
+  }
+  50% {
+    background-position: 100% 50%;
+  }
+  100% {
+    background-position: 0% 50%;
+  }
+}
+
+.discover-gradient {
+  background-image: linear-gradient(
+    110deg,
+    #6366f1,
+    #8b5cf6,
+    #d946ef,
+    #ec4899,
+    #8b5cf6,
+    #6366f1
+  );
+  background-size: 300% 300%;
+  animation: discover-gradient-pan 5s linear infinite;
+}
+
+/* Speeds the drift up while the background catalog check is running. */
+.discover-gradient-active {
+  animation-duration: 1.8s;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .discover-gradient {
+    animation: none;
+  }
+}
+
+/* "Searching" ellipsis that fills up one dot at a time (. / .. / ...) then
+   resets — a livelier loading cue than a static "…". Dots toggle opacity (not
+   display) so the button width never jumps. */
+@keyframes discover-dot-1 {
+  0%,
+  74.9% {
+    opacity: 1;
+  }
+  75%,
+  100% {
+    opacity: 0;
+  }
+}
+
+@keyframes discover-dot-2 {
+  0%,
+  24.9% {
+    opacity: 0;
+  }
+  25%,
+  74.9% {
+    opacity: 1;
+  }
+  75%,
+  100% {
+    opacity: 0;
+  }
+}
+
+@keyframes discover-dot-3 {
+  0%,
+  49.9% {
+    opacity: 0;
+  }
+  50%,
+  74.9% {
+    opacity: 1;
+  }
+  75%,
+  100% {
+    opacity: 0;
+  }
+}
+
+.discover-dots span:nth-child(1) {
+  animation: discover-dot-1 1.5s linear infinite;
+}
+.discover-dots span:nth-child(2) {
+  animation: discover-dot-2 1.5s linear infinite;
+}
+.discover-dots span:nth-child(3) {
+  animation: discover-dot-3 1.5s linear infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .discover-dots span {
+    animation: none;
+    opacity: 1;
+  }
+}
+
+/* Progress bar life: a highlight sweeps across the fill so the bar reads as
+   "working" even between the (chunked) value updates. */
+@keyframes discover-shimmer {
+  0% {
+    transform: translateX(-100%);
+  }
+  100% {
+    transform: translateX(250%);
+  }
+}
+
+.discover-shimmer {
+  animation: discover-shimmer 1.4s linear infinite;
+}
+
+/* Indeterminate bar (unknown total): a chunk slides back and forth. */
+@keyframes discover-indeterminate {
+  0% {
+    transform: translateX(-120%);
+  }
+  100% {
+    transform: translateX(320%);
+  }
+}
+
+.discover-indeterminate {
+  animation: discover-indeterminate 1.2s ease-in-out infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .discover-shimmer,
+  .discover-indeterminate {
+    animation: none;
+  }
+}

--- a/app/apps/client/src/ui/sidebar/sidebar-item.tsx
+++ b/app/apps/client/src/ui/sidebar/sidebar-item.tsx
@@ -40,6 +40,8 @@ interface SidebarItemProps {
   customIconUrl?: string
   /** Favicon background color (hex) */
   faviconBgColor?: string
+  /** Count badge shown on the icon (e.g. new songs available). 0/undefined hides it. */
+  badgeCount?: number
 }
 
 export function SidebarItem({
@@ -59,6 +61,7 @@ export function SidebarItem({
   iconColor,
   customIconUrl,
   faviconBgColor,
+  badgeCount,
 }: SidebarItemProps) {
   /**
    * Handle middle-click to open page in native window or new tab
@@ -198,9 +201,21 @@ export function SidebarItem({
     return <Icon size={20} className="flex-shrink-0" />
   }
 
+  const hasBadge = typeof badgeCount === 'number' && badgeCount > 0
+
   const content = (
     <>
-      {renderIcon()}
+      <span className="relative flex-shrink-0">
+        {renderIcon()}
+        {hasBadge && (
+          <span
+            aria-label={`${badgeCount} new`}
+            className="absolute -top-1.5 -right-1.5 min-w-[18px] h-[18px] px-1 rounded-full bg-indigo-600 text-white text-[10px] font-semibold flex items-center justify-center ring-2 ring-white dark:ring-gray-900"
+          >
+            {badgeCount > 99 ? '99+' : badgeCount}
+          </span>
+        )}
+      </span>
       {/* Mobile: always show label, Desktop: respect isCollapsed */}
       <span className="text-sm font-medium md:hidden">{label}</span>
       {!isCollapsed && (

--- a/app/apps/client/src/ui/sidebar/sidebar.tsx
+++ b/app/apps/client/src/ui/sidebar/sidebar.tsx
@@ -34,6 +34,7 @@ import type {
   IconColor,
   NativeWindowSettings,
 } from '../../features/sidebar-config/types'
+import { useSongDiscovery } from '../../features/song-discovery'
 import type { Permission } from '../../features/users/types'
 import { usePermissions } from '../../provider/permissions-provider'
 
@@ -57,6 +58,8 @@ export function Sidebar({
   const setIsMobileMenuOpen = onMobileMenuChange ?? setInternalMobileMenuOpen
   const [isFeedbackModalOpen, setIsFeedbackModalOpen] = useState(false)
   const feedbackUnreadCount = useFeedbackUnreadCount()
+  // New-songs badge on the Songs item, driven by the background catalog sync.
+  const { badgeCount: newSongsCount } = useSongDiscovery()
   const location = useLocation()
   // Defensive: /screen/* renders fullscreen via app-layout and never
   // mounts the sidebar. If something ever does mount it here (HMR race,
@@ -320,6 +323,7 @@ export function Sidebar({
               iconColor={getItemIconColor(item.id)}
               customIconUrl={item.customIconUrl}
               faviconBgColor={item.faviconBgColor}
+              badgeCount={item.to === '/songs' ? newSongsCount : undefined}
             />
           ))}
 

--- a/app/apps/server/drizzle/migrations/0029_add_songs_source_filename_index.sql
+++ b/app/apps/server/drizzle/migrations/0029_add_songs_source_filename_index.sql
@@ -1,0 +1,1 @@
+CREATE INDEX IF NOT EXISTS `idx_songs_source_filename` ON `songs` (`source_filename`);

--- a/app/apps/server/drizzle/migrations/meta/_journal.json
+++ b/app/apps/server/drizzle/migrations/meta/_journal.json
@@ -204,6 +204,13 @@
       "when": 1768700000000,
       "tag": "0028_add_song_tags",
       "breakpoints": true
+    },
+    {
+      "idx": 29,
+      "version": "6",
+      "when": 1768800000000,
+      "tag": "0029_add_songs_source_filename_index",
+      "breakpoints": true
     }
   ]
 }

--- a/app/apps/server/src/__tests__/api.test.ts
+++ b/app/apps/server/src/__tests__/api.test.ts
@@ -327,6 +327,180 @@ describe('Schedules API', () => {
   })
 })
 
+describe('Song Discovery Match', () => {
+  test('classifies external candidates by filename, title, similarity and novelty', async () => {
+    // Seed a distinctive library song with a source filename + lyrics so all
+    // four dedup verdicts can be exercised against it.
+    const ts = Date.now()
+    const seededTitle = `Izvorul Mantuirii Cantec ${ts}`
+    const seededFilename = `discovery-seed-${ts}.xml`
+    const seededLyrics =
+      'Izvorul mantuirii curge limpede peste inima mea cant de bucurie negraita'
+    const songRes = await authedFetch(`${BASE_URL}/api/songs`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        title: seededTitle,
+        sourceFilename: seededFilename,
+        slides: [{ content: `<p>${seededLyrics}</p>`, sortOrder: 0 }],
+      }),
+    })
+    expect(songRes.ok).toBe(true)
+    const songId = (await songRes.json()).data.id
+
+    try {
+      const res = await authedFetch(`${BASE_URL}/api/songs/discovery/match`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          candidates: [
+            {
+              tempId: 'by-filename',
+              title: `Totally Different Title ${ts}`,
+              lyrics: 'unrelated words here',
+              sourceFilename: seededFilename,
+            },
+            {
+              tempId: 'by-title',
+              title: seededTitle,
+              lyrics: 'different lyrics but identical title',
+              sourceFilename: `other-${ts}.xml`,
+            },
+            {
+              // Re-titled version: different (number-free) title, identical
+              // lyrics → pure-lyrics match path. A shared timestamp token in
+              // the title would leak title overlap and dilute the score.
+              tempId: 'by-similarity',
+              title: 'Cantarea Izvorului Celui Viu',
+              lyrics: seededLyrics,
+              sourceFilename: `sim-${ts}.xml`,
+            },
+            {
+              tempId: 'brand-new',
+              title: `Zymologica Quixotique Novum ${ts}`,
+              lyrics: 'zymologica quixotique novum verba singularia',
+              sourceFilename: `new-${ts}.xml`,
+            },
+          ],
+        }),
+      })
+      expect(res.status).toBe(200)
+      const json = await res.json()
+      expect(Array.isArray(json.data)).toBe(true)
+
+      const byTempId: Record<
+        string,
+        { verdict: string; exactSongId: number | null }
+      > = Object.fromEntries(json.data.map((r: any) => [r.tempId, r]))
+
+      expect(byTempId['by-filename'].verdict).toBe('exact-filename')
+      expect(byTempId['by-filename'].exactSongId).toBe(songId)
+      expect(byTempId['by-title'].verdict).toBe('exact-title')
+      expect(byTempId['by-title'].exactSongId).toBe(songId)
+      expect(byTempId['by-similarity'].verdict).toBe('similar')
+      expect(byTempId['brand-new'].verdict).toBe('new')
+    } finally {
+      await authedFetch(`${BASE_URL}/api/songs/${songId}`, { method: 'DELETE' })
+    }
+  })
+
+  test('rejects batches larger than 500 candidates', async () => {
+    const candidates = Array.from({ length: 501 }, (_, i) => ({
+      tempId: `c${i}`,
+      title: `T${i}`,
+      lyrics: 'x',
+      sourceFilename: null,
+    }))
+    const res = await authedFetch(`${BASE_URL}/api/songs/discovery/match`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ candidates }),
+    })
+    expect(res.status).toBe(400)
+  })
+
+  test('count endpoint reports how many candidates are new', async () => {
+    const ts = Date.now()
+    const seededTitle = `Count Seed Song ${ts}`
+    const seededFilename = `count-seed-${ts}.xml`
+    const seedRes = await authedFetch(`${BASE_URL}/api/songs`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        title: seededTitle,
+        sourceFilename: seededFilename,
+        slides: [{ content: '<p>count seed content</p>', sortOrder: 0 }],
+      }),
+    })
+    expect(seedRes.ok).toBe(true)
+    const songId = (await seedRes.json()).data.id
+
+    try {
+      const res = await authedFetch(`${BASE_URL}/api/songs/discovery/count`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          candidates: [
+            // matches by filename → not new
+            { title: `Renamed ${ts}`, sourceFilename: seededFilename },
+            // matches by title → not new
+            { title: seededTitle, sourceFilename: `x-${ts}.xml` },
+            // genuinely new
+            {
+              title: `Zenith Novel Discovery ${ts}`,
+              sourceFilename: `n-${ts}.xml`,
+            },
+          ],
+        }),
+      })
+      expect(res.status).toBe(200)
+      const json = await res.json()
+      expect(json.data.newCount).toBe(1)
+    } finally {
+      await authedFetch(`${BASE_URL}/api/songs/${songId}`, { method: 'DELETE' })
+    }
+  })
+
+  test('title match is case-insensitive (regression)', async () => {
+    const ts = Date.now()
+    // Seed with mixed case; the candidate uses lower case — they must still be
+    // recognized as the same song (the importer keys on LOWER(title)).
+    const seedRes = await authedFetch(`${BASE_URL}/api/songs`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        title: `Am Primit Darul Ceresc ${ts}`,
+        sourceFilename: `ci-seed-${ts}.xml`,
+        slides: [{ content: '<p>continut</p>', sortOrder: 0 }],
+      }),
+    })
+    expect(seedRes.ok).toBe(true)
+    const songId = (await seedRes.json()).data.id
+
+    try {
+      const res = await authedFetch(`${BASE_URL}/api/songs/discovery/match`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          candidates: [
+            {
+              tempId: 'lower-case',
+              title: `am primit darul ceresc ${ts}`,
+              lyrics: 'continut',
+              sourceFilename: `other-${ts}.xml`,
+            },
+          ],
+        }),
+      })
+      expect(res.status).toBe(200)
+      const json = await res.json()
+      expect(json.data[0].verdict).toBe('exact-title')
+    } finally {
+      await authedFetch(`${BASE_URL}/api/songs/${songId}`, { method: 'DELETE' })
+    }
+  })
+})
+
 describe('Bible API', () => {
   test('GET /api/bible/translations returns 200 with data array', async () => {
     const res = await fetch(`${BASE_URL}/api/bible/translations`)

--- a/app/apps/server/src/db/migrations/embedded.ts
+++ b/app/apps/server/src/db/migrations/embedded.ts
@@ -218,6 +218,13 @@ export const EMBEDDED_JOURNAL = {
       tag: '0028_add_song_tags',
       breakpoints: true,
     },
+    {
+      idx: 29,
+      version: '6',
+      when: 1768800000000,
+      tag: '0029_add_songs_source_filename_index',
+      breakpoints: true,
+    },
   ],
 } as const
 
@@ -259,22 +266,22 @@ export const EMBEDDED_MIGRATIONS: EmbeddedMigration[] = [
   },
   {
     tag: '0007_add_scene_shortcuts',
-    sql: 'ALTER TABLE `obs_scenes` ADD COLUMN `shortcuts` text NOT NULL DEFAULT \'[]\';\r\n',
+    sql: 'ALTER TABLE `obs_scenes` ADD COLUMN `shortcuts` text NOT NULL DEFAULT \'[]\';\n',
     when: 1766500000000,
   },
   {
     tag: '0008_add_broadcast_templates',
-    sql: 'CREATE TABLE `broadcast_templates` (\r\n\t`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,\r\n\t`name` text NOT NULL,\r\n\t`title` text NOT NULL,\r\n\t`description` text DEFAULT \'\' NOT NULL,\r\n\t`privacy_status` text DEFAULT \'unlisted\' NOT NULL,\r\n\t`stream_key_id` text,\r\n\t`playlist_id` text,\r\n\t`category` text,\r\n\t`used_at` integer NOT NULL,\r\n\t`created_at` integer DEFAULT (unixepoch()) NOT NULL\r\n);\r\n--> statement-breakpoint\r\nCREATE INDEX `idx_broadcast_templates_used_at` ON `broadcast_templates` (`used_at`);\r\n',
+    sql: 'CREATE TABLE `broadcast_templates` (\n\t`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,\n\t`name` text NOT NULL,\n\t`title` text NOT NULL,\n\t`description` text DEFAULT \'\' NOT NULL,\n\t`privacy_status` text DEFAULT \'unlisted\' NOT NULL,\n\t`stream_key_id` text,\n\t`playlist_id` text,\n\t`category` text,\n\t`used_at` integer NOT NULL,\n\t`created_at` integer DEFAULT (unixepoch()) NOT NULL\n);\n--> statement-breakpoint\nCREATE INDEX `idx_broadcast_templates_used_at` ON `broadcast_templates` (`used_at`);\n',
     when: 1766600000000,
   },
   {
     tag: '0009_add_selected_broadcast_config',
-    sql: 'ALTER TABLE `youtube_config` ADD COLUMN `selected_broadcast_id` text;\r\n--> statement-breakpoint\r\nALTER TABLE `youtube_config` ADD COLUMN `broadcast_mode` text DEFAULT \'create\' NOT NULL;\r\n',
+    sql: 'ALTER TABLE `youtube_config` ADD COLUMN `selected_broadcast_id` text;\n--> statement-breakpoint\nALTER TABLE `youtube_config` ADD COLUMN `broadcast_mode` text DEFAULT \'create\' NOT NULL;\n',
     when: 1766700000000,
   },
   {
     tag: '0010_add_stop_scene_name',
-    sql: 'ALTER TABLE `youtube_config` ADD COLUMN `stop_scene_name` text;\r\n',
+    sql: 'ALTER TABLE `youtube_config` ADD COLUMN `stop_scene_name` text;\n',
     when: 1766800000000,
   },
   {
@@ -289,7 +296,7 @@ export const EMBEDDED_MIGRATIONS: EmbeddedMigration[] = [
   },
   {
     tag: '0013_add_temporary_content',
-    sql: 'ALTER TABLE `presentation_state` ADD COLUMN `temporary_content` text;\r\n',
+    sql: 'ALTER TABLE `presentation_state` ADD COLUMN `temporary_content` text;\n',
     when: 1767100000000,
   },
   {
@@ -299,17 +306,17 @@ export const EMBEDDED_MIGRATIONS: EmbeddedMigration[] = [
   },
   {
     tag: '0015_add_schedule_bible_passage_versete_tineri',
-    sql: '-- Add bible_passage support to schedule_items table\r\nALTER TABLE schedule_items ADD COLUMN bible_passage_reference TEXT;\r\n--> statement-breakpoint\r\nALTER TABLE schedule_items ADD COLUMN bible_passage_translation TEXT;\r\n--> statement-breakpoint\r\n\r\n-- Create schedule_bible_passage_verses table for nested verses in bible_passage items\r\nCREATE TABLE IF NOT EXISTS schedule_bible_passage_verses (\r\n  id INTEGER PRIMARY KEY AUTOINCREMENT,\r\n  schedule_item_id INTEGER NOT NULL REFERENCES schedule_items(id) ON DELETE CASCADE,\r\n  verse_id INTEGER NOT NULL REFERENCES bible_verses(id) ON DELETE CASCADE,\r\n  reference TEXT NOT NULL,\r\n  text TEXT NOT NULL,\r\n  sort_order INTEGER NOT NULL DEFAULT 0,\r\n  created_at INTEGER NOT NULL DEFAULT (unixepoch())\r\n);\r\n--> statement-breakpoint\r\nCREATE INDEX IF NOT EXISTS idx_schedule_bible_passage_verses_item_id ON schedule_bible_passage_verses(schedule_item_id);\r\n--> statement-breakpoint\r\nCREATE INDEX IF NOT EXISTS idx_schedule_bible_passage_verses_sort_order ON schedule_bible_passage_verses(sort_order);\r\n--> statement-breakpoint\r\n\r\n-- Create schedule_versete_tineri_entries table for nested entries in versete_tineri slides\r\nCREATE TABLE IF NOT EXISTS schedule_versete_tineri_entries (\r\n  id INTEGER PRIMARY KEY AUTOINCREMENT,\r\n  schedule_item_id INTEGER NOT NULL REFERENCES schedule_items(id) ON DELETE CASCADE,\r\n  person_name TEXT NOT NULL,\r\n  translation_id INTEGER NOT NULL,\r\n  book_code TEXT NOT NULL,\r\n  book_name TEXT NOT NULL,\r\n  reference TEXT NOT NULL,\r\n  text TEXT NOT NULL,\r\n  start_chapter INTEGER NOT NULL,\r\n  start_verse INTEGER NOT NULL,\r\n  end_chapter INTEGER NOT NULL,\r\n  end_verse INTEGER NOT NULL,\r\n  sort_order INTEGER NOT NULL DEFAULT 0,\r\n  created_at INTEGER NOT NULL DEFAULT (unixepoch())\r\n);\r\n--> statement-breakpoint\r\nCREATE INDEX IF NOT EXISTS idx_schedule_versete_tineri_entries_item_id ON schedule_versete_tineri_entries(schedule_item_id);\r\n--> statement-breakpoint\r\nCREATE INDEX IF NOT EXISTS idx_schedule_versete_tineri_entries_sort_order ON schedule_versete_tineri_entries(sort_order);\r\n',
+    sql: '-- Add bible_passage support to schedule_items table\nALTER TABLE schedule_items ADD COLUMN bible_passage_reference TEXT;\n--> statement-breakpoint\nALTER TABLE schedule_items ADD COLUMN bible_passage_translation TEXT;\n--> statement-breakpoint\n\n-- Create schedule_bible_passage_verses table for nested verses in bible_passage items\nCREATE TABLE IF NOT EXISTS schedule_bible_passage_verses (\n  id INTEGER PRIMARY KEY AUTOINCREMENT,\n  schedule_item_id INTEGER NOT NULL REFERENCES schedule_items(id) ON DELETE CASCADE,\n  verse_id INTEGER NOT NULL REFERENCES bible_verses(id) ON DELETE CASCADE,\n  reference TEXT NOT NULL,\n  text TEXT NOT NULL,\n  sort_order INTEGER NOT NULL DEFAULT 0,\n  created_at INTEGER NOT NULL DEFAULT (unixepoch())\n);\n--> statement-breakpoint\nCREATE INDEX IF NOT EXISTS idx_schedule_bible_passage_verses_item_id ON schedule_bible_passage_verses(schedule_item_id);\n--> statement-breakpoint\nCREATE INDEX IF NOT EXISTS idx_schedule_bible_passage_verses_sort_order ON schedule_bible_passage_verses(sort_order);\n--> statement-breakpoint\n\n-- Create schedule_versete_tineri_entries table for nested entries in versete_tineri slides\nCREATE TABLE IF NOT EXISTS schedule_versete_tineri_entries (\n  id INTEGER PRIMARY KEY AUTOINCREMENT,\n  schedule_item_id INTEGER NOT NULL REFERENCES schedule_items(id) ON DELETE CASCADE,\n  person_name TEXT NOT NULL,\n  translation_id INTEGER NOT NULL,\n  book_code TEXT NOT NULL,\n  book_name TEXT NOT NULL,\n  reference TEXT NOT NULL,\n  text TEXT NOT NULL,\n  start_chapter INTEGER NOT NULL,\n  start_verse INTEGER NOT NULL,\n  end_chapter INTEGER NOT NULL,\n  end_verse INTEGER NOT NULL,\n  sort_order INTEGER NOT NULL DEFAULT 0,\n  created_at INTEGER NOT NULL DEFAULT (unixepoch())\n);\n--> statement-breakpoint\nCREATE INDEX IF NOT EXISTS idx_schedule_versete_tineri_entries_item_id ON schedule_versete_tineri_entries(schedule_item_id);\n--> statement-breakpoint\nCREATE INDEX IF NOT EXISTS idx_schedule_versete_tineri_entries_sort_order ON schedule_versete_tineri_entries(sort_order);\n',
     when: 1767300000000,
   },
   {
     tag: '0016_add_always_on_top_to_screens',
-    sql: 'ALTER TABLE `screens` ADD COLUMN `always_on_top` integer NOT NULL DEFAULT 0;\r\n',
+    sql: 'ALTER TABLE `screens` ADD COLUMN `always_on_top` integer NOT NULL DEFAULT 0;\n',
     when: 1767400000000,
   },
   {
     tag: '0017_add_bible_history',
-    sql: 'CREATE TABLE `bible_history` (\r\n\t`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,\r\n\t`verse_id` integer NOT NULL,\r\n\t`reference` text NOT NULL,\r\n\t`text` text NOT NULL,\r\n\t`translation_abbreviation` text NOT NULL,\r\n\t`book_name` text NOT NULL,\r\n\t`translation_id` integer NOT NULL,\r\n\t`book_id` integer NOT NULL,\r\n\t`chapter` integer NOT NULL,\r\n\t`verse` integer NOT NULL,\r\n\t`created_at` integer DEFAULT (unixepoch()) NOT NULL\r\n);\r\n--> statement-breakpoint\r\nCREATE INDEX `idx_bible_history_created_at` ON `bible_history` (`created_at`);\r\n',
+    sql: 'CREATE TABLE `bible_history` (\n\t`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,\n\t`verse_id` integer NOT NULL,\n\t`reference` text NOT NULL,\n\t`text` text NOT NULL,\n\t`translation_abbreviation` text NOT NULL,\n\t`book_name` text NOT NULL,\n\t`translation_id` integer NOT NULL,\n\t`book_id` integer NOT NULL,\n\t`chapter` integer NOT NULL,\n\t`verse` integer NOT NULL,\n\t`created_at` integer DEFAULT (unixepoch()) NOT NULL\n);\n--> statement-breakpoint\nCREATE INDEX `idx_bible_history_created_at` ON `bible_history` (`created_at`);\n',
     when: 1767500000000,
   },
   {
@@ -319,22 +326,22 @@ export const EMBEDDED_MIGRATIONS: EmbeddedMigration[] = [
   },
   {
     tag: '0019_add_obs_scene_name_to_schedule_items',
-    sql: '-- Add obs_scene_name column to schedule_items table for scene type slides\r\nALTER TABLE `schedule_items` ADD COLUMN `obs_scene_name` TEXT;\r\n',
+    sql: '-- Add obs_scene_name column to schedule_items table for scene type slides\nALTER TABLE `schedule_items` ADD COLUMN `obs_scene_name` TEXT;\n',
     when: 1767900000000,
   },
   {
     tag: '0020_add_music_tables',
-    sql: '-- Add music tables for audio file management and playlists\r\nCREATE TABLE `music_folders` (\r\n\t`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,\r\n\t`path` text NOT NULL,\r\n\t`name` text NOT NULL,\r\n\t`is_recursive` integer DEFAULT true NOT NULL,\r\n\t`last_sync_at` integer,\r\n\t`file_count` integer DEFAULT 0 NOT NULL,\r\n\t`created_at` integer DEFAULT (unixepoch()) NOT NULL,\r\n\t`updated_at` integer DEFAULT (unixepoch()) NOT NULL\r\n);\r\n--> statement-breakpoint\r\nCREATE UNIQUE INDEX `music_folders_path_unique` ON `music_folders` (`path`);\r\n--> statement-breakpoint\r\nCREATE INDEX `idx_music_folders_path` ON `music_folders` (`path`);\r\n--> statement-breakpoint\r\nCREATE TABLE `music_files` (\r\n\t`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,\r\n\t`folder_id` integer NOT NULL,\r\n\t`path` text NOT NULL,\r\n\t`filename` text NOT NULL,\r\n\t`title` text,\r\n\t`artist` text,\r\n\t`album` text,\r\n\t`genre` text,\r\n\t`year` integer,\r\n\t`track_number` integer,\r\n\t`duration` real,\r\n\t`format` text NOT NULL,\r\n\t`file_size` integer,\r\n\t`last_modified` integer,\r\n\t`created_at` integer DEFAULT (unixepoch()) NOT NULL,\r\n\t`updated_at` integer DEFAULT (unixepoch()) NOT NULL,\r\n\tFOREIGN KEY (`folder_id`) REFERENCES `music_folders`(`id`) ON UPDATE no action ON DELETE cascade\r\n);\r\n--> statement-breakpoint\r\nCREATE UNIQUE INDEX `music_files_path_unique` ON `music_files` (`path`);\r\n--> statement-breakpoint\r\nCREATE INDEX `idx_music_files_folder_id` ON `music_files` (`folder_id`);\r\n--> statement-breakpoint\r\nCREATE INDEX `idx_music_files_path` ON `music_files` (`path`);\r\n--> statement-breakpoint\r\nCREATE INDEX `idx_music_files_title` ON `music_files` (`title`);\r\n--> statement-breakpoint\r\nCREATE INDEX `idx_music_files_artist` ON `music_files` (`artist`);\r\n--> statement-breakpoint\r\nCREATE INDEX `idx_music_files_album` ON `music_files` (`album`);\r\n--> statement-breakpoint\r\nCREATE TABLE `music_playlists` (\r\n\t`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,\r\n\t`name` text NOT NULL,\r\n\t`description` text,\r\n\t`item_count` integer DEFAULT 0 NOT NULL,\r\n\t`total_duration` real DEFAULT 0 NOT NULL,\r\n\t`created_at` integer DEFAULT (unixepoch()) NOT NULL,\r\n\t`updated_at` integer DEFAULT (unixepoch()) NOT NULL\r\n);\r\n--> statement-breakpoint\r\nCREATE INDEX `idx_music_playlists_name` ON `music_playlists` (`name`);\r\n--> statement-breakpoint\r\nCREATE TABLE `music_playlist_items` (\r\n\t`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,\r\n\t`playlist_id` integer NOT NULL,\r\n\t`file_id` integer NOT NULL,\r\n\t`sort_order` integer DEFAULT 0 NOT NULL,\r\n\t`created_at` integer DEFAULT (unixepoch()) NOT NULL,\r\n\tFOREIGN KEY (`playlist_id`) REFERENCES `music_playlists`(`id`) ON UPDATE no action ON DELETE cascade,\r\n\tFOREIGN KEY (`file_id`) REFERENCES `music_files`(`id`) ON UPDATE no action ON DELETE cascade\r\n);\r\n--> statement-breakpoint\r\nCREATE INDEX `idx_music_playlist_items_playlist_sort` ON `music_playlist_items` (`playlist_id`, `sort_order`);\r\n--> statement-breakpoint\r\nCREATE INDEX `idx_music_playlist_items_file_id` ON `music_playlist_items` (`file_id`);\r\n',
+    sql: '-- Add music tables for audio file management and playlists\nCREATE TABLE `music_folders` (\n\t`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,\n\t`path` text NOT NULL,\n\t`name` text NOT NULL,\n\t`is_recursive` integer DEFAULT true NOT NULL,\n\t`last_sync_at` integer,\n\t`file_count` integer DEFAULT 0 NOT NULL,\n\t`created_at` integer DEFAULT (unixepoch()) NOT NULL,\n\t`updated_at` integer DEFAULT (unixepoch()) NOT NULL\n);\n--> statement-breakpoint\nCREATE UNIQUE INDEX `music_folders_path_unique` ON `music_folders` (`path`);\n--> statement-breakpoint\nCREATE INDEX `idx_music_folders_path` ON `music_folders` (`path`);\n--> statement-breakpoint\nCREATE TABLE `music_files` (\n\t`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,\n\t`folder_id` integer NOT NULL,\n\t`path` text NOT NULL,\n\t`filename` text NOT NULL,\n\t`title` text,\n\t`artist` text,\n\t`album` text,\n\t`genre` text,\n\t`year` integer,\n\t`track_number` integer,\n\t`duration` real,\n\t`format` text NOT NULL,\n\t`file_size` integer,\n\t`last_modified` integer,\n\t`created_at` integer DEFAULT (unixepoch()) NOT NULL,\n\t`updated_at` integer DEFAULT (unixepoch()) NOT NULL,\n\tFOREIGN KEY (`folder_id`) REFERENCES `music_folders`(`id`) ON UPDATE no action ON DELETE cascade\n);\n--> statement-breakpoint\nCREATE UNIQUE INDEX `music_files_path_unique` ON `music_files` (`path`);\n--> statement-breakpoint\nCREATE INDEX `idx_music_files_folder_id` ON `music_files` (`folder_id`);\n--> statement-breakpoint\nCREATE INDEX `idx_music_files_path` ON `music_files` (`path`);\n--> statement-breakpoint\nCREATE INDEX `idx_music_files_title` ON `music_files` (`title`);\n--> statement-breakpoint\nCREATE INDEX `idx_music_files_artist` ON `music_files` (`artist`);\n--> statement-breakpoint\nCREATE INDEX `idx_music_files_album` ON `music_files` (`album`);\n--> statement-breakpoint\nCREATE TABLE `music_playlists` (\n\t`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,\n\t`name` text NOT NULL,\n\t`description` text,\n\t`item_count` integer DEFAULT 0 NOT NULL,\n\t`total_duration` real DEFAULT 0 NOT NULL,\n\t`created_at` integer DEFAULT (unixepoch()) NOT NULL,\n\t`updated_at` integer DEFAULT (unixepoch()) NOT NULL\n);\n--> statement-breakpoint\nCREATE INDEX `idx_music_playlists_name` ON `music_playlists` (`name`);\n--> statement-breakpoint\nCREATE TABLE `music_playlist_items` (\n\t`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,\n\t`playlist_id` integer NOT NULL,\n\t`file_id` integer NOT NULL,\n\t`sort_order` integer DEFAULT 0 NOT NULL,\n\t`created_at` integer DEFAULT (unixepoch()) NOT NULL,\n\tFOREIGN KEY (`playlist_id`) REFERENCES `music_playlists`(`id`) ON UPDATE no action ON DELETE cascade,\n\tFOREIGN KEY (`file_id`) REFERENCES `music_files`(`id`) ON UPDATE no action ON DELETE cascade\n);\n--> statement-breakpoint\nCREATE INDEX `idx_music_playlist_items_playlist_sort` ON `music_playlist_items` (`playlist_id`, `sort_order`);\n--> statement-breakpoint\nCREATE INDEX `idx_music_playlist_items_file_id` ON `music_playlist_items` (`file_id`);\n',
     when: 1768000000000,
   },
   {
     tag: '0021_add_music_now_playing',
-    sql: '-- Add music_now_playing table for current playback queue\r\nCREATE TABLE `music_now_playing` (\r\n\t`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,\r\n\t`file_id` integer NOT NULL,\r\n\t`sort_order` integer DEFAULT 0 NOT NULL,\r\n\t`created_at` integer DEFAULT (unixepoch()) NOT NULL,\r\n\tFOREIGN KEY (`file_id`) REFERENCES `music_files`(`id`) ON UPDATE no action ON DELETE cascade\r\n);\r\n--> statement-breakpoint\r\nCREATE INDEX `idx_music_now_playing_sort_order` ON `music_now_playing` (`sort_order`);\r\n--> statement-breakpoint\r\nCREATE INDEX `idx_music_now_playing_file_id` ON `music_now_playing` (`file_id`);\r\n',
+    sql: '-- Add music_now_playing table for current playback queue\nCREATE TABLE `music_now_playing` (\n\t`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,\n\t`file_id` integer NOT NULL,\n\t`sort_order` integer DEFAULT 0 NOT NULL,\n\t`created_at` integer DEFAULT (unixepoch()) NOT NULL,\n\tFOREIGN KEY (`file_id`) REFERENCES `music_files`(`id`) ON UPDATE no action ON DELETE cascade\n);\n--> statement-breakpoint\nCREATE INDEX `idx_music_now_playing_sort_order` ON `music_now_playing` (`sort_order`);\n--> statement-breakpoint\nCREATE INDEX `idx_music_now_playing_file_id` ON `music_now_playing` (`file_id`);\n',
     when: 1768100000000,
   },
   {
     tag: '0022_add_song_search_history',
-    sql: '-- Add song_search_history table for saving AI search results\r\nCREATE TABLE `song_search_history` (\r\n\t`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,\r\n\t`query` text NOT NULL,\r\n\t`url_path` text NOT NULL,\r\n\t`search_type` text DEFAULT \'regular\' NOT NULL,\r\n\t`category_ids` text,\r\n\t`ai_results` text,\r\n\t`result_count` integer,\r\n\t`created_at` integer DEFAULT (unixepoch()) NOT NULL\r\n);\r\n--> statement-breakpoint\r\nCREATE INDEX `idx_song_search_history_created_at` ON `song_search_history` (`created_at`);\r\n--> statement-breakpoint\r\nCREATE INDEX `idx_song_search_history_search_type` ON `song_search_history` (`search_type`);\r\n',
+    sql: '-- Add song_search_history table for saving AI search results\nCREATE TABLE `song_search_history` (\n\t`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,\n\t`query` text NOT NULL,\n\t`url_path` text NOT NULL,\n\t`search_type` text DEFAULT \'regular\' NOT NULL,\n\t`category_ids` text,\n\t`ai_results` text,\n\t`result_count` integer,\n\t`created_at` integer DEFAULT (unixepoch()) NOT NULL\n);\n--> statement-breakpoint\nCREATE INDEX `idx_song_search_history_created_at` ON `song_search_history` (`created_at`);\n--> statement-breakpoint\nCREATE INDEX `idx_song_search_history_search_type` ON `song_search_history` (`search_type`);\n',
     when: 1768200000000,
   },
   {
@@ -364,7 +371,12 @@ export const EMBEDDED_MIGRATIONS: EmbeddedMigration[] = [
   },
   {
     tag: '0028_add_song_tags',
-    sql: 'CREATE TABLE IF NOT EXISTS `song_tags` (\n\t`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,\n\t`name` text NOT NULL,\n\t`sort_order` integer DEFAULT 0 NOT NULL,\n\t`created_at` integer DEFAULT (unixepoch()) NOT NULL,\n\t`updated_at` integer DEFAULT (unixepoch()) NOT NULL\n);\n--> statement-breakpoint\nCREATE UNIQUE INDEX IF NOT EXISTS `song_tags_name_unique` ON `song_tags` (`name`);\n--> statement-breakpoint\nCREATE INDEX IF NOT EXISTS `idx_song_tags_sort_order` ON `song_tags` (`sort_order`);\n--> statement-breakpoint\nCREATE TABLE IF NOT EXISTS `song_tag_assignments` (\n\t`song_id` integer NOT NULL REFERENCES `songs`(`id`) ON DELETE cascade,\n\t`tag_id` integer NOT NULL REFERENCES `song_tags`(`id`) ON DELETE cascade,\n\t`created_at` integer DEFAULT (unixepoch()) NOT NULL,\n\tPRIMARY KEY (`song_id`, `tag_id`)\n);\n--> statement-breakpoint\nCREATE INDEX IF NOT EXISTS `idx_song_tag_assignments_tag_id` ON `song_tag_assignments` (`tag_id`);\n',
+    sql: 'CREATE TABLE IF NOT EXISTS `song_tags` (\r\n\t`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,\r\n\t`name` text NOT NULL,\r\n\t`sort_order` integer DEFAULT 0 NOT NULL,\r\n\t`created_at` integer DEFAULT (unixepoch()) NOT NULL,\r\n\t`updated_at` integer DEFAULT (unixepoch()) NOT NULL\r\n);\r\n--> statement-breakpoint\r\nCREATE UNIQUE INDEX IF NOT EXISTS `song_tags_name_unique` ON `song_tags` (`name`);\r\n--> statement-breakpoint\r\nCREATE INDEX IF NOT EXISTS `idx_song_tags_sort_order` ON `song_tags` (`sort_order`);\r\n--> statement-breakpoint\r\nCREATE TABLE IF NOT EXISTS `song_tag_assignments` (\r\n\t`song_id` integer NOT NULL REFERENCES `songs`(`id`) ON DELETE cascade,\r\n\t`tag_id` integer NOT NULL REFERENCES `song_tags`(`id`) ON DELETE cascade,\r\n\t`created_at` integer DEFAULT (unixepoch()) NOT NULL,\r\n\tPRIMARY KEY (`song_id`, `tag_id`)\r\n);\r\n--> statement-breakpoint\r\nCREATE INDEX IF NOT EXISTS `idx_song_tag_assignments_tag_id` ON `song_tag_assignments` (`tag_id`);\r\n',
     when: 1768700000000,
+  },
+  {
+    tag: '0029_add_songs_source_filename_index',
+    sql: 'CREATE INDEX IF NOT EXISTS `idx_songs_source_filename` ON `songs` (`source_filename`);\n',
+    when: 1768800000000,
   },
 ]

--- a/app/apps/server/src/db/schema/songs.ts
+++ b/app/apps/server/src/db/schema/songs.ts
@@ -91,6 +91,10 @@ export const songs = sqliteTable(
     index('idx_songs_title').on(table.title),
     index('idx_songs_category_id').on(table.categoryId),
     index('idx_songs_song_group_id').on(table.songGroupId),
+    // Backs the exact-filename dedup pass in the song-discovery flow
+    // (matchCandidatesAgainstLibrary), which probes source_filename per
+    // external candidate before falling back to title/fuzzy matching.
+    index('idx_songs_source_filename').on(table.sourceFilename),
   ],
 )
 

--- a/app/apps/server/src/index.ts
+++ b/app/apps/server/src/index.ts
@@ -281,6 +281,8 @@ import {
   clearSearchCache,
   cloneSongSlide,
   completeSongReplacement,
+  countNewCandidates,
+  type DiscoveryCandidateInput,
   deleteCategory,
   deleteSong,
   deleteSongSlide,
@@ -299,6 +301,7 @@ import {
   getSongsPaginated,
   getSongWithSlides,
   linkSongs,
+  matchCandidatesAgainstLibrary,
   type ReorderCategoriesInput,
   type ReorderSongSlidesInput,
   type ReorderTagsInput,
@@ -4450,9 +4453,214 @@ async function startRealServer(): Promise<void> {
         }
       }
 
+      // POST /api/songs/discovery/match - Classify external (not-yet-imported)
+      // songs against the local library so the discovery screen shows only the
+      // ones the user lacks. Per candidate: exact-filename → exact-title →
+      // fuzzy-similar → new. Batched (client chunks ≤500) to avoid per-song
+      // round-trips over a multi-thousand-song catalog.
+      if (
+        req.method === 'POST' &&
+        url.pathname === '/api/songs/discovery/match'
+      ) {
+        const permError = checkPermission('songs.create')
+        if (permError) return permError
+
+        try {
+          const body = (await req.json()) as {
+            candidates: DiscoveryCandidateInput[]
+          }
+
+          if (!body.candidates || !Array.isArray(body.candidates)) {
+            return handleCors(
+              req,
+              new Response(
+                JSON.stringify({ error: 'Missing candidates array' }),
+                {
+                  status: 400,
+                  headers: { 'Content-Type': 'application/json' },
+                },
+              ),
+            )
+          }
+
+          if (body.candidates.length > 500) {
+            return handleCors(
+              req,
+              new Response(
+                JSON.stringify({
+                  error: 'Too many candidates (max 500 per request)',
+                }),
+                {
+                  status: 400,
+                  headers: { 'Content-Type': 'application/json' },
+                },
+              ),
+            )
+          }
+
+          const results = matchCandidatesAgainstLibrary(body.candidates)
+
+          return handleCors(
+            req,
+            new Response(JSON.stringify({ data: results }), {
+              headers: { 'Content-Type': 'application/json' },
+            }),
+          )
+        } catch {
+          return handleCors(
+            req,
+            new Response(JSON.stringify({ error: 'Invalid JSON body' }), {
+              status: 400,
+              headers: { 'Content-Type': 'application/json' },
+            }),
+          )
+        }
+      }
+
+      // POST /api/songs/discovery/count - Cheap "how many are new?" count for the
+      // background discovery check (sidebar badge + toast). Filename + title only,
+      // no FTS — so it stays fast even over a multi-thousand-song catalog.
+      if (
+        req.method === 'POST' &&
+        url.pathname === '/api/songs/discovery/count'
+      ) {
+        const permError = checkPermission('songs.create')
+        if (permError) return permError
+
+        try {
+          const body = (await req.json()) as {
+            candidates: { title: string; sourceFilename: string | null }[]
+          }
+
+          if (!body.candidates || !Array.isArray(body.candidates)) {
+            return handleCors(
+              req,
+              new Response(
+                JSON.stringify({ error: 'Missing candidates array' }),
+                {
+                  status: 400,
+                  headers: { 'Content-Type': 'application/json' },
+                },
+              ),
+            )
+          }
+
+          if (body.candidates.length > 5000) {
+            return handleCors(
+              req,
+              new Response(
+                JSON.stringify({
+                  error: 'Too many candidates (max 5000 per request)',
+                }),
+                {
+                  status: 400,
+                  headers: { 'Content-Type': 'application/json' },
+                },
+              ),
+            )
+          }
+
+          const newCount = countNewCandidates(body.candidates)
+
+          return handleCors(
+            req,
+            new Response(JSON.stringify({ data: { newCount } }), {
+              headers: { 'Content-Type': 'application/json' },
+            }),
+          )
+        } catch {
+          return handleCors(
+            req,
+            new Response(JSON.stringify({ error: 'Invalid JSON body' }), {
+              status: 400,
+              headers: { 'Content-Type': 'application/json' },
+            }),
+          )
+        }
+      }
+
       // ============================================================
       // Proxy Download Endpoint (for CORS bypass)
       // ============================================================
+
+      // GET /api/proxy/head - Cheap change-check for a whitelisted external file.
+      // Issues a HEAD and returns last-modified / etag / content-length so the
+      // background discovery sync can skip re-downloading an unchanged catalog.
+      if (req.method === 'GET' && url.pathname === '/api/proxy/head') {
+        const permError = checkPermission('songs.create')
+        if (permError) return permError
+
+        const targetUrl = url.searchParams.get('url')
+        if (!targetUrl) {
+          return handleCors(
+            req,
+            new Response(JSON.stringify({ error: 'Missing url parameter' }), {
+              status: 400,
+              headers: { 'Content-Type': 'application/json' },
+            }),
+          )
+        }
+
+        const allowedDomains = [
+          'download.resursecrestine.ro',
+          'resursecrestine.ro',
+        ]
+        let parsedHeadUrl: URL
+        try {
+          parsedHeadUrl = new URL(targetUrl)
+        } catch {
+          return handleCors(
+            req,
+            new Response(JSON.stringify({ error: 'Invalid URL' }), {
+              status: 400,
+              headers: { 'Content-Type': 'application/json' },
+            }),
+          )
+        }
+        if (!allowedDomains.includes(parsedHeadUrl.hostname)) {
+          return handleCors(
+            req,
+            new Response(
+              JSON.stringify({ error: 'Domain not allowed for proxy head' }),
+              {
+                status: 403,
+                headers: { 'Content-Type': 'application/json' },
+              },
+            ),
+          )
+        }
+
+        try {
+          const headResponse = await fetch(targetUrl, {
+            method: 'HEAD',
+            redirect: 'follow',
+          })
+          return handleCors(
+            req,
+            new Response(
+              JSON.stringify({
+                data: {
+                  lastModified: headResponse.headers.get('last-modified'),
+                  etag: headResponse.headers.get('etag'),
+                  contentLength: headResponse.headers.get('content-length'),
+                },
+              }),
+              { headers: { 'Content-Type': 'application/json' } },
+            ),
+          )
+        } catch (error) {
+          return handleCors(
+            req,
+            new Response(
+              JSON.stringify({ error: `Head request failed: ${error}` }),
+              {
+                status: 502,
+                headers: { 'Content-Type': 'application/json' },
+              },
+            ),
+          )
+        }
+      }
 
       // GET /api/proxy/download - Proxy download from external URL
       if (req.method === 'GET' && url.pathname === '/api/proxy/download') {
@@ -4504,15 +4712,30 @@ async function startRealServer(): Promise<void> {
         }
 
         try {
-          // biome-ignore lint/suspicious/noConsole: logging
-          console.log(`[INFO] [proxy] Downloading from ${targetUrl}`)
           const proxyStart = performance.now()
+
+          // Forward the client's Range header so the client can download in small
+          // chunks (bytes=start-end). Chunked download is what makes progress
+          // reliable: in-runtime streaming of a single big body proved unreliable
+          // (the client sat at 0% while the body buffered), but each ranged chunk
+          // is a small, complete request that returns fast — so the bar advances
+          // chunk by chunk regardless of streaming support.
+          const rangeHeader = req.headers.get('Range')
+          // biome-ignore lint/suspicious/noConsole: logging
+          console.log(
+            `[INFO] [proxy] Downloading from ${targetUrl}${rangeHeader ? ` (${rangeHeader})` : ''}`,
+          )
 
           const response = await fetch(targetUrl, {
             method: 'GET',
             redirect: 'follow',
+            // 60s per chunk is plenty (a chunk is a couple of MB); also guards a
+            // dead upstream so the request can't hang forever.
+            signal: AbortSignal.timeout(60_000),
+            headers: rangeHeader ? { Range: rangeHeader } : undefined,
           })
 
+          // 200 (full) and 206 (partial) are both success.
           if (!response.ok) {
             return handleCors(
               req,
@@ -4528,25 +4751,41 @@ async function startRealServer(): Promise<void> {
             )
           }
 
+          // Buffer the (small) chunk and return it as a complete response. For a
+          // ranged request this is ~a couple of MB and returns near-instantly.
           const data = await response.arrayBuffer()
-          const proxyTime = performance.now() - proxyStart
+
+          const proxyHeaders: Record<string, string> = {
+            'Content-Type':
+              response.headers.get('Content-Type') ||
+              'application/octet-stream',
+            'Content-Length': data.byteLength.toString(),
+            'Accept-Ranges': 'bytes',
+            'Access-Control-Expose-Headers':
+              'Content-Length, X-Content-Length, Content-Range, Accept-Ranges',
+          }
+          // Pass through Content-Range so the client can read the TOTAL size from
+          // "bytes start-end/total" even on a partial response.
+          const contentRange = response.headers.get('Content-Range')
+          if (contentRange) proxyHeaders['Content-Range'] = contentRange
+          // Mirror the full size into a custom header the runtime keeps. On a
+          // non-ranged 200 this is the total; on a 206 the client prefers
+          // Content-Range's total.
+          const fullLength = response.headers.get('Content-Length')
+          if (!contentRange && fullLength) {
+            proxyHeaders['X-Content-Length'] = fullLength
+          }
 
           // biome-ignore lint/suspicious/noConsole: logging
           console.log(
-            `[INFO] [proxy] [PERF] Download completed: ${proxyTime.toFixed(0)}ms, ${(data.byteLength / 1024 / 1024).toFixed(2)}MB`,
+            `[INFO] [proxy] Sent ${(data.byteLength / 1024 / 1024).toFixed(2)}MB (status ${response.status}) in ${(performance.now() - proxyStart).toFixed(0)}ms`,
           )
 
-          // Return the file with appropriate headers
           return handleCors(
             req,
             new Response(data, {
-              status: 200,
-              headers: {
-                'Content-Type':
-                  response.headers.get('Content-Type') ||
-                  'application/octet-stream',
-                'Content-Length': data.byteLength.toString(),
-              },
+              status: response.status,
+              headers: proxyHeaders,
             }),
           )
         } catch (error) {

--- a/app/apps/server/src/openapi/paths/songs.ts
+++ b/app/apps/server/src/openapi/paths/songs.ts
@@ -343,6 +343,113 @@ export const songsPaths = {
       },
     },
   },
+  '/api/songs/discovery/match': {
+    post: {
+      tags: ['Songs'],
+      summary: 'Match external candidates against the library',
+      description:
+        'Classifies external (not-yet-imported) songs against the local library so the discovery flow can show only the ones the user lacks. Per candidate the verdict is one of exact-filename, exact-title, similar, or new. Batched: send at most 500 candidates per request.',
+      security: [{ bearerAuth: [] }, { cookieAuth: [] }],
+      requestBody: {
+        required: true,
+        content: {
+          'application/json': {
+            schema: {
+              type: 'object',
+              required: ['candidates'],
+              properties: {
+                candidates: {
+                  type: 'array',
+                  maxItems: 500,
+                  items: {
+                    $ref: '#/components/schemas/DiscoveryCandidateInput',
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      responses: {
+        '200': {
+          description: 'Per-candidate match verdicts',
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                properties: {
+                  data: {
+                    type: 'array',
+                    items: {
+                      $ref: '#/components/schemas/DiscoveryMatchResult',
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        '400': { $ref: '#/components/responses/BadRequest' },
+        '401': { $ref: '#/components/responses/Unauthorized' },
+      },
+    },
+  },
+  '/api/songs/discovery/count': {
+    post: {
+      tags: ['Songs'],
+      summary: 'Count new external candidates',
+      description:
+        'Cheap "how many of these are new?" count for the background discovery check (sidebar badge + toast). Uses filename + normalized-title exact matching only — no fuzzy/FTS — so it stays fast over a multi-thousand-song catalog. Send at most 5000 candidates per request.',
+      security: [{ bearerAuth: [] }, { cookieAuth: [] }],
+      requestBody: {
+        required: true,
+        content: {
+          'application/json': {
+            schema: {
+              type: 'object',
+              required: ['candidates'],
+              properties: {
+                candidates: {
+                  type: 'array',
+                  maxItems: 5000,
+                  items: {
+                    type: 'object',
+                    required: ['title'],
+                    properties: {
+                      title: { type: 'string' },
+                      sourceFilename: { type: 'string', nullable: true },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      responses: {
+        '200': {
+          description: 'Count of candidates not already in the library',
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                properties: {
+                  data: {
+                    type: 'object',
+                    properties: {
+                      newCount: { type: 'integer' },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        '400': { $ref: '#/components/responses/BadRequest' },
+        '401': { $ref: '#/components/responses/Unauthorized' },
+      },
+    },
+  },
   '/api/songs/{id}': {
     get: {
       tags: ['Songs'],

--- a/app/apps/server/src/openapi/schemas/songs.ts
+++ b/app/apps/server/src/openapi/schemas/songs.ts
@@ -308,4 +308,45 @@ export const songSchemas = {
       },
     },
   },
+  DiscoveryCandidateInput: {
+    type: 'object',
+    required: ['tempId', 'title', 'lyrics'],
+    properties: {
+      tempId: {
+        type: 'string',
+        description:
+          'Client-assigned correlation id, echoed back in the result.',
+      },
+      title: { type: 'string' },
+      lyrics: {
+        type: 'string',
+        description: 'Joined slide text — drives the fuzzy similarity pass.',
+      },
+      sourceFilename: { type: 'string', nullable: true },
+    },
+  },
+  DiscoveryMatchResult: {
+    type: 'object',
+    properties: {
+      tempId: { type: 'string' },
+      verdict: {
+        type: 'string',
+        enum: ['exact-filename', 'exact-title', 'similar', 'new'],
+        description:
+          'How the candidate relates to the library: an exact filename/title duplicate, a fuzzy version match, or genuinely new.',
+      },
+      exactSongId: {
+        type: 'integer',
+        nullable: true,
+        description:
+          'The matched library song id for exact-filename / exact-title verdicts.',
+      },
+      similar: {
+        type: 'array',
+        description:
+          'Fuzzy version matches (empty unless verdict is "similar").',
+        items: { $ref: '#/components/schemas/SongVersionSuggestion' },
+      },
+    },
+  },
 }

--- a/app/apps/server/src/service/song-bookmarks/addBookmark.ts
+++ b/app/apps/server/src/service/song-bookmarks/addBookmark.ts
@@ -3,6 +3,7 @@ import { eq, sql } from 'drizzle-orm'
 import type { SongBookmark } from './types'
 import { getDatabase } from '../../db'
 import { songBookmarks, songCategories, songs } from '../../db/schema'
+import { getTagsBySongIds } from '../songs/tags'
 
 const DEBUG = process.env.DEBUG === 'true'
 
@@ -19,6 +20,10 @@ export function addBookmark(
     log('debug', `Adding bookmark for song ${songId}`)
 
     const db = getDatabase()
+
+    const songTagNames = (getTagsBySongIds([songId]).get(songId) ?? []).map(
+      (t) => t.name,
+    )
 
     // Check if already bookmarked
     const existing = db
@@ -47,6 +52,7 @@ export function addBookmark(
           songTitle: song?.title ?? '',
           songCategoryName: song?.categoryName ?? null,
           songKeyLine: song?.keyLine ?? null,
+          songTagNames,
           sortOrder: existing.sortOrder,
           createdAt: existing.createdAt.getTime(),
         },
@@ -88,6 +94,7 @@ export function addBookmark(
         songTitle: song?.title ?? '',
         songCategoryName: song?.categoryName ?? null,
         songKeyLine: song?.keyLine ?? null,
+        songTagNames,
         sortOrder: inserted.sortOrder,
         createdAt: inserted.createdAt.getTime(),
       },

--- a/app/apps/server/src/service/song-bookmarks/getBookmarks.ts
+++ b/app/apps/server/src/service/song-bookmarks/getBookmarks.ts
@@ -3,6 +3,7 @@ import { asc, eq } from 'drizzle-orm'
 import type { SongBookmark } from './types'
 import { getDatabase } from '../../db'
 import { songBookmarks, songCategories, songs } from '../../db/schema'
+import { getTagsBySongIds } from '../songs/tags'
 
 const DEBUG = process.env.DEBUG === 'true'
 
@@ -35,12 +36,16 @@ export function getBookmarks(): SongBookmark[] {
 
     log('debug', `Found ${records.length} bookmarks`)
 
+    // Bulk-fetch tags for all bookmarked songs in a single query (no N+1).
+    const tagsBySongId = getTagsBySongIds(records.map((r) => r.songId))
+
     return records.map((r) => ({
       id: r.id,
       songId: r.songId,
       songTitle: r.songTitle,
       songCategoryName: r.songCategoryName,
       songKeyLine: r.songKeyLine,
+      songTagNames: (tagsBySongId.get(r.songId) ?? []).map((t) => t.name),
       sortOrder: r.sortOrder,
       createdAt: r.createdAt.getTime(),
     }))

--- a/app/apps/server/src/service/song-bookmarks/types.ts
+++ b/app/apps/server/src/service/song-bookmarks/types.ts
@@ -4,6 +4,7 @@ export interface SongBookmark {
   songTitle: string
   songCategoryName: string | null
   songKeyLine: string | null
+  songTagNames: string[]
   sortOrder: number
   createdAt: number
 }

--- a/app/apps/server/src/service/songs/discovery.ts
+++ b/app/apps/server/src/service/songs/discovery.ts
@@ -1,0 +1,185 @@
+import { normalizeForIndex } from './search'
+import { getSimilarSongsForContent } from './song-groups'
+import type { DiscoveryCandidateInput, DiscoveryMatchResult } from './types'
+import { getDatabase } from '../../db'
+import { songs } from '../../db/schema'
+import { createLogger } from '../../utils/logger'
+
+const logger = createLogger('song-discovery')
+
+/** Below this fuzzy score a candidate is treated as genuinely new, not similar. */
+const SIMILAR_MIN_SCORE = 0.55
+
+/** How many fuzzy version matches to surface per candidate. */
+const SIMILAR_LIMIT = 5
+
+/**
+ * The two cheap exact-match indexes over the whole library, built once per
+ * request: `source_filename` → id and `normalizeForIndex(title)` → id.
+ * First-writer-wins on collisions — any match means the candidate is present.
+ */
+interface LibraryExactIndex {
+  byFilename: Map<string, number>
+  byNormalizedTitle: Map<string, number>
+}
+
+/**
+ * Case-insensitive title key. `normalizeForIndex` strips diacritics + punctuation
+ * but does NOT lowercase (FTS lowercases at tokenization time, so it doesn't need
+ * to). Our exact-title dedup compares strings directly, so we must lowercase —
+ * otherwise "Am primit darul ceresc" wouldn't match a library "Am primit Darul
+ * Ceresc", the song would show as new forever, yet the importer (which keys on
+ * LOWER(title)) would skip it as a duplicate. Keep this consistent with the
+ * importer's case-insensitive title match.
+ */
+function normalizeTitleKey(title: string): string {
+  return normalizeForIndex(title).toLowerCase()
+}
+
+function buildLibraryExactIndex(): LibraryExactIndex {
+  const db = getDatabase()
+  const libraryRows = db
+    .select({
+      id: songs.id,
+      title: songs.title,
+      sourceFilename: songs.sourceFilename,
+    })
+    .from(songs)
+    .all()
+
+  const byFilename = new Map<string, number>()
+  const byNormalizedTitle = new Map<string, number>()
+  for (const row of libraryRows) {
+    if (row.sourceFilename && !byFilename.has(row.sourceFilename)) {
+      byFilename.set(row.sourceFilename, row.id)
+    }
+    const normTitle = normalizeTitleKey(row.title)
+    if (normTitle && !byNormalizedTitle.has(normTitle)) {
+      byNormalizedTitle.set(normTitle, row.id)
+    }
+  }
+  return { byFilename, byNormalizedTitle }
+}
+
+/** Whether the candidate exactly matches a library song by filename or title. */
+function isExactLibraryMatch(
+  index: LibraryExactIndex,
+  candidate: { title: string; sourceFilename: string | null },
+): boolean {
+  if (
+    candidate.sourceFilename &&
+    index.byFilename.has(candidate.sourceFilename)
+  ) {
+    return true
+  }
+  const normTitle = normalizeTitleKey(candidate.title)
+  return normTitle.length > 0 && index.byNormalizedTitle.has(normTitle)
+}
+
+/**
+ * Classifies a batch of external (not-yet-imported) songs against the local
+ * library so the song-discovery screen can show ONLY the ones the user lacks
+ * and flag the ones that look like an existing song.
+ *
+ * Combined dedup, in increasing cost order — the cheap exact passes short-
+ * circuit so the expensive FTS-backed fuzzy pass only runs for candidates
+ * that are new-by-filename AND new-by-title:
+ *   1. exact `source_filename` match  → 'exact-filename'
+ *   2. exact normalized-title match   → 'exact-title'
+ *   3. fuzzy version match (FTS + Jaccard, reuses getSimilarSongsForContent)
+ *      → 'similar' (with matches) else 'new'
+ *
+ * The library snapshot (filename + normalized-title maps) is built ONCE for
+ * the whole batch, so the per-candidate cost of the two exact passes is a
+ * couple of hash lookups regardless of library size.
+ */
+export function matchCandidatesAgainstLibrary(
+  candidates: readonly DiscoveryCandidateInput[],
+): DiscoveryMatchResult[] {
+  if (candidates.length === 0) return []
+
+  try {
+    const { byFilename, byNormalizedTitle } = buildLibraryExactIndex()
+
+    return candidates.map((candidate) => {
+      // 1) Exact filename.
+      if (candidate.sourceFilename) {
+        const hit = byFilename.get(candidate.sourceFilename)
+        if (hit != null) {
+          return {
+            tempId: candidate.tempId,
+            verdict: 'exact-filename',
+            exactSongId: hit,
+            similar: [],
+          }
+        }
+      }
+
+      // 2) Exact normalized title (case-insensitive, like the importer).
+      const normTitle = normalizeTitleKey(candidate.title)
+      if (normTitle) {
+        const hit = byNormalizedTitle.get(normTitle)
+        if (hit != null) {
+          return {
+            tempId: candidate.tempId,
+            verdict: 'exact-title',
+            exactSongId: hit,
+            similar: [],
+          }
+        }
+      }
+
+      // 3) Fuzzy version match — only reached when both exact passes missed.
+      const similar = getSimilarSongsForContent(
+        candidate.title,
+        candidate.lyrics,
+        { limit: SIMILAR_LIMIT, minScore: SIMILAR_MIN_SCORE },
+      )
+
+      return {
+        tempId: candidate.tempId,
+        verdict: similar.length > 0 ? 'similar' : 'new',
+        exactSongId: null,
+        similar,
+      }
+    })
+  } catch (error) {
+    logger.error(`matchCandidatesAgainstLibrary failed: ${error}`)
+    // Fail open: treat everything as new so the operator can still review/import
+    // rather than losing the whole batch to one bad query.
+    return candidates.map((candidate) => ({
+      tempId: candidate.tempId,
+      verdict: 'new' as const,
+      exactSongId: null,
+      similar: [],
+    }))
+  }
+}
+
+/**
+ * Cheap "how many of these are new?" count for the BACKGROUND discovery check
+ * that drives the sidebar badge + toast. Deliberately skips the expensive FTS
+ * fuzzy pass — it only needs filename + normalized-title exact matching, which
+ * is two hash lookups per candidate. A candidate counts as new when it matches
+ * NO existing library song by filename or title (the fuzzy "similar" ones still
+ * count as new here, since the user doesn't actually have them yet).
+ *
+ * Returns just the count so the background job can decide whether to notify
+ * without paying for the full per-candidate similarity payload.
+ */
+export function countNewCandidates(
+  candidates: readonly { title: string; sourceFilename: string | null }[],
+): number {
+  if (candidates.length === 0) return 0
+  try {
+    const index = buildLibraryExactIndex()
+    let newCount = 0
+    for (const candidate of candidates) {
+      if (!isExactLibraryMatch(index, candidate)) newCount++
+    }
+    return newCount
+  } catch (error) {
+    logger.error(`countNewCandidates failed: ${error}`)
+    return 0
+  }
+}

--- a/app/apps/server/src/service/songs/index.ts
+++ b/app/apps/server/src/service/songs/index.ts
@@ -9,6 +9,8 @@ export {
   reorderCategories,
   upsertCategory,
 } from './categories'
+// Discovery (external-source import)
+export { countNewCandidates, matchCandidatesAgainstLibrary } from './discovery'
 export {
   completeSongReplacement,
   type ReplaceSongReferencesResult,
@@ -28,6 +30,7 @@ export {
 export {
   getGroupForSong,
   getSimilarSongs,
+  getSimilarSongsForContent,
   getSongGroupWithMembers,
   getVersionCounts,
   linkSongs,
@@ -73,6 +76,9 @@ export {
 export type {
   BatchImportResult,
   BatchImportSongInput,
+  DiscoveryCandidateInput,
+  DiscoveryMatchResult,
+  DiscoveryMatchVerdict,
   OperationResult,
   ReorderCategoriesInput,
   ReorderSongSlidesInput,

--- a/app/apps/server/src/service/songs/song-groups.ts
+++ b/app/apps/server/src/service/songs/song-groups.ts
@@ -825,6 +825,53 @@ export function getSimilarSongs(
       for (const m of groupMembers) exclude.add(m.id)
     }
 
+    // Subject lyrics — needed for the lyrics-recall query AND the rerank.
+    const subjectSlides = db
+      .select({ content: songSlides.content })
+      .from(songSlides)
+      .where(eq(songSlides.songId, songId))
+      .all()
+    const subjectLyrics = subjectSlides.map((s) => s.content).join(' ')
+
+    return getSimilarSongsForContent(subject.title, subjectLyrics, {
+      limit,
+      minScore,
+      excludeSongIds: [...exclude],
+    })
+  } catch (error) {
+    logger.error(`getSimilarSongs(${songId}) failed: ${error}`)
+    return []
+  }
+}
+
+/**
+ * The content-based core of `getSimilarSongs`: given a raw title + lyrics
+ * (NOT a persisted song id), surfaces likely existing-library versions.
+ *
+ * This is what lets the song-discovery flow ask "does the library already
+ * have something like this external song?" BEFORE importing it — the
+ * candidate isn't in the DB yet, so there's no `songId` to pass. The two
+ * recall passes + Jaccard rerank are identical to the by-id path.
+ *
+ * `excludeSongIds` lets the caller drop already-resolved members (e.g. the
+ * subject's own group siblings). Songs in hidden categories are always
+ * excluded — they're meant to vanish from version suggestions too.
+ */
+export function getSimilarSongsForContent(
+  title: string,
+  lyrics: string,
+  opts: {
+    limit?: number
+    minScore?: number
+    excludeSongIds?: readonly number[]
+  } = {},
+): SongVersionSuggestion[] {
+  const { limit = 5, minScore = 0.55, excludeSongIds = [] } = opts
+  try {
+    const db = getDatabase()
+
+    const exclude = new Set<number>(excludeSongIds)
+
     // Never suggest songs from a hidden category — a hidden category is meant
     // to disappear from the song browser AND from version "possible matches".
     const hiddenCategoryIds = getHiddenCategoryIds()
@@ -837,19 +884,12 @@ export function getSimilarSongs(
       for (const s of hiddenSongs) exclude.add(s.id)
     }
 
-    // Subject lyrics — needed for the lyrics-recall query AND the rerank.
-    const subjectSlides = db
-      .select({ content: songSlides.content })
-      .from(songSlides)
-      .where(eq(songSlides.songId, songId))
-      .all()
-    const subjectLyrics = subjectSlides.map((s) => s.content).join(' ')
-    const subjectTitleToks = tokenize(subject.title)
-    const subjectLyricToks = tokenize(subjectLyrics)
+    const subjectTitleToks = tokenize(title)
+    const subjectLyricToks = tokenize(lyrics)
 
     // 1) Title recall — cheap FTS over title/category/content using the title
     //    as the query. Understands diacritic folding + hymn numbers.
-    const titleCandidates = searchSongs(subject.title, undefined, 30).filter(
+    const titleCandidates = searchSongs(title, undefined, 30).filter(
       (c) => !exclude.has(c.id),
     )
 
@@ -966,7 +1006,7 @@ export function getSimilarSongs(
         : r
     })
   } catch (error) {
-    logger.error(`getSimilarSongs(${songId}) failed: ${error}`)
+    logger.error(`getSimilarSongsForContent("${title}") failed: ${error}`)
     return []
   }
 }

--- a/app/apps/server/src/service/songs/types.ts
+++ b/app/apps/server/src/service/songs/types.ts
@@ -302,6 +302,42 @@ export interface BatchImportResult {
 }
 
 /**
+ * One external (not-yet-imported) song the song-discovery flow asks the
+ * library about. `lyrics` is the joined slide text — enough to drive the
+ * FTS/Jaccard similarity pass without shipping the full slide structure.
+ */
+export interface DiscoveryCandidateInput {
+  /** Client-assigned correlation id, echoed back in the result. */
+  tempId: string
+  title: string
+  lyrics: string
+  sourceFilename: string | null
+}
+
+/**
+ * How an external candidate relates to the local library:
+ *  - `exact-filename`: a song with the same `source_filename` already exists.
+ *  - `exact-title`:    a song with the same normalized title already exists.
+ *  - `similar`:        no exact match, but ≥1 fuzzy version match was found.
+ *  - `new`:            nothing comparable in the library — safe to import.
+ */
+export type DiscoveryMatchVerdict =
+  | 'exact-filename'
+  | 'exact-title'
+  | 'similar'
+  | 'new'
+
+/** Per-candidate verdict returned by `matchCandidatesAgainstLibrary`. */
+export interface DiscoveryMatchResult {
+  tempId: string
+  verdict: DiscoveryMatchVerdict
+  /** The matched library song id for exact-filename / exact-title verdicts. */
+  exactSongId: number | null
+  /** Fuzzy version matches (empty unless verdict is `similar`). */
+  similar: SongVersionSuggestion[]
+}
+
+/**
  * A song group groups multiple `Song` rows that are versions of the same
  * underlying piece. Membership is non-destructive: every member keeps its
  * own row in `songs`; the group just records the relationship.


### PR DESCRIPTION
# feat(songs): discover & import new songs from external sources

### 1. Summary

This PR adds a **song discovery** flow to the Songs module: it pulls the catalog from an external source (Resurse Crestine), compares it against the local library, and shows **only the songs you don't already have** — letting you review, edit, and approve/skip each one before a single batch import. It also runs that check **in the background** and notifies you when new songs appear.

It contains four themes:

1. **Discovery backend** — a read-only dedup/similarity service and three HTTP endpoints, plus a refactor that lets the existing version-similarity logic run against not-yet-imported songs.
2. **Discovery screen** — a dedicated staging UI under `/songs/discover` with live progress, per-song edit/approve/skip, and a "similar in your library" panel.
3. **Background sync + entry point** — a daily, bandwidth-cheap catalog check that drives a sidebar badge + a one-time toast, and an animated "Discover" button in the songs header.
4. **Reliable downloading** — a chunked HTTP Range download (through the server proxy) that replaced a single-stream download which stalled at 0%.

### 2. Why

#### 2.1 No way to find songs that exist online but not in the library
- **Previous behaviour:** the only way to bring in Resurse Crestine songs was the existing one-shot "import everything" flow in Import/Export — no per-song review, no way to see what was actually *new* versus already owned.
- **Why it was problematic:** operators couldn't tell which songs were missing from their library, couldn't edit a song before importing it, and couldn't decide song-by-song.
- **User flow affected:** building/maintaining the song library from the external catalog.

#### 2.2 Knowing when new songs are published required manual effort
- There was no signal that the external catalog had grown — you'd only find new songs by manually re-importing everything.

#### 2.3 Downloading the catalog was unreliable
- A single streamed download of the ~18 MB catalog **buffered the whole body** before delivering any bytes (both the Tauri HTTP plugin and the Bun proxy did this), so the UI sat at "downloading… 0%" for minutes and looked frozen, even though the source itself is fast.

#### 2.4 Discovery and import disagreed about duplicates (phantom song)
- A song could be shown as "new" by discovery yet **skipped** by the importer, so it reappeared after every refresh. Root cause: `normalizeForIndex` does **not** lowercase (FTS lowercases at tokenization time), so discovery's title dedup was case-sensitive, while the importer keys on `LOWER(title)`. "Am primit darul ceresc" (catalog) never matched the library's "Am primit Darul Ceresc".

### 3. What changed

**Backend (`20c8ac5b`)**
- Extracted `getSimilarSongsForContent(title, lyrics, opts)` from `getSimilarSongs(songId)` so the FTS + Jaccard version-similarity can run on raw content (an external candidate that isn't in the DB yet). `getSimilarSongs` becomes a thin wrapper — no behaviour change for the existing Versions feature.
- New read-only service `service/songs/discovery.ts`:
  - `matchCandidatesAgainstLibrary` — per-candidate verdict via combined dedup, increasing cost order: exact `source_filename` → exact **case-insensitive** normalized title → fuzzy similarity.
  - `countNewCandidates` — a cheap count (filename + title only, no FTS) for the background badge.
  - `normalizeTitleKey` = `normalizeForIndex(title).toLowerCase()`, making title dedup **consistent with the importer's `LOWER(title)`** (fixes 2.4).
- `GET /api/proxy/download` is now **Range-aware**: it forwards the client's `Range` header and returns the chunk (status + `Content-Range`), instead of buffering the whole file. `GET /api/proxy/head` added for the background change-check.

**Frontend (`8643845b`)**
- New `features/song-discovery/` feature: a `SourceProvider` abstraction (Resurse Crestine implementation, registry stays extensible), hooks (`useFetchCatalog`, `useMatchCandidates`, `useImportApproved`, `useSongDiscoverySync`), a context provider, and the staging screen + sub-components.
- `/songs/discover` route (guarded by `songs.create`), a settings toggle, a sidebar badge, and an animated Discover button.
- `downloadFromUrl` rewritten to download in **2 MB HTTP Range chunks through the proxy**, reporting progress per chunk (fixes 2.3). Falls back to a streamed read if a server ignores ranges.
- After an import, imported rows are dropped locally and **the rest of the list stays** — no automatic re-analyze; re-running discovery is opt-in (header/empty-state "Refresh catalog").
- Titleless OpenSong files derive their title from the first lyric line instead of showing "unnamed".

**i18n (`d59dc6dc`)**
- New `songDiscovery` namespace (en + ro), plus `actions.discover` / `actions.discovering` in the `songs` namespace.

**Database (`20c8ac5b`)**
- New index `idx_songs_source_filename` (migration `0029`) backing the exact-filename dedup pass.

### 4. Technical details

| Kind | Name | Purpose |
|---|---|---|
| Service (server) | `matchCandidatesAgainstLibrary` | Per-candidate verdict: `exact-filename` / `exact-title` / `similar` / `new` |
| Service (server) | `countNewCandidates` | Cheap "how many are new?" (filename + title only) for the badge |
| Function (server) | `getSimilarSongsForContent` | Similarity on raw title+lyrics (extracted from `getSimilarSongs`) |
| Helper (server) | `normalizeTitleKey` | Case-insensitive title key, consistent with the importer |
| Provider (client) | `resurseCrestineProvider` | Download + parse the catalog into comparable candidates |
| Hook (client) | `useFetchCatalog` | React-Query-cached catalog fetch with progress |
| Hook (client) | `useMatchCandidates` | Streams the library diff with `analyzed/total` progress |
| Hook (client) | `useSongDiscoverySync` | Daily background check (HEAD change-check, localStorage, badge/toast) |
| Hook (client) | `useImportApproved` | Maps approved drafts → batch import (reuses `useBatchImportSongs`) |
| Context (client) | `SongDiscoveryProvider` | Runs the sync once app-wide; exposes badge count + dismiss |
| Component (client) | `SongDiscoveryScreen`, `CandidateList`, `CandidateEditorPanel`, `SimilarInLibraryPanel`, `DiscoveryProgress`, `DiscoveryToolbar`, `DiscoverButton`, `VerdictBadge`, `DiscoverySyncSettings` | The staging UI + entry point |

### 5. API changes

New:
```http
POST /api/songs/discovery/match     # permission: songs.create
# body:  { candidates: [{ tempId, title, lyrics, sourceFilename }] }  (≤ 500)
# reply: { data: [{ tempId, verdict, exactSongId, similar: SongVersionSuggestion[] }] }

POST /api/songs/discovery/count     # permission: songs.create
# body:  { candidates: [{ title, sourceFilename }] }  (≤ 5000)
# reply: { data: { newCount } }

GET  /api/proxy/head?url=<whitelisted>   # permission: songs.create
# reply: { data: { lastModified, etag, contentLength } }
```
Changed:
```http
GET  /api/proxy/download?url=<whitelisted>   # permission: songs.create
# now forwards the request's `Range` header and returns the partial chunk
# (status 206 + Content-Range), instead of buffering the entire file.
```
Both new POST routes are registered in OpenAPI (`/api/docs`).

### 6. Database changes

- **New index:** `idx_songs_source_filename` on `songs(source_filename)`.
- **Migration:** `0029_add_songs_source_filename_index.sql` (mirrored into the embedded migrations + journal).
- **Compatibility:** additive index only — no column/constraint changes, no data migration. Fully backward compatible.
- **Rollback:** `DROP INDEX IF EXISTS idx_songs_source_filename;` (or revert the migration). Dropping it only slows the exact-filename dedup pass; nothing else depends on it.

### 7. Permissions / Authorization

| Permission | Status | Grants |
|---|---|---|
| `songs.create` | **EXISTING** (reused) | Gates the `/songs/discover` route, the three new endpoints, and the proxy. Discovering + importing is a create operation, so it shares the same gate as song creation. |

No new permission keys are introduced. The background sync is also gated on `songs.create` (users who can't import are never pinged).

### 8. UI / UX changes

- **Discover button** in the songs header: animated gradient border + Sparkles icon sharing one moving gradient; spinner-free "searching" state with cumulative `.` `..` `...` dots; a red count badge when new songs are found.
- **`/songs/discover` screen:** hero header, live progress band (download MB/%, then `analyzed / total · %` with a moving shimmer), stat chips (online / new / selected), a virtualized candidate list with verdict badges + approve/skip, an editor panel (reusing the real song-editor sections on local state), and a "similar in your library" panel.
- **Empty/`all done` state** with an opt-in "Refresh catalog" button.
- **Error state** with a "Try again" button when the download fails/stalls.
- **Sidebar badge** on the Songs item showing the new-songs count.
- **Settings → Songs:** a toggle to enable/disable the background check + a "Check now" button.

### 9. Migration / Backfill strategy

- `0029_add_songs_source_filename_index.sql`: `CREATE INDEX IF NOT EXISTS idx_songs_source_filename ON songs(source_filename);`
  - **What it does:** adds a secondary index on `source_filename`.
  - **Safe:** additive, non-blocking for SQLite at this scale, no data touched.
  - **Idempotent:** `IF NOT EXISTS` — re-running is a no-op. The embedded-migration runner also tracks applied hashes, so it never re-applies.

### 10. Commit breakdown

#### Backend
- `20c8ac5b` feat(songs): discovery backend — match/count endpoints, content similarity, range proxy

#### i18n
- `d59dc6dc` feat(i18n): songDiscovery namespace + discover action strings (en/ro)

#### Frontend
- `8643845b` feat(songs): discovery screen, background sync, animated discover button

#### Tests
- `23db7f35` test(songs): discovery endpoints (match/count, case-insensitive) + UI e2e

### 11. Test plan

- [ ] **Happy path:** open `/songs/discover` → catalog appears (reused from background cache or downloaded with visible MB/% progress) → new songs stream in with `analyzed/total · %`.
- [ ] **Edit before import:** select a candidate, edit title/slides/metadata in the panel → changes persist in the draft.
- [ ] **Similar panel:** a candidate with a near-match in the library shows the "similar in your library" list + badge.
- [ ] **Import keeps the list:** approve some, import → imported rows disappear, the rest stay, **no auto re-analyze**.
- [ ] **Opt-in refresh:** when the list empties, the "Refresh catalog" button re-downloads + re-analyzes.
- [ ] **Background + badge:** with the toggle on, the Songs sidebar item shows a count and a one-time toast appears for a fresh catalog; the Discover button animates while checking.
- [ ] **Regression (phantom song):** "Am primit darul ceresc" (catalog title lower-case) is recognized as already-in-library and does NOT reappear after refresh.
- [ ] **API:** `POST /api/songs/discovery/match` returns correct verdicts incl. **case-insensitive** title match; `/count` returns `newCount`; both 400 over their caps. (covered by `api.test.ts`)
- [ ] **Database:** `idx_songs_source_filename` exists after boot; re-running the migration is a no-op.
- [ ] **Permission:** a user without `songs.create` cannot reach `/songs/discover` and gets 401/403 on the endpoints.
- [ ] **Download:** the catalog downloads in 2 MB chunks (server log `[proxy] Sent … MB (status 206)`); a stalled/failed download surfaces the error card.
- [ ] **Packaged app (cannot verify in dev/browser):** confirm the proxy-routed Range download behaves identically in the Tauri build's WebView.

### 12. Risks

| Area | Risk | Mitigation |
|---|---|---|
| Performance | Full match over a multi-thousand-song catalog | Match chunked (150/req) and streamed; exact passes short-circuit so FTS runs only for title-new candidates; background count skips FTS entirely |
| Bandwidth | Background sync re-downloading the catalog | HEAD change-check skips the download when unchanged; with no upstream validators it falls back to the daily cadence (not every open) |
| Compatibility | New DB index on existing installs | Additive + idempotent (`IF NOT EXISTS`); trivially reversible |
| UX | External source slow/down | Per-chunk timeouts + a clear error card with retry; total size surfaced immediately so 0% never looks frozen |
| Data | Importing duplicates | Dedup now consistent with the importer (case-insensitive); the server's insert/skip remains a safety net |

### 13. Out of scope

- No second external source is implemented (the provider registry is ready for one, but only Resurse Crestine ships here).
- No OS-level/system notifications — the "new songs" notification is in-app (toast + sidebar badge) only.
- No changes to the existing one-shot Import/Export flow (left intact).
- No server-side catalog cache or scheduled job — the background check is client-side.
- No changes to song slides/versions/grouping semantics beyond the extracted similarity helper.

<img width="1552" height="910" alt="image" src="https://github.com/user-attachments/assets/002a03eb-2696-4494-9160-8bac807f08ac" />
<img width="1552" height="910" alt="image" src="https://github.com/user-attachments/assets/eb9f05a9-4d45-4f5a-bfc0-19c7d9dff29b" />
<img width="1508" height="866" alt="image" src="https://github.com/user-attachments/assets/053920fe-cf8e-4063-a60f-66fdc3c77f81" />
<img width="1508" height="866" alt="image" src="https://github.com/user-attachments/assets/f268f28d-2f77-4033-a81a-9fa3f747d1c1" />
<img width="1552" height="910" alt="image" src="https://github.com/user-attachments/assets/1e02014a-233f-4dd0-a8f9-5007008505f4" />
<img width="1552" height="910" alt="image" src="https://github.com/user-attachments/assets/81518b10-053b-4115-aa00-4402f1666585" />
<img width="1552" height="910" alt="image" src="https://github.com/user-attachments/assets/af216359-3f2b-4a29-b01f-a2a8608763ee" />
<img width="1508" height="866" alt="image" src="https://github.com/user-attachments/assets/0cbc5111-cb77-4b6a-8484-890024502d83" />
