### PR TITLE
Fix/Bible verse scroll warp

### DIFF
--- a/app/apps/client/e2e/bible.spec.ts
+++ b/app/apps/client/e2e/bible.spec.ts
@@ -458,6 +458,76 @@ test.describe('Bible Feature', () => {
     expect(texts.some((t) => t.includes('3'))).toBe(true)
   })
 
+  test('scrolling after selecting a verse does not warp back to it', async ({
+    page,
+  }) => {
+    // Bug: selecting a verse armed a ~3s window that re-centered the verse
+    // every ~150ms, and the window restarted on every re-render (the chapters
+    // array from useQueries is a new reference each time). Scrolling — which
+    // itself triggers a re-render — got yanked back to the selected verse.
+    // Uses Geneza 1 deliberately: it is the first chapter of the Bible, so
+    // canLoadPrevious is false and no chapter can be prepended. That rules out
+    // the legitimate scroll-preservation adjustment as a cause of movement,
+    // leaving the auto-scroll as the only thing that could move us.
+    await page.goto('/bible')
+    await page.waitForLoadState('networkidle')
+
+    const geneza = page.getByRole('button', { name: /geneza/i }).first()
+    await expect(geneza).toBeVisible({ timeout: 10000 })
+    await geneza.click()
+
+    const chapter1 = page.getByRole('button', { name: /^1$/ }).first()
+    await expect(chapter1).toBeVisible({ timeout: 5000 })
+    await chapter1.click()
+
+    const verseButtons = page.locator('.space-y-1 button.w-full.text-left')
+    await expect(verseButtons.first()).toBeVisible({ timeout: 15000 })
+
+    // Present the FIRST verse: its centered resting position is the very top
+    // of the list, so a warp-back is unmistakable (scrollTop collapses to ~0)
+    // rather than landing coincidentally near where we scrolled to.
+    await verseButtons.first().click()
+    await expect(page.locator('button.ring-green-500')).toBeVisible({
+      timeout: 5000,
+    })
+
+    // Resolve the verses scroller from a verse button. `.text-left` is load
+    // bearing: it is what distinguishes a verse button from the nav sidebar's
+    // buttons, whose own scroll container would otherwise be measured instead.
+    const readScrollTop = () =>
+      page.evaluate(() => {
+        const verse = document.querySelector('.space-y-1 button.w-full.text-left')
+        const scroller = verse?.closest('.overflow-y-auto') as HTMLElement | null
+        return scroller?.scrollTop ?? -1
+      })
+
+    // Park the cursor over a verse so the wheel targets the verses scroller.
+    const verseBox = await verseButtons.nth(3).boundingBox()
+    expect(verseBox).toBeTruthy()
+    await page.mouse.move(
+      verseBox!.x + verseBox!.width / 2,
+      verseBox!.y + verseBox!.height / 2,
+    )
+
+    // Scroll fast, well inside the re-centering window that selection armed.
+    for (let i = 0; i < 8; i++) {
+      await page.mouse.wheel(0, 400)
+      await page.waitForTimeout(60)
+    }
+
+    await expect.poll(readScrollTop, { timeout: 5000 }).toBeGreaterThan(1000)
+    const afterScroll = await readScrollTop()
+
+    // Let the full ~3s re-centering budget elapse. Previously every remaining
+    // attempt in that window would drag us back toward the presented verse.
+    await page.waitForTimeout(3500)
+    const afterSettle = await readScrollTop()
+
+    // We must still be roughly where the user left off, not warped to the top.
+    expect(afterSettle).toBeGreaterThan(1000)
+    expect(Math.abs(afterSettle - afterScroll)).toBeLessThan(150)
+  })
+
   test('arrow key navigation backwards across chapter boundary', async ({
     page,
   }) => {

--- a/app/apps/client/src/features/bible/components/BibleNavigationPanel.tsx
+++ b/app/apps/client/src/features/bible/components/BibleNavigationPanel.tsx
@@ -662,7 +662,6 @@ export function BibleNavigationPanel({
         ) : (
           <VersesList
             bookId={state.bookId || 0}
-            bookName={state.bookName || ''}
             bookCode={bookCode}
             chapter={state.chapter || 0}
             chapters={infiniteChapters}

--- a/app/apps/client/src/features/bible/components/VersesList.tsx
+++ b/app/apps/client/src/features/bible/components/VersesList.tsx
@@ -17,7 +17,6 @@ import type { BibleTranslation } from '../types'
 
 interface VersesListProps {
   bookId: number
-  bookName: string
   bookCode: string
   chapter: number
   chapters: ChapterData[]
@@ -42,7 +41,6 @@ interface VersesListProps {
 
 export function VersesList({
   bookId,
-  bookName,
   bookCode,
   chapter,
   chapters,

--- a/app/apps/client/src/features/bible/components/VersesList.tsx
+++ b/app/apps/client/src/features/bible/components/VersesList.tsx
@@ -72,6 +72,10 @@ export function VersesList({
   const chapterKeyRef = useRef(`${bookId}-${chapter}`)
   // Track if user has scrolled (to enable infinite scroll)
   const hasUserScrolledRef = useRef(false)
+  // Track whether the user has taken manual control of the scroll position.
+  // While true, the auto-scroll below stands down so it never fights an
+  // in-progress gesture. Picking a new target hands control back to it.
+  const userTookOverScrollRef = useRef(false)
   // Track previous chapters count for scroll position preservation
   const prevChaptersCountRef = useRef(chapters.length)
   const scrollPreservationRef = useRef<{
@@ -158,12 +162,42 @@ export function VersesList({
     return () => container.removeEventListener('scroll', handleScroll)
   }, [])
 
+  // Hand scroll ownership to the user on any genuine input gesture. We listen
+  // for input events rather than 'scroll' because a scroll event is emitted
+  // identically for our own scrollTop writes below, so it cannot tell a user
+  // gesture apart from the auto-scroll's own output. 'touchmove' (not
+  // 'touchstart') and 'pointerdown' keep taps on a verse from counting as
+  // scroll intent while still catching drags of the scrollbar.
+  useEffect(() => {
+    const container = containerRef.current
+    if (!container) return
+
+    const takeOverScroll = () => {
+      userTookOverScrollRef.current = true
+    }
+
+    const gestures = ['wheel', 'touchmove', 'pointerdown', 'keydown'] as const
+    for (const gesture of gestures) {
+      container.addEventListener(gesture, takeOverScroll, { passive: true })
+    }
+    return () => {
+      for (const gesture of gestures) {
+        container.removeEventListener(gesture, takeOverScroll)
+      }
+    }
+  }, [])
+
   // Scroll to highlighted verse or first verse of current chapter. Runs as a
   // layout effect so the scroll happens synchronously before paint, then keeps
   // retrying for ~5s to survive the case where the new chapter's verses arrive
   // after the first attempt (chapter cross can re-mount the highlighted button
   // multiple times as the infinite-scroll window updates).
   useLayoutEffect(() => {
+    // A genuinely new target (verse selected, chapter crossed, verses arrived)
+    // means the auto-scroll owns the scroll position again, even if the user
+    // had scrolled away from the previous target.
+    userTookOverScrollRef.current = false
+
     const rafIds: number[] = []
     let timeoutId: ReturnType<typeof setTimeout> | null = null
     let cancelled = false
@@ -218,11 +252,14 @@ export function VersesList({
     // Scroll on every attempt for the full window. We can't stop early on
     // isInView because subsequent layout shifts (a sibling chapter finishing
     // its query) can push the verse off-screen again after we declared
-    // success. Total budget ~3s, scrolling roughly every 150ms.
+    // success. Total budget ~3s, scrolling roughly every 150ms. The user
+    // taking over is the one condition that ends the window early — otherwise
+    // every remaining attempt yanks the list back mid-gesture.
     const scheduleAttempt = (attemptsLeft: number, delayMs: number) => {
       const raf = requestAnimationFrame(() => {
+        if (cancelled || userTookOverScrollRef.current) return
         scrollToTarget()
-        if (cancelled || attemptsLeft <= 0) return
+        if (attemptsLeft <= 0) return
         timeoutId = setTimeout(
           () => scheduleAttempt(attemptsLeft - 1, delayMs),
           delayMs,
@@ -238,7 +275,14 @@ export function VersesList({
       for (const id of rafIds) cancelAnimationFrame(id)
       if (timeoutId !== null) clearTimeout(timeoutId)
     }
-  }, [scrollTargetIndex, versesKey, currentChapterKey, chapters])
+    // `chapters` is deliberately not a dependency: useQueries hands back a new
+    // array reference on nearly every render (including the re-render the
+    // scroll listener above causes), which restarted this ~3s re-centering
+    // window mid-scroll and warped the list back to the selected verse.
+    // versesKey and currentChapterKey already cover every change to the
+    // current chapter's own verses; a sibling chapter's late layout shift is
+    // handled by the retry window rather than by re-running the effect.
+  }, [scrollTargetIndex, versesKey, currentChapterKey])
 
   // IntersectionObserver for infinite scroll - load previous chapters
   useEffect(() => {


### PR DESCRIPTION
---

https://github.com/user-attachments/assets/092282ae-193b-4f8f-8588-81873df90aa4

  
  # fix(bible): stop auto-scroll from warping the verse list during user scroll

  ### 1. Summary
  When a user selects a verse in the Bible reader and then scrolls the verse list, the list was being yanked back to the selected
  verse. This PR fixes that warping so a user's manual scroll is respected, while keeping the intended auto-scroll behaviour
  (centering a newly-selected verse, or the first verse of a freshly-crossed chapter). It also removes a now-unused `bookName` prop
  from `VersesList`.

  Two themes:
  - **Bug fix** — the auto-scroll re-centering window no longer fights an in-progress user gesture, and no longer restarts on every
  unrelated re-render.
  - **Cleanup** — drop the dead `bookName` prop threaded into `VersesList`.

  ### 2. Why
  **Previous behaviour.** Selecting a verse armed a ~3-second window in `VersesList` that re-centered the selected verse roughly every
  ~150ms (a retry loop that exists so the target survives late layout shifts as infinite-scroll chapters resolve).

  **Why it was wrong.** Two compounding problems:

  1. The re-centering `useLayoutEffect` listed `chapters` in its dependency array. `chapters` comes from `useQueries`, which returns a
  **new array reference on nearly every render**. Any re-render — including the one caused by the scroll listener itself — restarted
  the ~3s window from scratch.
  2. Every remaining attempt inside that window wrote `scrollTop` back toward the selected verse. Because scrolling itself triggers a
  re-render (restarting the window per problem 1), the loop effectively never expired while the user was interacting.

  **Concrete example.** Open Geneza 1, select verse 1 (its centered resting position is the very top of the list), then scroll down.
  The list snaps back to the top mid-gesture — `scrollTop` collapses to ~0 — instead of staying where the user scrolled.

  **Affected user flow.** Anyone reading/browsing the Bible after presenting or selecting a verse: the reader fights their scroll,
  making it feel broken and making it hard to read surrounding context.

  **Impact.** Core navigation of the Bible feature felt broken whenever a verse was active; users could not scroll away from a
  selected verse to read context.

  ### 3. What changed

  **Bug fix — `VersesList.tsx`**
  - **Intent:** let a genuine user gesture take ownership of the scroll position, and stop the re-centering window from restarting on
  unrelated re-renders.
  - **Implementation:**
    - Added a `userTookOverScrollRef` flag. On any genuine input gesture (`wheel`, `touchmove`, `pointerdown`, `keydown`) on the
  scroll container, it flips to `true` and the auto-scroll stands down.
    - Input events are listened to instead of the `scroll` event because a `scroll` event fires identically for the auto-scroll's own
  `scrollTop` writes — it cannot distinguish user intent from the effect's own output. `touchmove`/`pointerdown` (not `touchstart`)
  keep a tap on a verse from being mistaken for scroll intent while still catching scrollbar drags.
    - The re-centering loop now bails early when `userTookOverScrollRef.current` is set — the one condition that ends the window
  before its ~3s budget elapses.
    - Picking a genuinely new target (verse selected, chapter crossed, verses arrived) resets the flag to `false`, handing control
  back to the auto-scroll.
    - **Removed `chapters` from the `useLayoutEffect` dependency array.** `versesKey` and `currentChapterKey` already cover every
  change to the current chapter's own verses; a sibling chapter's late layout shift is handled by the existing retry window rather
  than by re-running the effect.
  - **Backward compatibility:** intended auto-scroll (center selected verse / first verse of a crossed chapter) is preserved; only the
  fighting-the-user behaviour is removed.

  **Cleanup — dead prop removal (`VersesList.tsx`, `BibleNavigationPanel.tsx`)**
  - Removed the unused `bookName` prop from the `VersesListProps` interface, the component signature, and the call site in
  `BibleNavigationPanel`. No behaviour change.

  **Test — `bible.spec.ts`**
  - Added an e2e regression test: after selecting the first verse of Geneza 1, scroll fast within the re-centering window and assert
  the list stays where the user left it (does not warp back to the top).

  Commits:
  - `2d9dc061` fix(bible): stop auto-scroll from warping the verse list during user scroll
  - `2d7f90b1` refactor(bible): remove unused bookName prop from VersesList

  ### 4. Technical details

  | Kind | Name | Purpose |
  | --- | --- | --- |
  | Ref | `userTookOverScrollRef` | Tracks whether the user has taken manual control of the scroll; while `true` the auto-scroll
  stands down |
  | Effect | gesture listener `useEffect` | Attaches `wheel`/`touchmove`/`pointerdown`/`keydown` passive listeners that set the
  takeover flag |
  | Effect | re-centering `useLayoutEffect` | Resets the takeover flag on a new target, then runs the retry loop that bails when the
  user takes over; `chapters` removed from deps |

  Key reasoning:
  - **Input events over `scroll`:** the `scroll` event cannot tell a user gesture apart from the auto-scroll's own `scrollTop` writes,
  so intent is detected from the raw input gestures instead.
  - **`chapters` dependency removal:** `useQueries` returns a new array reference nearly every render, which restarted the ~3s window
  mid-scroll. `versesKey` + `currentChapterKey` cover the current chapter's verse changes without that churn.

  ### 5. API changes
  No API changes.

  ### 6. Database changes
  No database changes.

  ### 7. Permissions / Authorization
  No permission or authorization changes.

  ### 8. UI / UX changes
  - Scrolling the Bible verse list after selecting a verse now stays where the user scrolls, instead of snapping back to the selected
  verse.
  - Intended auto-scroll (centering a newly-selected verse or the first verse of a newly-crossed chapter) is unchanged.
  - No visual/label changes.

  ### 9. Migration / Backfill strategy
  No migration or backfill. Pure client-side behaviour change.

  ### 10. Commit breakdown

  #### Bug fix
  - `2d9dc061` fix(bible): stop auto-scroll from warping the verse list during user scroll

  #### Cleanup
  - `2d7f90b1` refactor(bible): remove unused bookName prop from VersesList

  ### 11. Test plan
  - [ ] Open the Bible reader, select a book/chapter (e.g. Geneza 1).
  - [ ] Select the first verse; confirm it centers (rests at the top for verse 1).
  - [ ] Immediately scroll down with the mouse wheel — the list stays where you scroll and does **not** warp back to the selected
  verse.
  - [ ] Repeat with a mid-chapter verse; scroll both up and down within ~3s of selecting.
  - [ ] Touch device / trackpad: drag-scroll after selecting a verse — no warp.
  - [ ] Tap directly on a verse (not a drag) — selection still works and still centers (tap is not mistaken for scroll intent).
  - [ ] Cross a chapter boundary (scroll to the end/start) — the first verse of the newly-crossed chapter still auto-centers.
  - [ ] Regression: keyboard arrow navigation across chapter boundaries still works.
  - [ ] e2e: `bible.spec.ts` — "scrolling after selecting a verse does not warp back to it" passes.

  ### 12. Risks
  | Risk | Mitigation |
  | --- | --- |
  | A user gesture is missed and the list still warps | Covers the full realistic gesture set (`wheel`, `touchmove`, `pointerdown`,
  `keydown`); passive listeners on the scroll container |
  | A tap on a verse is misread as scroll intent, suppressing the intended center | Listens to `touchmove`/`pointerdown` rather than
  `touchstart`; selecting a new target resets the takeover flag so auto-scroll resumes |
  | Removing `chapters` from deps misses a needed re-center after a sibling chapter's late layout shift |
  `versesKey`/`currentChapterKey` cover the current chapter; the existing ~3s retry window absorbs late sibling shifts |

  ### 13. Out of scope
  - No changes to how verses are fetched, queried, or cached (`useQueries` behaviour is unchanged).
  - No changes to infinite-scroll chapter loading or scroll-position preservation when prepending chapters.
  - No API, database, permission, or i18n changes.
  - No visual redesign of the Bible reader.

  ---
  