### PR TITLE
fix(ci): stop sync-version-back from moving main's version backwards

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -488,6 +488,21 @@ jobs:
           VERSION=${GITHUB_REF#refs/tags/v}
           # Match the build job: strip non-numeric pre-release identifiers.
           TAURI_VERSION=$(echo "$VERSION" | sed 's/-[^0-9].*//')
+
+          # Never move main backwards. This job runs at the very end of a build,
+          # so a release cut while an earlier one was still building would
+          # otherwise have the older run overwrite the newer version — which is
+          # exactly what happened when v0.1.88 finished after v0.1.89 was
+          # tagged, leaving main claiming 0.1.88 and the next `release.sh patch`
+          # about to collide with an existing tag.
+          CURRENT=$(grep -m1 '"version"' app/tauri/tauri.conf.json \
+            | sed -E 's/.*: *"([^"]+)".*/\1/')
+          NEWEST=$(printf '%s\n%s\n' "$CURRENT" "$TAURI_VERSION" | sort -V | tail -1)
+          if [ "$CURRENT" != "$TAURI_VERSION" ] && [ "$NEWEST" = "$CURRENT" ]; then
+            echo "main is at $CURRENT, newer than $TAURI_VERSION — refusing to downgrade."
+            exit 0
+          fi
+
           echo "Syncing main to version $TAURI_VERSION"
 
           # tauri.conf.json is the single source of truth for the displayed


### PR DESCRIPTION
### The bug

`sync-version-back` runs at the end of a release build and rewrites
`tauri.conf.json` on `main` to the version it just built — unconditionally.
Because it runs *last*, a release cut while an earlier build is still running
lets the **older** run win.

Observed twice in one afternoon:

| Run | What happened |
|---|---|
| v0.1.86 | Job failed outright — `main` had moved under it, so the push was rejected non-fast-forward |
| v0.1.88 | Job succeeded *after* v0.1.89 was tagged, pushing `chore: sync version to v0.1.88` and leaving `main` claiming **0.1.88** while **v0.1.89** was already released |

The second is the dangerous one: it is silent, and the next `release.sh patch`
would have produced `0.1.89` — colliding with a tag that already exists.

### The fix

Compare before syncing and skip when `main` is already ahead:

```bash
CURRENT=$(grep -m1 '"version"' app/tauri/tauri.conf.json | sed -E 's/.*: *"([^"]+)".*/\1/')
NEWEST=$(printf '%s\n%s\n' "$CURRENT" "$TAURI_VERSION" | sort -V | tail -1)
if [ "$CURRENT" != "$TAURI_VERSION" ] && [ "$NEWEST" = "$CURRENT" ]; then
  echo "main is at $CURRENT, newer than $TAURI_VERSION — refusing to downgrade."
  exit 0
fi
```

`sort -V` rather than a string compare, so `0.1.9` vs `0.1.10` orders correctly.
The commit step already no-ops when there is no diff, so skipping here is enough.

Verified against the four cases:

```
main=0.1.88 tag=0.1.89 -> sync
main=0.1.89 tag=0.1.88 -> SKIP (would downgrade)
main=0.1.89 tag=0.1.89 -> sync
main=0.1.9  tag=0.1.10 -> sync
```

### Test plan

- [x] Guard logic exercised for equal / newer / older / multi-digit versions.
- [ ] Next release: `sync-version-back` still syncs normally when `main` is behind.
- [ ] Overlapping releases: the older build's job logs the refusal and exits 0
      instead of downgrading.

### Out of scope

Serialising release builds (a concurrency group on the workflow) would remove
the overlap entirely, but that is a bigger behavioural change — this makes the
existing arrangement safe.