### PR TITLE
feat(backup): restore the database from a local copy, in any folder

### DIFF
--- a/app/apps/client/e2e/backup.spec.ts
+++ b/app/apps/client/e2e/backup.spec.ts
@@ -263,6 +263,122 @@ test.describe('Backup - local', () => {
     expect(missingName.status()).toBe(400)
   })
 
+  /**
+   * A restore swaps the live database out, so these tests restore a backup the
+   * test itself just made — the file is byte-for-byte the database already in
+   * use, which exercises the whole close/copy/reopen path without changing any
+   * data. The assertion that matters is that the server still answers queries
+   * afterwards: that is what proves the connection was reopened in-process
+   * rather than left closed.
+   */
+  test('restores a backup from the configured folder', async ({ request }) => {
+    await request.put('/api/backup/config', {
+      data: { localBackupPath: folder },
+    })
+    expect((await request.post('/api/backup/local/now')).status()).toBe(200)
+
+    const backups = (await (await request.get('/api/backup/local/list')).json())
+      .data.backups
+    expect(backups.length).toBe(1)
+
+    const restored = await request.post('/api/backup/local/restore', {
+      data: { fileName: backups[0].name },
+    })
+    expect(restored.status()).toBe(200)
+    const json = (await restored.json()).data
+    expect(json.success).toBe(true)
+    expect(json.requiresRestart).toBe(false)
+
+    // The database reopened — a real query still works.
+    const alive = await request.get('/api/backup/local/list')
+    expect(alive.status()).toBe(200)
+  })
+
+  test('restores from a folder that is not the configured one', async ({
+    request,
+  }) => {
+    await request.put('/api/backup/config', {
+      data: { localBackupPath: folder },
+    })
+    expect((await request.post('/api/backup/local/now')).status()).toBe(200)
+    const fileName = readdirSync(folder).find((n) => n.endsWith('.db'))
+    expect(fileName).toBeTruthy()
+
+    // Local backups off: the folder is now somewhere the app has never written.
+    await request.put('/api/backup/config', { data: { localBackupPath: null } })
+    expect(
+      (await (await request.get('/api/backup/local/list')).json()).data.backups,
+    ).toEqual([])
+
+    // Browsing it still finds the backup, without reconfiguring anything.
+    const browsed = await request.get(
+      `/api/backup/local/list?dir=${encodeURIComponent(folder)}`,
+    )
+    expect(browsed.status()).toBe(200)
+    expect((await browsed.json()).data.backups.length).toBe(1)
+
+    // Browsing alone did not make it the configured folder.
+    const whileBrowsing = await (
+      await request.get('/api/backup/config')
+    ).json()
+    expect(whileBrowsing.data.localBackupPath).toBeNull()
+
+    const restored = await request.post('/api/backup/local/restore', {
+      data: { path: join(folder, fileName as string) },
+    })
+    expect(restored.status()).toBe(200)
+    expect((await restored.json()).data.success).toBe(true)
+
+    // Settings live in the database, so a restore brings back the ones the
+    // backup was taken with — including the folder that was configured then.
+    // That is the whole point of a restore, not a side effect of browsing.
+    const afterRestore = await (await request.get('/api/backup/config')).json()
+    expect(afterRestore.data.localBackupPath).toBe(folder)
+  })
+
+  test('browsing a relative folder lists nothing', async ({ request }) => {
+    const browsed = await request.get('/api/backup/local/list?dir=relative/dir')
+    expect(browsed.status()).toBe(200)
+    expect((await browsed.json()).data.backups).toEqual([])
+  })
+
+  test('restore refuses sources outside the backup naming convention', async ({
+    request,
+  }) => {
+    await request.put('/api/backup/config', {
+      data: { localBackupPath: folder },
+    })
+
+    const cases: { data: Record<string, string>; error: string }[] = [
+      { data: {}, error: 'no_source' },
+      { data: { fileName: '../../etc/hosts' }, error: 'invalid_file_name' },
+      { data: { fileName: 'notes.txt' }, error: 'invalid_file_name' },
+      {
+        data: { path: 'relative/church-hub-backup-v1-2026-01-01.db' },
+        error: 'path_not_absolute',
+      },
+      { data: { path: '/etc/hosts' }, error: 'invalid_file_name' },
+    ]
+
+    for (const { data, error } of cases) {
+      const response = await request.post('/api/backup/local/restore', { data })
+      expect(response.status()).toBe(400)
+      expect((await response.json()).error).toBe(error)
+    }
+  })
+
+  test('restore by file name needs a configured folder', async ({
+    request,
+  }) => {
+    await request.put('/api/backup/config', { data: { localBackupPath: null } })
+
+    const response = await request.post('/api/backup/local/restore', {
+      data: { fileName: 'church-hub-backup-v1-2026-01-01T00-00-00-000Z.db' },
+    })
+    expect(response.status()).toBe(400)
+    expect((await response.json()).error).toBe('no_local_path')
+  })
+
   test('retention prunes older local backups', async ({ request }) => {
     await request.put('/api/backup/config', {
       data: { localBackupPath: folder, maxBackups: 2 },

--- a/app/apps/client/src/features/backup/components/LocalBackupPanel.tsx
+++ b/app/apps/client/src/features/backup/components/LocalBackupPanel.tsx
@@ -1,9 +1,13 @@
 import {
+  AlertTriangle,
   FolderOpen,
+  FolderSearch,
   HardDriveDownload,
   Loader2,
   RefreshCw,
+  RotateCcw,
   Trash2,
+  X,
 } from 'lucide-react'
 import { useCallback, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -48,8 +52,15 @@ export function LocalBackupPanel({
   const { t } = useTranslation('settings')
   const { showToast } = useToast()
   const hasPath = !!localBackupPath
-  const local = useLocalBackup(hasPath)
+  // A folder the operator is looking inside to restore from. Separate from the
+  // configured path on purpose: restoring last month's copy off a stick should
+  // not redirect where tonight's backup is written.
+  const [browseDir, setBrowseDir] = useState<string | null>(null)
+  const local = useLocalBackup(hasPath, browseDir)
   const [pendingDelete, setPendingDelete] = useState<LocalBackupFile | null>(
+    null,
+  )
+  const [pendingRestore, setPendingRestore] = useState<LocalBackupFile | null>(
     null,
   )
   // Non-Tauri (browser) has no folder picker, so the path is typed there.
@@ -99,6 +110,51 @@ export function LocalBackupPanel({
       showToast(t('sections.backup.local.toast.failed'), 'error')
     }
   }, [local, showToast, t])
+
+  /**
+   * Picks a folder to restore *from*. Unlike `handleChooseFolder` this never
+   * writes the choice to the config — it only points the listing somewhere else.
+   */
+  const handleBrowseFolder = useCallback(async () => {
+    if (!isTauri()) return
+    const { open } = await import('@tauri-apps/plugin-dialog')
+    const selected = await open({
+      directory: true,
+      multiple: false,
+      title: t('sections.backup.local.restoreFrom.choose'),
+      defaultPath: browseDir ?? localBackupPath ?? undefined,
+    })
+    if (typeof selected === 'string' && selected) {
+      setBrowseDir(selected)
+    }
+  }, [browseDir, localBackupPath, t])
+
+  const handleRestoreConfirm = useCallback(async () => {
+    if (!pendingRestore) return
+    // Sends the absolute path when browsing another folder, and the bare file
+    // name when it came from the configured one — the server resolves the latter
+    // inside that folder and refuses anything that tries to leave it.
+    const result = await local.restore(
+      browseDir
+        ? { path: pendingRestore.path }
+        : { fileName: pendingRestore.name },
+    )
+    setPendingRestore(null)
+
+    if (!result.success) {
+      showToast(t('sections.backup.local.toast.restoreFailed'), 'error')
+      return
+    }
+    if (result.requiresRestart) {
+      // The file was swapped but the database could not be reopened in place;
+      // reloading the page would not reconnect it, so say what actually helps.
+      showToast(t('sections.backup.local.toast.restoreNeedsRestart'), 'error')
+      return
+    }
+    showToast(t('sections.backup.local.toast.restoreSuccess'), 'success')
+    // Every cached query now describes the old database — start clean.
+    setTimeout(() => window.location.reload(), 1000)
+  }, [pendingRestore, browseDir, local, showToast, t])
 
   const handleDeleteConfirm = useCallback(async () => {
     if (!pendingDelete) return
@@ -203,15 +259,64 @@ export function LocalBackupPanel({
                 ? t('sections.backup.local.backingUp')
                 : t('sections.backup.local.button')}
             </button>
+            {isTauri() && (
+              <button
+                type="button"
+                onClick={handleBrowseFolder}
+                data-testid="local-backup-browse"
+                className="inline-flex items-center gap-2 rounded-md bg-gray-100 px-3 py-1.5 text-sm text-gray-700 hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600"
+              >
+                <FolderSearch className="h-4 w-4" />
+                {t('sections.backup.local.restoreFrom.button')}
+              </button>
+            )}
             <span className="text-xs text-gray-500 dark:text-gray-400">
               {t('sections.backup.local.lastBackup')}:{' '}
               {formatDate(lastLocalBackupAt ?? 0)}
             </span>
           </div>
 
+          {/* Restore-from folder, typed where there is no native picker */}
+          {!isTauri() && (
+            <div className="mt-3">
+              <span className="block text-xs font-medium text-gray-700 dark:text-gray-300">
+                {t('sections.backup.local.restoreFrom.label')}
+              </span>
+              <input
+                type="text"
+                defaultValue={browseDir ?? ''}
+                onBlur={(e) => setBrowseDir(e.target.value.trim() || null)}
+                placeholder={t('sections.backup.local.pathPlaceholder')}
+                data-testid="local-backup-browse-input"
+                className="mt-1 w-full rounded-md border border-gray-200 bg-white px-3 py-2 text-xs text-gray-900 dark:border-gray-600 dark:bg-gray-900 dark:text-white"
+              />
+            </div>
+          )}
+
           {/* Local backup list */}
-          {hasPath && (
+          {(hasPath || browseDir) && (
             <div className="mt-4">
+              {browseDir && (
+                <div
+                  className="mb-2 flex items-center gap-2 rounded-md bg-amber-50 px-3 py-2 dark:bg-amber-900/20"
+                  data-testid="local-backup-browsing-banner"
+                >
+                  <FolderSearch className="h-4 w-4 shrink-0 text-amber-600 dark:text-amber-400" />
+                  <span className="min-w-0 flex-1 truncate text-[11px] text-amber-800 dark:text-amber-200">
+                    {t('sections.backup.local.restoreFrom.browsing', {
+                      path: browseDir,
+                    })}
+                  </span>
+                  <button
+                    type="button"
+                    onClick={() => setBrowseDir(null)}
+                    title={t('sections.backup.local.restoreFrom.stopBrowsing')}
+                    className="shrink-0 rounded p-1 text-amber-700 hover:bg-amber-100 dark:text-amber-300 dark:hover:bg-amber-900/40"
+                  >
+                    <X className="h-3.5 w-3.5" />
+                  </button>
+                </div>
+              )}
               <div className="mb-2 flex items-center justify-between">
                 <span className="text-xs font-medium text-gray-700 dark:text-gray-300">
                   {t('sections.backup.local.listTitle')}
@@ -253,14 +358,29 @@ export function LocalBackupPanel({
                           {formatBytes(file.sizeBytes)}
                         </p>
                       </div>
-                      <button
-                        type="button"
-                        onClick={() => setPendingDelete(file)}
-                        title={t('sections.backup.list.delete')}
-                        className="shrink-0 rounded-md p-1.5 text-gray-500 hover:bg-red-50 hover:text-red-600 dark:text-gray-400 dark:hover:bg-red-900/20 dark:hover:text-red-400"
-                      >
-                        <Trash2 className="h-4 w-4" />
-                      </button>
+                      <div className="flex shrink-0 items-center gap-1">
+                        <button
+                          type="button"
+                          onClick={() => setPendingRestore(file)}
+                          title={t('sections.backup.local.restoreFrom.restore')}
+                          data-testid="local-backup-restore"
+                          className="rounded-md p-1.5 text-gray-500 hover:bg-emerald-50 hover:text-emerald-600 dark:text-gray-400 dark:hover:bg-emerald-900/20 dark:hover:text-emerald-400"
+                        >
+                          <RotateCcw className="h-4 w-4" />
+                        </button>
+                        {/* Deleting is scoped to the configured folder, so it is
+                            hidden while browsing someone else's. */}
+                        {!browseDir && (
+                          <button
+                            type="button"
+                            onClick={() => setPendingDelete(file)}
+                            title={t('sections.backup.list.delete')}
+                            className="rounded-md p-1.5 text-gray-500 hover:bg-red-50 hover:text-red-600 dark:text-gray-400 dark:hover:bg-red-900/20 dark:hover:text-red-400"
+                          >
+                            <Trash2 className="h-4 w-4" />
+                          </button>
+                        )}
+                      </div>
                     </li>
                   ))}
                 </ul>
@@ -269,6 +389,64 @@ export function LocalBackupPanel({
           )}
         </div>
       </div>
+
+      {/* Restore confirmation — destructive, so it names the file and warns */}
+      {pendingRestore && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center">
+          <div
+            className="absolute inset-0 bg-black/50"
+            onClick={() => !local.isRestoring && setPendingRestore(null)}
+            onKeyDown={(e) => e.key === 'Escape' && setPendingRestore(null)}
+          />
+          <div className="relative mx-4 w-full max-w-md rounded-lg bg-white p-5 shadow-xl dark:bg-gray-800">
+            <div className="flex items-start gap-3">
+              <div className="rounded-full bg-amber-100 p-2 dark:bg-amber-900/30">
+                <AlertTriangle className="h-5 w-5 text-amber-600 dark:text-amber-400" />
+              </div>
+              <div className="min-w-0">
+                <h3 className="text-lg font-semibold text-gray-900 dark:text-white">
+                  {t('sections.backup.local.restoreModal.title')}
+                </h3>
+                <p className="mt-2 text-sm text-gray-600 dark:text-gray-300">
+                  {t('sections.backup.local.restoreModal.message', {
+                    date: formatDate(pendingRestore.createdAtMs),
+                  })}
+                </p>
+                <p className="mt-2 break-all text-xs text-gray-400 dark:text-gray-500">
+                  {pendingRestore.path}
+                </p>
+                <p className="mt-2 text-sm font-medium text-amber-700 dark:text-amber-400">
+                  {t('sections.backup.local.restoreModal.warning')}
+                </p>
+              </div>
+            </div>
+            <div className="mt-5 flex justify-end gap-2">
+              <button
+                type="button"
+                onClick={() => setPendingRestore(null)}
+                disabled={local.isRestoring}
+                className="rounded-md px-3 py-1.5 text-sm text-gray-700 hover:bg-gray-100 disabled:opacity-50 dark:text-gray-300 dark:hover:bg-gray-700"
+              >
+                {t('sections.backup.local.restoreModal.cancel')}
+              </button>
+              <button
+                type="button"
+                onClick={handleRestoreConfirm}
+                disabled={local.isRestoring}
+                data-testid="local-backup-restore-confirm"
+                className="inline-flex items-center gap-2 rounded-md bg-emerald-600 px-3 py-1.5 text-sm text-white hover:bg-emerald-700 disabled:opacity-50"
+              >
+                {local.isRestoring && (
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                )}
+                {local.isRestoring
+                  ? t('sections.backup.local.restoreModal.restoring')
+                  : t('sections.backup.local.restoreModal.confirm')}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
 
       {/* Delete confirmation */}
       {pendingDelete && (

--- a/app/apps/client/src/features/backup/hooks/useLocalBackup.ts
+++ b/app/apps/client/src/features/backup/hooks/useLocalBackup.ts
@@ -6,6 +6,7 @@ import {
   type LocalBackupFile,
   listLocalBackups,
   localBackupNow,
+  restoreLocalBackup,
   updateBackupConfig,
 } from '../service'
 
@@ -18,14 +19,19 @@ const LOCAL_LIST_KEY = ['backup', 'local', 'list']
  * Kept separate from `useBackup` because this half works with no Google account
  * connected — the backups page renders it above the Drive connection card so an
  * operator who never signs in still gets a usable backup story.
+ *
+ * `browseDir` points the listing at another folder — a stick, a share, an old
+ * backup directory — so a copy can be restored from it without that folder
+ * becoming the place future backups are written to. It is part of the query key,
+ * so switching folders swaps the list rather than mixing two folders' files.
  */
-export function useLocalBackup(enabled: boolean) {
+export function useLocalBackup(enabled: boolean, browseDir?: string | null) {
   const queryClient = useQueryClient()
 
   const listQuery = useQuery<LocalBackupFile[]>({
-    queryKey: LOCAL_LIST_KEY,
-    queryFn: listLocalBackups,
-    enabled,
+    queryKey: [...LOCAL_LIST_KEY, browseDir ?? null],
+    queryFn: () => listLocalBackups(browseDir),
+    enabled: enabled || !!browseDir,
     staleTime: 30_000,
   })
 
@@ -50,6 +56,17 @@ export function useLocalBackup(enabled: boolean) {
     onSuccess: invalidate,
   })
 
+  // No invalidation: a successful restore swaps the whole database out from
+  // under every cache in the app, so the component reloads the page instead —
+  // the same thing the Drive restore does.
+  const restoreMutation = useMutation<
+    BackupActionResult,
+    Error,
+    { fileName?: string; path?: string }
+  >({
+    mutationFn: restoreLocalBackup,
+  })
+
   const setPathMutation = useMutation<unknown, Error, string | null>({
     mutationFn: (localBackupPath) => updateBackupConfig({ localBackupPath }),
     onSuccess: invalidate,
@@ -65,6 +82,8 @@ export function useLocalBackup(enabled: boolean) {
     isBackingUp: backupNowMutation.isPending,
     deleteBackup: deleteMutation.mutateAsync,
     isDeleting: deleteMutation.isPending,
+    restore: restoreMutation.mutateAsync,
+    isRestoring: restoreMutation.isPending,
     setPath: setPathMutation.mutateAsync,
     isSettingPath: setPathMutation.isPending,
   }

--- a/app/apps/client/src/features/backup/service/backup.ts
+++ b/app/apps/client/src/features/backup/service/backup.ts
@@ -264,15 +264,53 @@ export async function updateBackupConfig(
 }
 
 /** Lists the backups in the configured local folder, newest first. */
-export async function listLocalBackups(): Promise<LocalBackupFile[]> {
+/**
+ * Backups in the configured folder, or in `dir` when the operator is browsing
+ * somewhere else to restore from — passing a folder here never changes where
+ * future backups are written.
+ */
+export async function listLocalBackups(
+  dir?: string | null,
+): Promise<LocalBackupFile[]> {
+  const query = dir ? `?dir=${encodeURIComponent(dir)}` : ''
   const res = await fetcher<ApiResponse<{ backups: LocalBackupFile[] }>>(
-    '/api/backup/local/list',
+    `/api/backup/local/list${query}`,
     { cache: 'no-store' },
   )
   if (res.error) {
     throw new Error(res.error)
   }
   return res.data?.backups ?? []
+}
+
+/**
+ * Replaces the database with a local backup — either one in the configured
+ * folder (`fileName`) or one anywhere on disk (`path`).
+ *
+ * Given the same ten-minute budget as the Drive restore: the work is a
+ * checkpoint plus a file copy, which on a large library outlasts the default
+ * request timeout even though nothing is downloaded.
+ */
+export async function restoreLocalBackup(input: {
+  fileName?: string
+  path?: string
+}): Promise<BackupActionResult> {
+  const res = await fetcher<
+    ApiResponse<{ success: boolean; message: string; requiresRestart: boolean }>
+  >('/api/backup/local/restore', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(input),
+    timeout: LARGE_OP_TIMEOUT_MS,
+  })
+  if (res.error) {
+    return { success: false, error: res.error }
+  }
+  return {
+    success: true,
+    requiresRestart: res.data?.requiresRestart,
+    message: res.data?.message,
+  }
 }
 
 /** Writes a fresh backup into the configured local folder. */

--- a/app/apps/client/src/features/backup/service/index.ts
+++ b/app/apps/client/src/features/backup/service/index.ts
@@ -19,5 +19,6 @@ export {
   listLocalBackups,
   localBackupNow,
   restoreBackup,
+  restoreLocalBackup,
   updateBackupConfig,
 } from './backup'

--- a/app/apps/client/src/i18n/locales/en/settings.json
+++ b/app/apps/client/src/i18n/locales/en/settings.json
@@ -19,7 +19,7 @@
       "sidebar": "Sidebar",
       "developer": "Developer",
       "backup": "Backup",
-    "updates": "Updates",
+      "updates": "Updates",
       "logs": "Logs",
       "shortcuts": "Shortcuts"
     }
@@ -873,29 +873,48 @@
         "warningMessage": "Your Drive has only {{free}} free, but the next backup needs about {{needed}}. Free up space in Google Drive, otherwise backups will fail."
       },
       "local": {
-      "title": "Local backup",
-      "description": "Keep a copy on this computer or an external drive. Works without a Google account, and automatic backups write here first.",
-      "folderLabel": "Backup folder",
-      "noFolder": "No folder chosen",
-      "chooseFolder": "Choose folder",
-      "clearFolder": "Clear",
-      "pathPlaceholder": "Absolute path, e.g. /Users/me/ChurchHubBackups",
-      "folderHint": "Backups are named like the Drive ones and pruned to the same retention setting.",
-      "button": "Back up locally",
-      "backingUp": "Backing up...",
-      "lastBackup": "Last local backup",
-      "listTitle": "Local backups",
-      "empty": "No local backups yet",
-      "pathSaved": "Backup folder saved",
-      "pathCleared": "Local backups turned off",
-      "toast": {
-        "success": "Local backup created",
-        "failed": "Local backup failed",
-        "deleteSuccess": "Local backup deleted",
-        "deleteFailed": "Could not delete the local backup"
-      }
-    },
-    "retention": {
+        "title": "Local backup",
+        "description": "Keep a copy on this computer or an external drive. Works without a Google account, and automatic backups write here first.",
+        "folderLabel": "Backup folder",
+        "noFolder": "No folder chosen",
+        "chooseFolder": "Choose folder",
+        "clearFolder": "Clear",
+        "pathPlaceholder": "Absolute path, e.g. /Users/me/ChurchHubBackups",
+        "folderHint": "Backups are named like the Drive ones and pruned to the same retention setting.",
+        "button": "Back up locally",
+        "backingUp": "Backing up...",
+        "lastBackup": "Last local backup",
+        "listTitle": "Local backups",
+        "empty": "No local backups yet",
+        "pathSaved": "Backup folder saved",
+        "pathCleared": "Local backups turned off",
+        "toast": {
+          "success": "Local backup created",
+          "failed": "Local backup failed",
+          "deleteSuccess": "Local backup deleted",
+          "deleteFailed": "Could not delete the local backup",
+          "restoreSuccess": "Backup restored. Reloading...",
+          "restoreFailed": "Could not restore the backup",
+          "restoreNeedsRestart": "The backup was restored but the database could not be reopened. Please restart the application."
+        },
+        "restoreFrom": {
+          "button": "Restore from a folder",
+          "choose": "Choose the folder holding the backup",
+          "label": "Restore from folder",
+          "browsing": "Showing backups in {{path}}",
+          "stopBrowsing": "Back to the backup folder",
+          "restore": "Restore this backup"
+        },
+        "restoreModal": {
+          "title": "Restore this backup?",
+          "message": "The database will be replaced with the copy made on {{date}}.",
+          "warning": "Everything added since then is lost. A copy of the current database is kept next to it in case the restore fails.",
+          "cancel": "Cancel",
+          "confirm": "Restore",
+          "restoring": "Restoring..."
+        }
+      },
+      "retention": {
         "title": "Backups kept",
         "description": "Keeps the most recent {{total}} backups in Drive; when a new one exceeds that, the oldest is deleted automatically."
       },
@@ -907,8 +926,8 @@
         "songs": "Songs ({{total}})",
         "schedules": "Schedules ({{total}})",
         "scheduleSongs_one": "{{count}} song",
-      "scheduleSongs_other": "{{count}} songs",
-      "playlists": "Playlists ({{total}})",
+        "scheduleSongs_other": "{{count}} songs",
+        "playlists": "Playlists ({{total}})",
         "more": "…and {{total}} more",
         "playlistItems_one": "{{count}} item",
         "playlistItems_other": "{{count}} items",

--- a/app/apps/client/src/i18n/locales/ro/settings.json
+++ b/app/apps/client/src/i18n/locales/ro/settings.json
@@ -19,7 +19,7 @@
       "sidebar": "Bara Laterală",
       "developer": "Dezvoltatori",
       "backup": "Copie de rezervă",
-    "updates": "Actualizari",
+      "updates": "Actualizari",
       "logs": "Jurnale",
       "shortcuts": "Scurtături"
     }
@@ -874,29 +874,48 @@
         "warningMessage": "Drive-ul tău mai are doar {{free}} liber, dar următorul backup are nevoie de aproximativ {{needed}}. Eliberează spațiu în Google Drive, altfel backupurile vor eșua."
       },
       "local": {
-      "title": "Copie locala",
-      "description": "Pastreaza o copie pe acest calculator sau pe un disc extern. Functioneaza fara cont Google, iar copiile automate se scriu mai intai aici.",
-      "folderLabel": "Folderul copiilor",
-      "noFolder": "Niciun folder ales",
-      "chooseFolder": "Alege folder",
-      "clearFolder": "Sterge",
-      "pathPlaceholder": "Cale absoluta, ex. /Users/eu/CopiiChurchHub",
-      "folderHint": "Copiile sunt denumite ca cele din Drive si sunt pastrate dupa aceeasi setare de retentie.",
-      "button": "Fa copie locala",
-      "backingUp": "Se creeaza copia...",
-      "lastBackup": "Ultima copie locala",
-      "listTitle": "Copii locale",
-      "empty": "Nicio copie locala inca",
-      "pathSaved": "Folderul copiilor a fost salvat",
-      "pathCleared": "Copiile locale au fost dezactivate",
-      "toast": {
-        "success": "Copie locala creata",
-        "failed": "Copia locala a esuat",
-        "deleteSuccess": "Copie locala stearsa",
-        "deleteFailed": "Copia locala nu a putut fi stearsa"
-      }
-    },
-    "retention": {
+        "title": "Copie locala",
+        "description": "Pastreaza o copie pe acest calculator sau pe un disc extern. Functioneaza fara cont Google, iar copiile automate se scriu mai intai aici.",
+        "folderLabel": "Folderul copiilor",
+        "noFolder": "Niciun folder ales",
+        "chooseFolder": "Alege folder",
+        "clearFolder": "Sterge",
+        "pathPlaceholder": "Cale absoluta, ex. /Users/eu/CopiiChurchHub",
+        "folderHint": "Copiile sunt denumite ca cele din Drive si sunt pastrate dupa aceeasi setare de retentie.",
+        "button": "Fa copie locala",
+        "backingUp": "Se creeaza copia...",
+        "lastBackup": "Ultima copie locala",
+        "listTitle": "Copii locale",
+        "empty": "Nicio copie locala inca",
+        "pathSaved": "Folderul copiilor a fost salvat",
+        "pathCleared": "Copiile locale au fost dezactivate",
+        "toast": {
+          "success": "Copie locala creata",
+          "failed": "Copia locala a esuat",
+          "deleteSuccess": "Copie locala stearsa",
+          "deleteFailed": "Copia locala nu a putut fi stearsa",
+          "restoreSuccess": "Copia a fost restaurată. Se reîncarcă...",
+          "restoreFailed": "Copia nu a putut fi restaurată",
+          "restoreNeedsRestart": "Copia a fost restaurată, dar baza de date nu a putut fi redeschisă. Te rugăm să repornești aplicația."
+        },
+        "restoreFrom": {
+          "button": "Restaurează dintr-un folder",
+          "choose": "Alege folderul care conține copia",
+          "label": "Restaurează din folderul",
+          "browsing": "Se afișează copiile din {{path}}",
+          "stopBrowsing": "Înapoi la folderul copiilor",
+          "restore": "Restaurează această copie"
+        },
+        "restoreModal": {
+          "title": "Restaurezi această copie?",
+          "message": "Baza de date va fi înlocuită cu copia făcută pe {{date}}.",
+          "warning": "Tot ce a fost adăugat de atunci se pierde. O copie a bazei de date curente este păstrată alături, în caz că restaurarea eșuează.",
+          "cancel": "Anulează",
+          "confirm": "Restaurează",
+          "restoring": "Se restaurează..."
+        }
+      },
+      "retention": {
         "title": "Backupuri păstrate",
         "description": "Păstrează cele mai recente {{total}} backupuri în Drive; când unul nou depășește limita, cel mai vechi este șters automat."
       },
@@ -908,8 +927,8 @@
         "songs": "Cântări ({{total}})",
         "schedules": "Programe ({{total}})",
         "scheduleSongs_one": "{{count}} cantare",
-      "scheduleSongs_other": "{{count}} cantari",
-      "playlists": "Playlisturi ({{total}})",
+        "scheduleSongs_other": "{{count}} cantari",
+        "playlists": "Playlisturi ({{total}})",
         "more": "…și încă {{total}}",
         "playlistItems_one": "{{count}} element",
         "playlistItems_few": "{{count}} elemente",

--- a/app/apps/server/src/index.ts
+++ b/app/apps/server/src/index.ts
@@ -144,7 +144,9 @@ import {
   inspectBackup,
   listBackups,
   listLocalBackups,
+  type RestoreLocalBackupInput,
   restoreBackup,
+  restoreLocalBackup,
   runLocalBackup,
   startBackupScheduler,
   uploadBackup,
@@ -2412,12 +2414,14 @@ async function startRealServer(): Promise<void> {
       // Deliberately independent of Drive: these work with no Google account
       // connected, which is the whole point of an on-disk copy.
 
-      // GET /api/backup/local/list - Backups present in the configured folder
+      // GET /api/backup/local/list - Backups present in the configured folder,
+      // or in `?dir=` when the operator is browsing another one to restore from
       if (req.method === 'GET' && url.pathname === '/api/backup/local/list') {
         const guard = backupLocalhostGuard()
         if (guard) return guard
 
-        const backups = await listLocalBackups()
+        const dir = url.searchParams.get('dir') || undefined
+        const backups = await listLocalBackups(dir)
         return handleCors(
           req,
           new Response(JSON.stringify({ data: { backups } }), {
@@ -2476,6 +2480,41 @@ async function startRealServer(): Promise<void> {
         }
 
         const result = await deleteLocalBackup(fileName)
+        return handleCors(
+          req,
+          new Response(
+            JSON.stringify(
+              result.success ? { data: result } : { error: result.error },
+            ),
+            {
+              status: result.success ? 200 : 400,
+              headers: { 'Content-Type': 'application/json' },
+            },
+          ),
+        )
+      }
+
+      // POST /api/backup/local/restore - Replace the database with a local copy
+      if (
+        req.method === 'POST' &&
+        url.pathname === '/api/backup/local/restore'
+      ) {
+        const guard = backupLocalhostGuard()
+        if (guard) return guard
+
+        let input: RestoreLocalBackupInput = {}
+        try {
+          const body = (await req.json()) as RestoreLocalBackupInput
+          input = {
+            fileName:
+              typeof body.fileName === 'string' ? body.fileName : undefined,
+            path: typeof body.path === 'string' ? body.path : undefined,
+          }
+        } catch {
+          // Falls through to the service's `no_source` error below.
+        }
+
+        const result = await restoreLocalBackup(input)
         return handleCors(
           req,
           new Response(

--- a/app/apps/server/src/openapi/paths/backup.ts
+++ b/app/apps/server/src/openapi/paths/backup.ts
@@ -456,7 +456,17 @@ export const backupPaths: Record<string, Record<string, unknown>> = {
       tags: ['Backup'],
       summary: 'List local backups',
       description:
-        'Lists the backup files present in the configured local folder, newest first. Returns an empty list when local backups are off or the folder is unreachable. Only accessible from localhost.',
+        'Lists the backup files present in the configured local folder, newest first. Returns an empty list when local backups are off or the folder is unreachable. Pass `dir` to look inside another folder instead — used when restoring a copy from somewhere else, and it does not change where future backups are written. Only accessible from localhost.',
+      parameters: [
+        {
+          name: 'dir',
+          in: 'query',
+          required: false,
+          schema: { type: 'string' },
+          description:
+            'Absolute path of a folder to list instead of the configured one. Relative paths yield an empty list.',
+        },
+      ],
       responses: {
         '200': {
           description: 'Local backups',
@@ -484,6 +494,75 @@ export const backupPaths: Record<string, Record<string, unknown>> = {
                     },
                   },
                 },
+              },
+            },
+          },
+        },
+        '403': localhostError,
+      },
+    },
+  },
+  '/api/backup/local/restore': {
+    post: {
+      tags: ['Backup'],
+      summary: 'Restore the database from a local backup',
+      description:
+        'Replaces the live database with a backup file on disk, using the same whole-file swap the Drive restore performs: the current database is checkpointed, copied aside, replaced, and the connection reinitialised in-process, rolling back if that fails. Send `fileName` for a file in the configured folder, or `path` for an absolute path anywhere the operator browsed to. Either way the name must follow the backup naming convention. Works without a Google account. Only accessible from localhost.',
+      requestBody: {
+        required: true,
+        content: {
+          'application/json': {
+            schema: {
+              type: 'object',
+              properties: {
+                fileName: {
+                  type: 'string',
+                  description:
+                    'Backup file inside the configured local folder. Cannot contain a path separator.',
+                },
+                path: {
+                  type: 'string',
+                  description:
+                    'Absolute path to a backup file in any folder. Takes precedence over fileName.',
+                },
+              },
+            },
+          },
+        },
+      },
+      responses: {
+        '200': {
+          description: 'Database restored',
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                properties: {
+                  data: {
+                    type: 'object',
+                    properties: {
+                      success: { type: 'boolean' },
+                      message: { type: 'string' },
+                      requiresRestart: {
+                        type: 'boolean',
+                        description:
+                          'True only when the database was replaced but could not be reopened in-process, so the server has to be restarted.',
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        '400': {
+          description:
+            'Restore refused or failed — `no_source`, `no_local_path`, `path_not_absolute`, `invalid_file_name`, or the import error message.',
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                properties: { error: { type: 'string' } },
               },
             },
           },

--- a/app/apps/server/src/service/backup/index.ts
+++ b/app/apps/server/src/service/backup/index.ts
@@ -44,6 +44,11 @@ export {
 } from './oauth'
 export { type RestoreBackupResult, restoreBackup } from './restoreBackup'
 export {
+  type RestoreLocalBackupInput,
+  type RestoreLocalBackupResult,
+  restoreLocalBackup,
+} from './restoreLocalBackup'
+export {
   runScheduledBackupIfDue,
   startBackupScheduler,
   stopBackupScheduler,

--- a/app/apps/server/src/service/backup/localBackup.ts
+++ b/app/apps/server/src/service/backup/localBackup.ts
@@ -1,8 +1,8 @@
 import { mkdir, readdir, stat, unlink } from 'node:fs/promises'
 import { isAbsolute, join } from 'node:path'
 
-import { buildBackupFileName, isBackupFile } from './constants'
 import { getBackupConfig, upsertBackupConfig } from './backupConfig'
+import { buildBackupFileName, isBackupFile } from './constants'
 import { createLogger } from '../../utils/logger'
 import { checkpointAndExport } from '../database/database'
 
@@ -52,12 +52,22 @@ export async function getLocalBackupDir(): Promise<string | null> {
 }
 
 /**
- * Lists the backups present in the configured folder, newest first. Returns an
- * empty list when local backups are off or the folder is gone (an unplugged
- * external drive is a normal state, not an error).
+ * Lists the backups present in a folder, newest first. Returns an empty list
+ * when local backups are off or the folder is gone (an unplugged external drive
+ * is a normal state, not an error).
+ *
+ * `dirOverride` lets the operator look inside a folder they just picked without
+ * making it the configured backup destination — restoring a copy carried over
+ * on a USB stick should not silently redirect where future backups are written.
  */
-export async function listLocalBackups(): Promise<LocalBackupFile[]> {
-  const dir = await getLocalBackupDir()
+export async function listLocalBackups(
+  dirOverride?: string,
+): Promise<LocalBackupFile[]> {
+  const dir = dirOverride?.trim()
+    ? isAbsolute(dirOverride.trim())
+      ? dirOverride.trim()
+      : null
+    : await getLocalBackupDir()
   if (!dir) return []
 
   let entries: string[]
@@ -157,7 +167,11 @@ export async function deleteLocalBackup(
   if (!dir) {
     return { success: false, error: 'no_local_path' }
   }
-  if (!isBackupFile(fileName) || fileName.includes('/') || fileName.includes('\\')) {
+  if (
+    !isBackupFile(fileName) ||
+    fileName.includes('/') ||
+    fileName.includes('\\')
+  ) {
     return { success: false, error: 'invalid_file_name' }
   }
 

--- a/app/apps/server/src/service/backup/restoreLocalBackup.ts
+++ b/app/apps/server/src/service/backup/restoreLocalBackup.ts
@@ -1,0 +1,104 @@
+import { basename, isAbsolute, join } from 'node:path'
+
+import { isBackupFile } from './constants'
+import { getLocalBackupDir } from './localBackup'
+import { createLogger } from '../../utils/logger'
+import { importDatabase } from '../database'
+
+const logger = createLogger('backup')
+
+export interface RestoreLocalBackupInput {
+  /** A file inside the configured local backup folder. */
+  fileName?: string
+  /** Absolute path to a backup anywhere on disk — a folder the operator picked. */
+  path?: string
+}
+
+export interface RestoreLocalBackupResult {
+  success: boolean
+  message: string
+  requiresRestart: boolean
+  error?: string
+}
+
+/**
+ * Turns a request into the absolute file to restore from, or an error code.
+ *
+ * Two shapes are accepted because they answer different questions. `fileName`
+ * is "restore the copy I made here", resolved inside the configured folder and
+ * never allowed to escape it. `path` is "restore the copy I just found",
+ * pointing anywhere the operator can browse to — a USB stick, a network share,
+ * last month's folder — which is the whole point of choosing a folder at restore
+ * time. Both require the backup naming convention, so neither can be pointed at
+ * an unrelated file by accident.
+ */
+function resolveSourcePath(
+  input: RestoreLocalBackupInput,
+  configuredDir: string | null,
+): { path: string } | { error: string } {
+  const explicit = input.path?.trim()
+  if (explicit) {
+    if (!isAbsolute(explicit)) return { error: 'path_not_absolute' }
+    if (!isBackupFile(basename(explicit))) return { error: 'invalid_file_name' }
+    return { path: explicit }
+  }
+
+  const fileName = input.fileName?.trim()
+  if (!fileName) return { error: 'no_source' }
+  if (
+    !isBackupFile(fileName) ||
+    fileName.includes('/') ||
+    fileName.includes('\\')
+  ) {
+    return { error: 'invalid_file_name' }
+  }
+  if (!configuredDir) return { error: 'no_local_path' }
+  return { path: join(configuredDir, fileName) }
+}
+
+/**
+ * Replaces the live database with a backup sitting on disk.
+ *
+ * Delegates to `importDatabase`, the same whole-file swap the Drive restore
+ * uses: it checkpoints and closes the current database, keeps a `.backup` copy
+ * of it, copies the source over, and reinitialises in-process — rolling back to
+ * that copy if the reinitialisation fails. Nothing is deleted row by row, so a
+ * restore is all-or-nothing and a failed one leaves the operator where they
+ * started.
+ *
+ * No temp file is involved, unlike the Drive path, because the source is already
+ * a local file and copying it twice would only double the I/O on databases that
+ * can run to hundreds of megabytes.
+ */
+export async function restoreLocalBackup(
+  input: RestoreLocalBackupInput,
+): Promise<RestoreLocalBackupResult> {
+  const configuredDir = await getLocalBackupDir()
+  const resolved = resolveSourcePath(input, configuredDir)
+
+  if ('error' in resolved) {
+    logger.warning(`Local restore refused: ${resolved.error}`)
+    return {
+      success: false,
+      message: '',
+      requiresRestart: false,
+      error: resolved.error,
+    }
+  }
+
+  logger.info(`Restoring database from local backup: ${resolved.path}`)
+  const result = await importDatabase(resolved.path)
+
+  if (!result.success) {
+    logger.error(`Local restore failed: ${result.message}`)
+  } else {
+    logger.info('Local restore completed')
+  }
+
+  return {
+    success: result.success,
+    message: result.message,
+    requiresRestart: result.requiresRestart,
+    error: result.success ? undefined : result.message,
+  }
+}


### PR DESCRIPTION
# feat(backup): restore the database from a local copy, in any folder

### 1. Summary

Local backups could be **written, listed and deleted — but never restored**. This PR closes that loop:

1. A **Restore** action on every row of the local backup list, with a confirmation modal that names the file and states what is lost.
2. A **folder picker** so the copy being restored does not have to live in the configured backup folder — a USB stick, a network share, or last year's directory all work.
3. The server primitive behind both: `restoreLocalBackup`, plus a `dir` override on the listing endpoint so another folder can be inspected without becoming the configured one.

### 2. Why

**The backup half of the feature had no matching restore half.** `localBackup.ts` shipped `runLocalBackup`, `listLocalBackups`, `pruneLocalBackups` and `deleteLocalBackup` — everything except the operation the backups exist for.

An operator whose database was damaged had two options, both bad:

| Option | Why it fails |
|---|---|
| Restore from Drive (`POST /api/backup/restore`) | Requires a connected Google account. The entire point of the local backup card is that it works *without* one. |
| Settings → Database → Import (`POST /api/database/import`) | A different page, a different vocabulary ("import a SQLite file"), and no connection to "the copy I made last Sunday". The operator must know where the file is and what it is called. |

**Second problem: the configured folder is not always where the copy is.** The one moment a restore matters most — a new machine, a reinstall, a corrupted database — is precisely when the copy is somewhere the app has never written to. Requiring the operator to first *reconfigure* the backup folder in order to restore from it conflates two unrelated decisions: *where tonight's backup goes* and *which copy I want back right now*.

Concrete flow this unblocks: a machine dies, the operator installs Church Hub on a replacement, plugs in the stick with the backups, and restores — without connecting Google, without configuring anything, and without the new machine's future backups silently being redirected to the stick.

### 3. What changed

#### Backend

- **New service** `restoreLocalBackup.ts` — resolves a request to an absolute file, then delegates to the existing `importDatabase`. Intent: reuse the Drive restore's proven swap rather than write a second one.
- **`listLocalBackups` takes an optional `dirOverride`** — the only change to existing behaviour, and it is additive: calling it with no argument behaves exactly as before, so `pruneLocalBackups` and the existing route are untouched in effect.

#### API

- `POST /api/backup/local/restore` (new).
- `GET /api/backup/local/list?dir=` (new optional parameter; existing callers unaffected).

#### Frontend

- `restoreLocalBackup()` service wrapper and a `restore` mutation on `useLocalBackup`.
- `useLocalBackup(enabled, browseDir)` — `browseDir` joins the query key so switching folders swaps the list rather than mixing two folders' files.
- `LocalBackupPanel` gains: a "Restore from a folder" button (native picker in the desktop app, a text input in the browser), a banner naming the folder being browsed with an X to leave it, a Restore button per row, and a restore-confirmation modal.

#### Backward compatibility

Nothing is removed or renamed. Every existing endpoint, hook signature and component prop keeps working; the one changed function signature gains an optional parameter.

### 4. Technical details

| Kind | Name | Purpose |
|---|---|---|
| Service | `restoreLocalBackup(input)` | Resolve + validate a source file, then swap the database |
| Helper (private) | `resolveSourcePath(input, configuredDir)` | Turns `{fileName}` or `{path}` into an absolute file or an error code |
| Service (changed) | `listLocalBackups(dirOverride?)` | Lists the configured folder, or an explicit one |
| Client service | `restoreLocalBackup({fileName?, path?})` | POSTs the restore, 10-minute timeout |
| Client service (changed) | `listLocalBackups(dir?)` | Adds the `dir` query parameter |
| Hook (changed) | `useLocalBackup(enabled, browseDir?)` | Adds `restore` / `isRestoring`; `browseDir` in the query key |
| Component (changed) | `LocalBackupPanel` | Restore button, folder picker, browsing banner, confirmation modal |

**Why two request shapes.** They answer different questions. `fileName` means *"restore the copy I made here"* — resolved inside the configured folder, rejecting `/` and `\` so it cannot escape. `path` means *"restore the copy I just found"* — absolute, anywhere the operator browsed to. Both require the backup naming convention (`church-hub-backup-*.db`), so neither can be aimed at an unrelated file by accident.

**Why no temp file.** The Drive restore downloads to a temp path first because the source is remote. Here the source is already a local file, and copying it twice would double the I/O on databases that run to hundreds of megabytes.

**Why the restore mutation has no cache invalidation.** A successful restore replaces the whole database, so every cached query describes data that no longer exists. The component reloads the page instead — the same thing `BackupManager` does after a Drive restore.

**Timeout.** `LARGE_OP_TIMEOUT_MS` (10 min), matching the Drive restore. Nothing is downloaded, but a checkpoint plus a file copy on a large library still outlasts the default request timeout.

### 5. API changes

```http
POST /api/backup/local/restore
Content-Type: application/json

{ "fileName": "church-hub-backup-v0.1.89-2026-07-30T18-00-00-000Z.db" }
```
```http
POST /api/backup/local/restore
Content-Type: application/json

{ "path": "/Volumes/Stick/backups/church-hub-backup-v0.1.85-2026-06-01T09-00-00-000Z.db" }
```
```http
200 OK
{ "data": { "success": true, "message": "...", "requiresRestart": false } }

400 Bad Request
{ "error": "no_source" | "no_local_path" | "path_not_absolute" | "invalid_file_name" | "<import error>" }
```

Changed:

```http
GET /api/backup/local/list?dir=/Volumes/Stick/backups
```

`dir` is optional. Omitted → the configured folder, as before. Relative → an empty list, never a CWD-relative read.

**Authorization:** both routes sit behind `backupLocalhostGuard()` (`isStrictLocalhost()`), the same guard every other `/api/backup/*` route uses. Registered in `openapi/paths/backup.ts`, so both appear in Scalar at `/api/docs`.

### 6. Database changes

**No schema changes.** No new tables, columns, indexes or constraints.

What the feature *does* to the database at runtime is replace the file wholesale — see §9.

### 7. Permissions / Authorization

**No new permissions.**

| Guard | Status | Grants |
|---|---|---|
| `isStrictLocalhost()` via `backupLocalhostGuard()` | EXISTING | Both new/changed routes, identical to every other `/api/backup/*` route |

The reasoning for keeping this rather than adding a permission key: a restore is a local-machine operation on the operator's own data, gated the same way taking and deleting backups already is. Introducing a `backup.restore` permission would leave the *destructive* delete route less protected than restore, which would be incoherent.

Path validation is the substantive authorization surface here, and it is covered in §4 and tested in §11.

### 8. UI / UX changes

- **Restore from a folder** button next to "Back up locally" — native directory picker in the desktop app; in the browser (no picker available) a text input, matching how the configured path already degrades.
- **Browsing banner** — amber, names the folder being listed, with an X to return to the configured folder.
- **Restore button** (↺) on every backup row, next to Delete.
- **Delete is hidden while browsing another folder** — deletion is scoped to the configured folder server-side, so offering it there would be a button that cannot work.
- **Restore confirmation modal** — amber warning icon, the backup's date, its full path, and an explicit line that everything added since is lost and that a copy of the current database is kept in case the restore fails. Cancel / Restore, with a spinner on the confirm button.
- **After a restore** — success toast, then a full page reload after 1s. If the database was replaced but could not be reopened, a distinct message asks the operator to restart the application, because reloading the page would not help.

New i18n keys under `sections.backup.local` in **both** `en` and `ro`: `restoreFrom.*` (6 keys), `restoreModal.*` (6 keys), `toast.restoreSuccess` / `restoreFailed` / `restoreNeedsRestart`.

### 9. Migration / Backfill strategy

**No migrations.** Nothing to backfill.

The restore itself is the risky operation, and its safety comes from `importDatabase`, unchanged by this PR:

1. Validate the source exists and carries the `SQLite format 3` header.
2. Checkpoint the source's WAL, then the live database's.
3. Close the live connection.
4. **Copy the live database to `<dbPath>.backup`** — the rollback artefact.
5. Remove stale `-wal` / `-shm` files at the destination.
6. Copy source over destination.
7. Reinitialise in-process; **on failure, copy `<dbPath>.backup` back and reinitialise again.**

Re-running a restore is harmless: it is a file copy, not a mutation, so restoring the same backup twice yields the same database.

### 10. Commit breakdown

#### Restore from a local backup
- `8f07a34d` feat(backup): restore the database from a local copy, in any folder

### 11. Test plan

**Automated (all 22 tests in `backup.spec.ts` pass locally; 272 server unit tests pass):**

- [x] Restores a backup from the configured folder; `requiresRestart` is false and the server still answers queries afterwards — proving the connection reopened in-process rather than being left closed.
- [x] Restores from a folder that is **not** the configured one, via `path`, with local backups switched off entirely.
- [x] `?dir=` lists a folder the app has never written to, and browsing alone does **not** change `localBackupPath`.
- [x] `?dir=relative/dir` lists nothing (no CWD-relative read).
- [x] Restore refuses every bad source: `{}` → `no_source`, `../../etc/hosts` → `invalid_file_name`, `notes.txt` → `invalid_file_name`, a relative `path` → `path_not_absolute`, `/etc/hosts` → `invalid_file_name`.
- [x] Restore by `fileName` with no folder configured → `no_local_path`.
- [x] Existing local backup tests (write/list/delete, retention pruning, relative-path refusal) still pass.

One assertion was **corrected during review rather than the code**: the test initially asserted `localBackupPath` was still null after restoring, and failed. That is correct behaviour — settings live in the database, so a restore brings back the configuration the backup was taken with. The test now asserts and documents this.

**Manual (desktop app — not reproducible in the Playwright/Chromium environment, which is not Tauri):**

- [ ] "Restore from a folder" opens the native directory picker on macOS and on Windows.
- [ ] Picking a folder with backups lists them and shows the amber banner; the X returns to the configured folder.
- [ ] Delete is hidden while browsing, visible in the configured folder.
- [ ] Restoring reloads the app and the restored data is present.
- [ ] Restore from an external drive that is not the configured folder.
- [ ] Cancelling the modal restores nothing.
- [ ] Romanian UI: every new string is translated and fits.

### 12. Risks

| Risk | Mitigation |
|---|---|
| **Data loss** — a restore overwrites the live database | The confirmation modal names the file, its date, and states plainly what is lost. `importDatabase` keeps `<dbPath>.backup` and auto-rolls back if the new file cannot be opened. |
| **Path traversal** — `path` accepts an absolute path anywhere | Both shapes require the `church-hub-backup-*.db` naming convention; `fileName` additionally rejects separators. Routes are localhost-only. This exposes nothing new: `POST /api/database/import` already accepts an arbitrary `sourcePath` under the same guard. |
| **Browsing silently redirecting backups** | `browseDir` is component state, never written to config. Asserted in the e2e suite. |
| **Restoring an older schema** | The reinitialisation runs the same boot migrations as startup, so an older backup is migrated forward exactly as if the app had been launched with that file. |
| **Long restores looking hung** | Confirm button spins and is disabled; the 10-minute timeout matches the Drive restore. |
| **Stale caches after a restore** | Full page reload rather than selective invalidation. |

### 13. Out of scope

- **Inspecting a local backup before restoring.** `inspectBackup` downloads from Drive; `readBackupContents` is already exported and takes an open handle, so a local variant is a small follow-up — but it is a separate feature from restoring.
- **Restoring a single table** (songs only, schedules only). `selectiveImportDatabase` exists and could back this, but the local card's vocabulary is whole copies.
- **Restoring a hand-renamed file.** The naming convention is enforced; anything renamed still goes through Settings → Database → Import.
- **Automatic restore-on-startup** after a detected corruption.
- **Any change to the Drive restore flow.**
- **The repo-wide CRLF/lint drift.** `biome check --write` reformats 1153 files in this working tree because `core.autocrlf=true` checks everything out with CRLF. Unrelated files were deliberately reverted so this diff contains only the 12 files this feature touches.
