### PR TITLE
fix(backup): embed Google Drive OAuth credentials in the final sidecar

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -358,27 +358,14 @@ jobs:
         id: sidecar-cache
         with:
           path: app/tauri/bin/church-hub-sidecar-${{ matrix.sidecar_suffix }}
-          # `drive1` namespaces the cache so the first build that embeds the
-          # Google Drive OAuth credentials can't reuse an older binary compiled
-          # without them. Bump the token if the embedded secrets ever change.
-          key: ${{ runner.os }}-sidecar-${{ matrix.sidecar_suffix }}-drive1-${{ hashFiles('app/apps/server/src/**', 'app/apps/server/package.json') }}
+          key: ${{ runner.os }}-sidecar-${{ matrix.sidecar_suffix }}-${{ hashFiles('app/apps/server/src/**', 'app/apps/server/package.json') }}
           restore-keys: |
-            ${{ runner.os }}-sidecar-${{ matrix.sidecar_suffix }}-drive1-
+            ${{ runner.os }}-sidecar-${{ matrix.sidecar_suffix }}-
 
       - name: Compile server sidecar
         if: steps.sidecar-cache.outputs.cache-hit != 'true'
         working-directory: app/apps/server
         shell: bash
-        env:
-          # Google Drive backup OAuth credentials. This is a Google "Desktop
-          # app" client, whose secret Google treats as non-confidential (the
-          # loopback/PKCE flow protects it), so baking it into the shipped
-          # sidecar is expected. `--define` inlines them as compile-time
-          # constants so `process.env.GOOGLE_DRIVE_*` resolves at runtime
-          # without shipping a .env. Unset secrets inline to "" and the feature
-          # disables gracefully.
-          GOOGLE_DRIVE_CLIENT_ID: ${{ secrets.GOOGLE_DRIVE_CLIENT_ID }}
-          GOOGLE_DRIVE_CLIENT_SECRET: ${{ secrets.GOOGLE_DRIVE_CLIENT_SECRET }}
         run: |
           mkdir -p ../../tauri/bin
           OUTFILE="../../tauri/bin/church-hub-sidecar-${{ matrix.sidecar_suffix }}"
@@ -389,8 +376,6 @@ jobs:
             --minify \
             --minify-syntax \
             --target ${{ matrix.bun_target }} \
-            --define "process.env.GOOGLE_DRIVE_CLIENT_ID=\"${GOOGLE_DRIVE_CLIENT_ID}\"" \
-            --define "process.env.GOOGLE_DRIVE_CLIENT_SECRET=\"${GOOGLE_DRIVE_CLIENT_SECRET}\"" \
             --outfile "$OUTFILE" \
             ./src/index.ts
 
@@ -411,6 +396,15 @@ jobs:
         uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Google Drive backup OAuth credentials. Tauri's beforeBuildCommand
+          # runs apps/server compile.ts, which bakes these into the FINAL
+          # sidecar via `bun build --define`. They MUST be present on THIS step
+          # (the earlier "Compile server sidecar" step's binary is overwritten
+          # by this build). Google "Desktop app" client → secret is
+          # non-confidential (loopback/PKCE); unset → embeds "" and the feature
+          # disables gracefully.
+          GOOGLE_DRIVE_CLIENT_ID: ${{ secrets.GOOGLE_DRIVE_CLIENT_ID }}
+          GOOGLE_DRIVE_CLIENT_SECRET: ${{ secrets.GOOGLE_DRIVE_CLIENT_SECRET }}
         with:
           projectPath: app
           tauriScript: bunx tauri

--- a/app/apps/server/scripts/compile.ts
+++ b/app/apps/server/scripts/compile.ts
@@ -128,8 +128,25 @@ async function main() {
   console.log('\x1b[34mCopying MIDI native modules...\x1b[0m')
   copyMidiPrebuilds(os, arch)
 
+  // Embed the Google Drive backup OAuth credentials as compile-time constants
+  // so the shipped sidecar can read `process.env.GOOGLE_DRIVE_*` at runtime
+  // without a .env. This is a Google "Desktop app" client whose secret Google
+  // treats as non-confidential (loopback/PKCE protects it). Sourced from the
+  // environment (CI secrets, or the local .env in dev); unset → embeds "" and
+  // the feature disables gracefully. This script produces the FINAL binary
+  // (Tauri's beforeBuildCommand), so the embedding must happen HERE.
+  const driveClientId = process.env.GOOGLE_DRIVE_CLIENT_ID ?? ''
+  const driveClientSecret = process.env.GOOGLE_DRIVE_CLIENT_SECRET ?? ''
+  const defineDriveId = `process.env.GOOGLE_DRIVE_CLIENT_ID=${JSON.stringify(driveClientId)}`
+  const defineDriveSecret = `process.env.GOOGLE_DRIVE_CLIENT_SECRET=${JSON.stringify(driveClientSecret)}`
+  console.log(
+    `\x1b[36mGoogle Drive credentials embedded:\x1b[0m ${Boolean(
+      driveClientId && driveClientSecret,
+    )}`,
+  )
+
   console.log('\x1b[34mCompiling server with Bun...\x1b[0m')
-  await $`bun build --compile --production --minify --minify-syntax --target bun --bundle ./src/index.ts --outfile ${outfile}`
+  await $`bun build --compile --production --minify --minify-syntax --target bun --bundle --define ${defineDriveId} --define ${defineDriveSecret} ./src/index.ts --outfile ${outfile}`
 
   console.log('\x1b[32mDone! Binary created at:\x1b[0m', outfile)
 }


