### PR TITLE
fix(app-update): make "Check now" actually check, including on a dev instance

### DIFF
--- a/app/apps/client/src/features/app-update/components/UpdateNotification.tsx
+++ b/app/apps/client/src/features/app-update/components/UpdateNotification.tsx
@@ -23,16 +23,17 @@ interface UpdateNotificationProps {
 export function UpdateNotification({ isCollapsed }: UpdateNotificationProps) {
   const { t } = useTranslation('sidebar')
   const navigate = useNavigate()
-  const { updateInfo, isDismissed, isDevInstance, dismissUpdate } =
-    useAppUpdate()
+  const { updateInfo, isDismissed, dismissUpdate } = useAppUpdate()
 
   const { isReady, isDownloading, progress } = useUpdateDownload(
     updateInfo?.downloadUrl ?? null,
     updateInfo?.latestVersion ?? null,
   )
 
-  // Only inside the packaged desktop app — never on a dev instance.
-  if (isDevInstance || !isTauri() || !updateInfo?.hasUpdate) return null
+  // A dev instance never polls, so `hasUpdate` can only be true there after
+  // the operator pressed "Check now" — at which point hiding the badge would
+  // be hiding something they asked for.
+  if (!isTauri() || !updateInfo?.hasUpdate) return null
   // A downloaded-but-uninstalled update outranks dismissal: the operator asked
   // for it, so it stays until it is actually applied.
   if (isDismissed && !isReady) return null

--- a/app/apps/client/src/features/app-update/components/UpdatePanel.tsx
+++ b/app/apps/client/src/features/app-update/components/UpdatePanel.tsx
@@ -236,7 +236,18 @@ export function UpdatePanel() {
             {isReady ? (
               <button
                 type="button"
-                onClick={() => void install()}
+                onClick={() => {
+                  void install().then((result) => {
+                    if (!result.success) {
+                      showToast(
+                        t('sections.updates.available.installFailed', {
+                          reason: result.error ?? '',
+                        }),
+                        'error',
+                      )
+                    }
+                  })
+                }}
                 disabled={isInstalling}
                 data-testid="update-install"
                 className="inline-flex items-center gap-2 rounded-lg bg-green-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-green-700 disabled:opacity-50"

--- a/app/apps/client/src/features/app-update/hooks/useAppUpdate.ts
+++ b/app/apps/client/src/features/app-update/hooks/useAppUpdate.ts
@@ -23,6 +23,10 @@ interface UseAppUpdateResult {
   isDismissed: boolean
   isDownloading: boolean
   isDevInstance: boolean
+  /**
+   * Runs the check. Pressing the button in the UI always reaches GitHub, even
+   * on a dev instance — see `checkNow` for why.
+   */
   checkNow: () => Promise<void>
   dismissUpdate: () => void
   downloadUpdate: () => Promise<void>
@@ -35,26 +39,35 @@ export function useAppUpdate(): UseAppUpdateResult {
   const [isDismissed, setIsDismissed] = useState(false)
   const [isDownloading, setIsDownloading] = useState(false)
 
-  const checkNow = useCallback(async () => {
-    // Dev instances never reach out to GitHub — that just logs noisy
-    // rate-limit errors and there's nothing to upgrade to. Surface the
-    // current version so the UI can still show it (with a dev badge).
-    if (IS_DEV_INSTANCE) {
-      const currentVersion = await getCurrentVersion()
-      setUpdateInfo({
-        currentVersion,
-        latestVersion: currentVersion,
-        hasUpdate: false,
-        releaseUrl: '',
-        releaseNotes: '',
-        downloadUrl: null,
-        publishedAt: '',
-      })
-      setError(null)
-      setIsLoading(false)
-      return
-    }
+  /**
+   * Fills in the current version without contacting GitHub. Used for the
+   * automatic check on a dev instance, where polling would only burn the
+   * unauthenticated rate limit for a build that has nothing to upgrade to.
+   */
+  const showLocalVersionOnly = useCallback(async () => {
+    const currentVersion = await getCurrentVersion()
+    setUpdateInfo({
+      currentVersion,
+      latestVersion: currentVersion,
+      hasUpdate: false,
+      releaseUrl: '',
+      releaseNotes: '',
+      downloadUrl: null,
+      publishedAt: '',
+    })
+    setError(null)
+    setIsLoading(false)
+  }, [])
 
+  /**
+   * Checks GitHub for a newer release.
+   *
+   * This runs on a dev instance too. Automatic polling is still skipped there
+   * — see the effect below — but a button labelled "Check now" that silently
+   * does nothing is worse than a wasted request, and it made the update flow
+   * impossible to try out without cutting a real build first.
+   */
+  const checkNow = useCallback(async () => {
     setIsLoading(true)
     setError(null)
     try {
@@ -94,10 +107,15 @@ export function useAppUpdate(): UseAppUpdateResult {
     }
   }, [updateInfo])
 
-  // Initial check on mount
+  // On mount a dev instance only shows its own version; the operator can still
+  // press "Check now" to reach GitHub deliberately.
   useEffect(() => {
+    if (IS_DEV_INSTANCE) {
+      void showLocalVersionOnly()
+      return
+    }
     void checkNow()
-  }, [checkNow])
+  }, [checkNow, showLocalVersionOnly])
 
   // Periodic check — skipped entirely on dev instances (nothing to poll).
   useEffect(() => {

--- a/app/apps/client/src/features/release-notes/changelog.generated.json
+++ b/app/apps/client/src/features/release-notes/changelog.generated.json
@@ -1,22 +1,5 @@
 [
   {
-    "version": "0.1.88",
-    "date": "2026-08-01T22:22:24+02:00",
-    "features": [
-      {
-        "scope": "app-update",
-        "message": "a real updates page instead of a pop-up and a link to GitHub"
-      }
-    ],
-    "bugFixes": [],
-    "changes": [
-      {
-        "scope": null,
-        "message": "sync version to v0.1.87 [skip ci]"
-      }
-    ]
-  },
-  {
     "version": "0.1.87",
     "date": "2026-08-01T10:15:23+02:00",
     "features": [],

--- a/app/apps/client/src/i18n/locales/en/settings.json
+++ b/app/apps/client/src/i18n/locales/en/settings.json
@@ -1211,6 +1211,7 @@
         "downloading": "Downloading...",
         "readyToInstall": "Ready to install",
         "install": "Install and restart",
+        "installFailed": "The install could not start ({{reason}}). A development instance cannot replace itself — try it from an installed build.",
         "installing": "Installing...",
         "later": "Later",
         "failed": "The download failed. Check the folder and your connection, then try again.",

--- a/app/apps/client/src/i18n/locales/ro/settings.json
+++ b/app/apps/client/src/i18n/locales/ro/settings.json
@@ -1213,6 +1213,7 @@
         "downloading": "Se descarca...",
         "readyToInstall": "Gata de instalare",
         "install": "Instaleaza si reporneste",
+        "installFailed": "Instalarea nu a putut porni ({{reason}}). O instanta de dezvoltare nu se poate inlocui pe sine - incearca dintr-o versiune instalata.",
         "installing": "Se instaleaza...",
         "later": "Mai tarziu",
         "failed": "Descarcarea a esuat. Verifica folderul si conexiunea, apoi incearca din nou.",

--- a/app/tauri/tauri.conf.json
+++ b/app/tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "church-hub",
-  "version": "0.1.88",
+  "version": "0.1.87",
   "identifier": "com.church-hub",
   "build": {
     "devUrl": "http://localhost:3000",


### PR DESCRIPTION
### Summary

`checkNow` short-circuited on any Vite-served build (`vite dev`, `tauri dev`):
it set `hasUpdate: false` and returned without contacting GitHub. Pressing
**Check now** therefore did nothing — no request, no result, no error — and the
whole update flow was untestable without cutting a real release first.

### Why it was wrong

Skipping the **automatic hourly poll** on a dev instance is correct: it would
burn the unauthenticated GitHub rate limit (60/hr/IP) for a build that has
nothing to upgrade to. Skipping an **explicit button press** is not — a control
labelled "Check now" that silently no-ops is worse than a wasted request.

### What changed

- `checkNow` always reaches GitHub. The dev-only "just show my version" path
  moved into `showLocalVersionOnly`, used by the mount effect.
- The hourly poll is still skipped on a dev instance (unchanged).
- `UpdateNotification` drops its `isDevInstance` guard: with polling off,
  `hasUpdate` can only be true there after a deliberate check, so hiding it
  would hide something the operator asked for.
- Install failures surface as a toast. A dev instance gets
  `unsupported_platform` because the sidecar is not inside an installed bundle
  and `resolveInstalledApp` refuses to swap anything — correct behaviour, but
  previously it looked like a dead button.

### Test plan

- [x] 1003 unit tests, 10 `app-update` e2e — green.
- [ ] In `tauri dev` with a version older than the latest release: press
      **Check now** → the new version, its grouped changelog, and a working
      Download with progress.
- [ ] Install from a dev instance → toast explaining it cannot replace itself.
- [ ] In a packaged build, behaviour is unchanged: it polls on its own.

### Risks

| Risk | Mitigation |
|---|---|
| A dev instance can now hit the GitHub rate limit | Only on an explicit press; the hourly poll is still off there |