### PR TITLE
fix(e2e): update discovery heading selector after screen rename

### DIFF
--- a/app/apps/client/e2e/song-discovery.spec.ts
+++ b/app/apps/client/e2e/song-discovery.spec.ts
@@ -182,7 +182,9 @@ test.describe('Song Discovery — staging UI', () => {
     // The screen auto-fetches on open (reusing the mocked download) — no click.
     await page.goto('/songs/discover')
     await expect(
-      page.getByRole('heading', { name: /Discover new songs|Descoperă/ }),
+      page.getByRole('heading', {
+        name: /Download the latest songs|Descarcă ultimele cântări/,
+      }),
     ).toBeVisible()
 
     // Wait for the diff to stream in and surface the new song.


### PR DESCRIPTION
# fix(e2e): update discovery heading selector after screen rename

### 1. Summary
Repairs the only failing test in the suite: the Song Discovery staging-UI e2e
(`song-discovery.spec.ts`). The discovery screen's title was renamed in an
earlier commit, but the test still asserted the old heading text, so it failed
**deterministically** at the heading check — before ever reaching the
import flow it was meant to exercise. This PR points the heading locator at the
current title in both supported locales (English + Romanian).

### 2. Why
The CI `e2e-tests` job was red (`296 passed, 1 failed`) while `unit-tests` and
`server-tests` were green. The single failure was:

```
[chromium] › e2e/song-discovery.spec.ts:134:3 › Song Discovery — staging UI ›
shows only new songs, lets the user import an approved candidate
```

- **Previous behaviour:** the test asserted
  `getByRole('heading', { name: /Discover new songs|Descoperă/ })`.
- **Why it was wrong:** the discovery screen heading (`t('title')`,
  `SongDiscoveryScreen.tsx`) was renamed to
  *"Download the latest songs from Resurse Crestine"* (ro: *"Descarcă ultimele
  cântări de pe Resurse Creștine"*). Neither locale contains "Discover new
  songs" or "Descoperă" anymore, so the locator never matched.
- **Concrete example:** locally the test fails at `:186` with
  `expect(locator).toBeVisible()` → `element(s) not found`, 5 s timeout, on the
  heading assertion — the body of the test (streaming the diff, surfacing the
  new song, approving and importing it) never runs.
- **Affected flow:** the discovery → review → import end-to-end path is left
  unverified, and the red e2e job blocks the release `test` gate.
- **Impact:** a stale selector (not a product defect) was failing CI on every
  push to `main` and on the `v*` release builds.

### 3. What changed
**Tests (e2e) only.**
- `e214d768` — point the heading locator at the renamed title, matching both
  locales: `/Download the latest songs|Descarcă ultimele cântări/`. No
  production code is touched; the rest of the test (mocked ZIP download, HEAD
  change-check stub, duplicate-by-filename hidden, approve + import, library
  search assertion) is unchanged and already correct.

Backward compatibility: none affected — this is a test-only selector update.

### 4. Technical details
| Kind | Name | Change |
| --- | --- | --- |
| e2e spec | `song-discovery.spec.ts` | Heading regex updated to the current `songDiscovery.title` strings (en + ro) |

Root-cause verification: the new-song title is rendered as plain text
(`CandidateList.tsx`, `item.draft.title`), the test's `alphaId` token survives
`sanitizeSongTitle` unchanged, and the per-candidate **Import** /
**Import selected** button selectors still match the current `actions.approve`
and `toolbar.importApproved` strings — so once the heading matches, the rest of
the flow passes.

### 5. API changes
N/A — no API surface touched.

### 6. Database changes
N/A — no schema, migration, or data change.

### 7. Permissions / Authorization
N/A — no permission keys added or newly enforced.

### 8. UI / UX changes
N/A — no production UI change. (This PR only realigns a test with a heading that
was already renamed in a prior change.)

### 9. Migration / Backfill strategy
N/A — no migration.

### 10. Commit breakdown
#### Test fix
- `e214d768` fix(e2e): update discovery heading selector after screen rename

### 11. Test plan
- [x] `song-discovery.spec.ts` passes locally on chromium (full spec: 4 passed).
- [x] Ran the failing test 3× with a fresh timestamp each run (no shared state)
      — green every time, no flakiness; the import flow (`:189` onward) is
      reached and passes.
- [x] `unit-tests` green (994 passed) — unaffected.
- [x] `server-tests` green (250 passed) — unaffected.
- [x] Confirmed no other e2e spec references the old discovery strings
      (`Discover new songs` / `Descoperă`), so no sibling test is impacted.
- [ ] CI `e2e-tests` job green on this branch (to be confirmed by the PR run).

### 12. Risks
- **Locale drift:** if the discovery title is renamed again, this selector will
  need another update. *Mitigation:* the regex matches both locales' current
  titles and keys off the distinctive "Download the latest songs / Descarcă
  ultimele cântări" phrase rather than a single word.
- **Hidden flakiness downstream:** the test previously never reached the import
  assertions, so they were effectively unexercised in CI. *Mitigation:* ran the
  full flow repeatedly locally with fresh state; all green.

### 13. Out of scope
- No changes to the discovery screen, its hooks/services, or the match/diff
  pipeline.
- No re-rename of the heading or i18n strings.
- No changes to unit or server tests (already passing).
- No broader e2e refactor or selector-hardening pass beyond this one heading.