### PR DESCRIPTION
# fix(backup): embed Google Drive OAuth credentials in the FINAL sidecar

### 1. Summary
Hotfix for **v0.1.81**, where the Google Drive backup feature shipped disabled — connecting showed "functionality not available." The credentials were being embedded in the wrong place in the release pipeline and were overwritten before the app was bundled. This moves the embedding into `compile.ts` (the script that produces the actually-shipped sidecar) and passes the secrets to the Tauri build step.

### 2. Why (root cause)
The v0.1.81 release embedded `GOOGLE_DRIVE_CLIENT_ID/SECRET` via `bun build --define` in the CI **"Compile server sidecar"** step. But the sidecar is compiled **twice** in the build:

1. The manual "Compile server sidecar" step → produced a binary *with* the credentials.
2. The **"Build Tauri app"** step runs `beforeBuildCommand` = `build:apps` → `apps/server` `compile.ts`, which **recompiles the sidecar to the same path** (`app/tauri/bin/church-hub-sidecar-<target>`) **without** the credentials — overwriting the binary from step 1.

Evidence from the v0.1.81 Windows build log:
```
06:36:39  church-hub-sidecar-...msvc.exe   # step 1 (with creds), "verified successfully"
06:37:02  server compile: ... Done!         # compile.ts recompiles same path (no creds)
```
So the shipped binary's `process.env.GOOGLE_DRIVE_CLIENT_ID/SECRET` resolved to `''` → `getDriveOAuthConfig().configured === false` → the feature reports itself unavailable.

The GitHub secrets themselves were correct (present as Actions repo secrets, created before the build); only the embedding location was wrong.

### 3. What changed
- **`app/apps/server/scripts/compile.ts`** — bakes the credentials into the final binary via `bun build --define process.env.GOOGLE_DRIVE_CLIENT_ID=<json> --define process.env.GOOGLE_DRIVE_CLIENT_SECRET=<json>`, read from `process.env` (CI secrets, or the local `.env` in dev). Logs `Google Drive credentials embedded: true/false` for diagnosability. Unset → embeds `""` and the feature disables gracefully.
- **`.github/workflows/build-release.yml`** — passes `GOOGLE_DRIVE_CLIENT_ID/SECRET` from secrets on the **"Build Tauri app"** step (which runs `compile.ts`). Reverts the now-dead `--define`/env on the earlier "Compile server sidecar" step and the temporary cache-key bump, since that step's output is always overwritten.

### 4. Technical details
`compile.ts` uses Bun Shell (`$`); the define args are built with `JSON.stringify(value)` so the value is a valid JS string literal and Bun Shell passes each `process.env.X="..."` as a single argument. `--define` runs before `--minify`, so the string literals survive minification.

### 5. API changes
None.

### 6. Database changes
None.

### 7. Permissions / Authorization
None. (Google "Desktop app" OAuth client — its secret is non-confidential by design; loopback + PKCE protect the flow. Embedding it in the distributed binary is expected.)

### 8. UI / UX changes
None directly. Effect: after this release, Settings → Backup → connect Google Drive works instead of reporting "functionality not available."

### 9. Migration / Backfill strategy
None.

### 10. Commit breakdown
- `c1475929` fix(backup): embed Drive OAuth creds in compile.ts (final sidecar)

### 11. Test plan
- [x] Run the real `compile.ts` with test credentials → both the client id and secret are present in the produced sidecar binary (`grep -a` and `strings`), and `configured: true` from an empty runtime env in a standalone `--define` probe.
- [x] Unset credentials → `compile.ts` embeds `""` (graceful disable).
- [ ] Release build (validated by CI on the tag): after `v0.1.82`, install the Windows `.exe`, open Settings → Backup, connect Google Drive — the OAuth flow proceeds (no "not available").
- [ ] Same check on macOS builds.

### 12. Risks
| Risk | Mitigation |
| --- | --- |
| Secret not passed to the Tauri build step | Both secrets added to that step's `env`; verified locally the define bakes into the binary |
| Local dev prod builds embed a developer's `.env` creds | Expected (their own build); mirrors CI behavior |
| Minify stripping the constants | `--define` applies before minify; verified strings survive |

### 13. Out of scope
- OS code-signing / notarization (builds remain unsigned).
- The redundant double-compile of the sidecar in CI (pre-existing; left as-is — only its credential handling is corrected).
