### PR TITLE
fix(worker): refuse to deploy with missing .prod.vars values

### DIFF
--- a/churchhub-backend/deploy.sh
+++ b/churchhub-backend/deploy.sh
@@ -1,7 +1,33 @@
 #!/usr/bin/env bash
 set -e
 
+if [ ! -f .prod.vars ]; then
+  echo "ERROR: .prod.vars not found (create it next to deploy.sh)." >&2
+  exit 1
+fi
+
 source .prod.vars
+
+# Every deploy REPLACES the worker's vars wholesale — a missing value here
+# would silently wipe it in production (this exact failure once emptied
+# ALLOWED_ORIGINS and broke all OAuth). Refuse to deploy incomplete.
+REQUIRED_VARS=(
+  YOUTUBE_CLIENT_ID
+  YOUTUBE_CLIENT_SECRET
+  YOUTUBE_REDIRECT_URI
+  COOKIE_ENCRYPTION_KEY
+  ALLOWED_ORIGINS
+  GITHUB_TOKEN
+)
+MISSING=()
+for v in "${REQUIRED_VARS[@]}"; do
+  [ -n "${!v:-}" ] || MISSING+=("$v")
+done
+if [ ${#MISSING[@]} -gt 0 ]; then
+  echo "ERROR: missing in .prod.vars: ${MISSING[*]}" >&2
+  echo "Note: ALLOWED_ORIGINS must include http://localhost:3000 (the desktop app's origin)." >&2
+  exit 1
+fi
 
 wrangler deploy \
   --var "YOUTUBE_CLIENT_ID:$YOUTUBE_CLIENT_ID" \


### PR DESCRIPTION
### Summary
`deploy.sh` passes every worker var via `wrangler deploy --var`, which **replaces** the deployment's vars wholesale. Sourcing an empty/incomplete `.prod.vars` therefore silently wipes them in production — this exact failure just deployed with ALL vars empty (including `ALLOWED_ORIGINS` and the Google client credentials), breaking both the YouTube and the Drive OAuth flows (every request 403'd with 'Invalid or missing origin').

### What changed
`deploy.sh` now aborts before deploying when `.prod.vars` is missing or any required var (`YOUTUBE_CLIENT_ID`, `YOUTUBE_CLIENT_SECRET`, `YOUTUBE_REDIRECT_URI`, `COOKIE_ENCRYPTION_KEY`, `ALLOWED_ORIGINS`, `GITHUB_TOKEN`) is empty, printing the missing names. Verified: guard trips correctly on the empty file; `bash -n` clean.

### Test plan
- [x] `bash deploy.sh` with empty .prod.vars → aborts listing all 6 vars
- [ ] With a filled .prod.vars → deploys as before