### PR TITLE
app-update + song search: release-notes card, honest download errors, one word in every spelling

### DIFF
--- a/app/apps/client/e2e/app-update.spec.ts
+++ b/app/apps/client/e2e/app-update.spec.ts
@@ -115,6 +115,43 @@ test.describe('App update - download state', () => {
     expect((await res.json()).error).toBe('Missing url')
   })
 
+  test('a failed download says why, and cancel clears it', async ({
+    request,
+  }) => {
+    // Nothing listens on this port, so every attempt is refused; the sidecar
+    // retries a network failure before giving up, hence the wait.
+    const deadUrl = 'http://127.0.0.1:9/church-hub-test-v-9.9.9.dmg'
+    const started = await request.post('/api/app-update/download', {
+      data: { url: deadUrl, version: '9.9.9' },
+    })
+    expect(started.status()).toBe(200)
+    expect((await started.json()).data.phase).toBe('downloading')
+
+    await expect
+      .poll(
+        async () => {
+          const res = await request.get('/api/app-update/status')
+          return (await res.json()).data.phase
+        },
+        { timeout: 15000 },
+      )
+      .toBe('error')
+
+    const failed = (await (await request.get('/api/app-update/status')).json())
+      .data
+    expect(failed.errorCode).toBe('network')
+    expect(failed.error).toBeTruthy()
+
+    // Seen once, then gone — it must not greet the next visit as a new failure.
+    const cleared = await request.post('/api/app-update/cancel')
+    expect(cleared.status()).toBe(200)
+    expect((await cleared.json()).data).toMatchObject({
+      phase: 'idle',
+      error: null,
+      errorCode: null,
+    })
+  })
+
   test('install refuses when nothing has been downloaded', async ({
     request,
   }) => {
@@ -144,6 +181,98 @@ test.describe('App update - page', () => {
     // The check runs against GitHub, which may be unreachable from CI; either
     // way the page must stay usable rather than get stuck.
     await expect(check).toBeEnabled({ timeout: 15000 })
+  })
+
+  test('a new version is presented like a release-notes entry, not as markdown', async ({
+    page,
+  }) => {
+    // Stand in for GitHub with a release newer than any build, carrying the
+    // body our changelog generator writes.
+    const body = [
+      '# Church Hub v99.0.0',
+      '',
+      "## What's Changed",
+      '',
+      '### ✨ Features',
+      '',
+      '- **songs**: transpose from the stage view',
+      '- remote control from a phone',
+      '',
+      '### 🐛 Bug Fixes',
+      '',
+      '- **bible**: verse search ignored diacritics',
+      '',
+      '### 🔧 Changes',
+      '',
+      '- faster startup on Windows',
+      '',
+      '## Direct Downloads',
+      '',
+      '| Platform | Download |',
+      '| **macOS** | [Download .dmg](https://example.invalid/x.dmg) |',
+    ].join('\n')
+
+    await page.route('https://api.github.com/**', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify([
+          {
+            tag_name: 'v99.0.0',
+            name: 'v99.0.0',
+            body,
+            html_url:
+              'https://github.com/radio-crestin/church-hub/releases/tag/v99.0.0',
+            published_at: '2026-08-23T10:00:00Z',
+            draft: false,
+            prerelease: false,
+            assets: [],
+          },
+        ]),
+      }),
+    )
+
+    await page.goto('/settings/updates')
+    const panel = page.getByTestId('update-panel')
+    await expect(panel).toBeVisible({ timeout: 10000 })
+
+    await panel.getByTestId('update-check-now').click()
+    await expect(panel.getByTestId('update-new-version')).toHaveText(
+      'v99.0.0',
+      {
+        timeout: 15000,
+      },
+    )
+
+    const card = panel.getByTestId('update-version-notes')
+    await expect(card).toBeVisible()
+    // Version, badge and date in the header — the same header the history
+    // uses. The test database may be in either shipped language.
+    await expect(card).toContainText('v99.0.0')
+    await expect(card).toContainText(/New|Nouă/)
+    await expect(card).toContainText('2026')
+    // Grouped, with scopes pulled out of the bold prefix.
+    await expect(card).toContainText(/(Features|Funcționalități) \(2\)/)
+    await expect(card).toContainText('songs: transpose from the stage view')
+    await expect(card).toContainText(/(Bug Fixes|Corectări de erori) \(1\)/)
+    await expect(card).toContainText('bible: verse search ignored diacritics')
+    await expect(card).toContainText(/(Changes|Modificări) \(1\)/)
+    // No markdown leaks through, and the download table stays out.
+    const text = (await card.textContent()) ?? ''
+    expect(text).not.toContain('##')
+    expect(text).not.toContain('**')
+    expect(text).not.toContain('Direct Downloads')
+
+    // A browser tab has no installer to fetch; it says so and links to GitHub.
+    await expect(card.getByTestId('update-unavailable')).toBeVisible()
+    await expect(card.getByRole('link', { name: /GitHub/ })).toHaveAttribute(
+      'href',
+      /releases\/tag\/v99\.0\.0/,
+    )
+
+    await card.screenshot({
+      path: `${process.env.UPDATE_SHOT_DIR ?? 'test-results'}/update-card.png`,
+    })
   })
 
   test('no update dialog opens over the app', async ({ page }) => {

--- a/app/apps/client/e2e/search-diacritics.spec.ts
+++ b/app/apps/client/e2e/search-diacritics.spec.ts
@@ -22,7 +22,12 @@ async function search(request: APIRequestContext, query: string) {
     `/api/songs/search?q=${encodeURIComponent(query)}`,
   )
   expect(response.status()).toBe(200)
-  return (await response.json()).data as Array<{ id: number; title: string }>
+  return (await response.json()).data as Array<{
+    id: number
+    title: string
+    highlightedTitle: string
+    matchedContent: string
+  }>
 }
 
 test.describe('Song search', () => {
@@ -70,6 +75,71 @@ test.describe('Song search', () => {
     } finally {
       await request.delete(`/api/songs/${lyricsMatch.id}`).catch(() => {})
       await request.delete(`/api/songs/${titleMatch.id}`).catch(() => {})
+    }
+  })
+
+  test('one word, every spelling: hyphen, apostrophe, joined, with î', async ({
+    request,
+  }) => {
+    // "ne-ncetat", "ne'ncetat", "nencetat" and "neîncetat" are the same
+    // word in Romanian songbooks; whichever one the operator types has to
+    // find all of them, title first, and the mark has to cover the sign.
+    // A made-up word with the same shape keeps the real songbook out of it.
+    const uniq = Date.now()
+    const hyphen = await createSong(
+      request,
+      `Doamne ne-ncezat Te lăudăm ${uniq}`,
+      'Doamne, ne-ncezat Te lăudăm',
+    )
+    const apostrophe = await createSong(
+      request,
+      `Mulțimea Te-nconjoară ${uniq}`,
+      "Mulțimea Te-nconjoară, Isuse, ne'ncezat privirea",
+    )
+    const joined = await createSong(
+      request,
+      `Spune-ți nencezat la toți ${uniq}`,
+      'Spune-ți nencezat la toți să știe',
+    )
+    const withI = await createSong(
+      request,
+      `Te lăudăm neîncezat ${uniq}`,
+      'Te lăudăm neîncezat căci meriți',
+    )
+    const all = [hyphen, apostrophe, joined, withI]
+
+    try {
+      for (const query of ['ne-ncezat', "ne'ncezat", 'nencezat', 'neîncezat']) {
+        const results = await search(request, query)
+        const ids = results.map((song) => song.id)
+        for (const song of all) expect(ids, query).toContain(song.id)
+
+        // The three with the word in the title come before the lyrics-only one.
+        const lyricsOnlyIndex = ids.indexOf(apostrophe.id)
+        for (const song of [hyphen, joined, withI]) {
+          expect(ids.indexOf(song.id), query).toBeLessThan(lyricsOnlyIndex)
+        }
+      }
+
+      // The mark covers the whole word, sign included, in title and lyrics.
+      const results = await search(request, 'ne-ncezat')
+      const byId = new Map(results.map((song) => [song.id, song]))
+      expect(byId.get(hyphen.id)?.highlightedTitle).toContain(
+        '<mark>ne-ncezat</mark>',
+      )
+      expect(byId.get(withI.id)?.highlightedTitle).toContain(
+        '<mark>neîncezat</mark>',
+      )
+      expect(byId.get(joined.id)?.highlightedTitle).toContain(
+        '<mark>nencezat</mark>',
+      )
+      expect(byId.get(apostrophe.id)?.matchedContent).toMatch(
+        /<mark>ne(?:'|&#0?39;|’)ncezat<\/mark>/,
+      )
+    } finally {
+      for (const song of all) {
+        await request.delete(`/api/songs/${song.id}`).catch(() => {})
+      }
     }
   })
 })

--- a/app/apps/client/src/features/app-update/components/AboutSection.tsx
+++ b/app/apps/client/src/features/app-update/components/AboutSection.tsx
@@ -1,3 +1,4 @@
+import { Link } from '@tanstack/react-router'
 import { Download, ExternalLink, Info, RefreshCw } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 
@@ -6,14 +7,7 @@ import { useAppUpdate } from '../hooks/useAppUpdate'
 
 export function AboutSection() {
   const { t } = useTranslation('settings')
-  const {
-    updateInfo,
-    isLoading,
-    isDownloading,
-    isDevInstance,
-    checkNow,
-    downloadUpdate,
-  } = useAppUpdate()
+  const { updateInfo, isLoading, isDevInstance, checkNow } = useAppUpdate()
 
   return (
     <div className="flex flex-col gap-6">
@@ -80,16 +74,17 @@ export function AboutSection() {
                     {t('sections.about.updateDescription')}
                   </p>
                 </div>
-                <button
-                  onClick={() => void downloadUpdate()}
-                  disabled={isDownloading}
-                  className="flex items-center gap-2 px-4 py-2 bg-green-600 hover:bg-green-700 text-white rounded-lg font-medium transition-colors disabled:opacity-50 whitespace-nowrap"
+                {/* The whole flow — notes, download, install — lives on the
+                    updates page; sending people to a browser download is how
+                    updates used to go unapplied. */}
+                <Link
+                  to="/settings/updates"
+                  data-testid="about-open-updates"
+                  className="flex items-center gap-2 px-4 py-2 bg-green-600 hover:bg-green-700 text-white rounded-lg font-medium transition-colors whitespace-nowrap"
                 >
                   <Download size={16} />
-                  {isDownloading
-                    ? t('sections.about.downloading')
-                    : t('sections.about.downloadUpdate')}
-                </button>
+                  {t('sections.about.openUpdates')}
+                </Link>
               </div>
             </div>
           ) : (

--- a/app/apps/client/src/features/app-update/components/UpdatePanel.tsx
+++ b/app/apps/client/src/features/app-update/components/UpdatePanel.tsx
@@ -1,18 +1,20 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import {
-  Bug,
   CheckCircle2,
   Download,
+  ExternalLink,
   FolderOpen,
   Loader2,
   RefreshCw,
-  Sparkles,
-  Wrench,
 } from 'lucide-react'
-import { useCallback, useMemo } from 'react'
+import { useCallback, useEffect, useMemo, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 
-import { ChangeCategoryList, useReleaseNotes } from '~/features/release-notes'
+import {
+  parseReleaseBody,
+  useReleaseNotes,
+  VersionNotesCard,
+} from '~/features/release-notes'
 import { useToast } from '~/ui/toast'
 import { isTauri } from '~/utils/isTauri'
 import { useAppUpdate } from '../hooks/useAppUpdate'
@@ -54,18 +56,40 @@ export function UpdatePanel() {
     isReady,
     isInstalling,
     error,
+    errorCode,
     startDownload,
     isStarting,
+    dismissError,
     install,
   } = useUpdateDownload(updateInfo?.downloadUrl ?? null, version)
 
-  // The same structured notes the release-notes history renders, so a new
-  // version reads exactly like every past one instead of raw markdown.
-  const { data: notes } = useReleaseNotes()
-  const versionNotes = useMemo(
-    () => notes?.find((entry) => entry.version === version) ?? null,
-    [notes, version],
+  // A failure stays on screen while the operator is here, and is cleared once
+  // they leave — so it is seen once, not again on every later visit.
+  const hasErrorRef = useRef(false)
+  hasErrorRef.current = !!error
+  useEffect(
+    () => () => {
+      if (hasErrorRef.current) void dismissError()
+    },
+    [dismissError],
   )
+
+  // The same structured notes the release-notes history renders, so a new
+  // version reads exactly like every past one instead of raw markdown. The
+  // history comes from its own request to GitHub; when that one has not landed
+  // (or was rate-limited) the release body the update check already fetched is
+  // parsed the same way, so the notes never fall back to "nothing here".
+  const { data: notes } = useReleaseNotes()
+  const versionNotes = useMemo(() => {
+    if (!version || !updateInfo) return null
+    const listed = notes?.find((entry) => entry.version === version)
+    if (listed) return listed
+    return parseReleaseBody(
+      version,
+      updateInfo.publishedAt || null,
+      updateInfo.releaseNotes,
+    )
+  }, [notes, version, updateInfo])
 
   const configQuery = useQuery({
     queryKey: CONFIG_KEY,
@@ -97,12 +121,6 @@ export function UpdatePanel() {
   }, [config?.effectiveDownloadDir, setDir, t])
 
   const canDownload = isTauri() && !!updateInfo?.downloadUrl
-  const isEmptyNotes =
-    !!versionNotes &&
-    versionNotes.features.length +
-      versionNotes.bugFixes.length +
-      versionNotes.changes.length ===
-      0
 
   return (
     <div className="space-y-4" data-testid="update-panel">
@@ -157,42 +175,18 @@ export function UpdatePanel() {
         </div>
       </div>
 
-      {/* What's new — same shape as the release-notes history */}
-      {hasUpdate && (
-        <div className="rounded-lg border border-green-200 bg-green-50/40 p-4 dark:border-green-800 dark:bg-green-900/10">
-          <h4 className="mb-3 text-sm font-semibold text-gray-900 dark:text-white">
+      {/* What's new — the same card the release-notes history uses */}
+      {hasUpdate && versionNotes && (
+        <div data-testid="update-available">
+          <h4 className="mb-2 text-sm font-semibold text-gray-900 dark:text-white">
             {t('sections.updates.whatsNew', { version })}
           </h4>
 
-          {versionNotes && !isEmptyNotes ? (
-            <div className="space-y-3">
-              <ChangeCategoryList
-                icon={Sparkles}
-                label={tNotes('categories.features')}
-                accentClassName="text-green-600 dark:text-green-400"
-                entries={versionNotes.features}
-              />
-              <ChangeCategoryList
-                icon={Bug}
-                label={tNotes('categories.bugFixes')}
-                accentClassName="text-red-600 dark:text-red-400"
-                entries={versionNotes.bugFixes}
-              />
-              <ChangeCategoryList
-                icon={Wrench}
-                label={tNotes('categories.changes')}
-                accentClassName="text-blue-600 dark:text-blue-400"
-                entries={versionNotes.changes}
-              />
-            </div>
-          ) : (
-            <p className="text-sm italic text-gray-500 dark:text-gray-400">
-              {tNotes('empty')}
-            </p>
-          )}
-
-          {/* Download / progress / install */}
-          <div className="mt-4 border-t border-green-200 pt-4 dark:border-green-800">
+          <VersionNotesCard
+            notes={versionNotes}
+            variant="available"
+            data-testid="update-version-notes"
+          >
             {(isDownloading || isReady || isInstalling) && (
               <div className="mb-3">
                 <div className="mb-1 flex items-center justify-between text-xs text-gray-600 dark:text-gray-400">
@@ -228,70 +222,88 @@ export function UpdatePanel() {
             )}
 
             {error && (
-              <p className="mb-2 text-sm text-red-600 dark:text-red-400">
-                {t('sections.updates.available.failed')}
-              </p>
+              <div
+                role="alert"
+                data-testid="update-error"
+                className="mb-3 rounded-md border border-red-200 bg-red-50 px-3 py-2 dark:border-red-900 dark:bg-red-900/20"
+              >
+                <p className="text-sm font-medium text-red-700 dark:text-red-300">
+                  {t(
+                    `sections.updates.available.errors.${errorCode ?? 'unknown'}`,
+                  )}
+                </p>
+                <p className="mt-0.5 break-all font-mono text-xs text-red-600/80 dark:text-red-400/80">
+                  {error}
+                </p>
+              </div>
             )}
 
-            {isReady ? (
-              <button
-                type="button"
-                onClick={() => {
-                  void install().then((result) => {
-                    if (!result.success) {
-                      showToast(
-                        t('sections.updates.available.installFailed', {
-                          reason: result.error ?? '',
-                        }),
-                        'error',
-                      )
-                    }
-                  })
-                }}
-                disabled={isInstalling}
-                data-testid="update-install"
-                className="inline-flex items-center gap-2 rounded-lg bg-green-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-green-700 disabled:opacity-50"
-              >
-                {isInstalling ? (
-                  <Loader2 size={16} className="animate-spin" />
-                ) : (
-                  <CheckCircle2 size={16} />
-                )}
-                {t('sections.updates.available.install')}
-              </button>
-            ) : !canDownload ? (
-              /* A disabled button with only a tooltip left the operator with
-                 no idea why nothing happened. Say it outright. */
-              <div data-testid="update-unavailable">
-                <p className="text-sm text-amber-700 dark:text-amber-400">
+            <div className="flex flex-wrap items-center gap-3">
+              {isReady ? (
+                <button
+                  type="button"
+                  onClick={() => {
+                    void install().then((result) => {
+                      if (!result.success) {
+                        showToast(
+                          t('sections.updates.available.installFailed', {
+                            reason: result.error ?? '',
+                          }),
+                          'error',
+                        )
+                      }
+                    })
+                  }}
+                  disabled={isInstalling}
+                  data-testid="update-install"
+                  className="inline-flex items-center gap-2 rounded-lg bg-green-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-green-700 disabled:opacity-50"
+                >
+                  {isInstalling ? (
+                    <Loader2 size={16} className="animate-spin" />
+                  ) : (
+                    <CheckCircle2 size={16} />
+                  )}
+                  {t('sections.updates.available.install')}
+                </button>
+              ) : !canDownload ? (
+                /* A disabled button with only a tooltip left the operator with
+                   no idea why nothing happened. Say it outright. */
+                <p
+                  className="text-sm text-amber-700 dark:text-amber-400"
+                  data-testid="update-unavailable"
+                >
                   {t('sections.updates.available.unavailable')}
                 </p>
-                <a
-                  href={updateInfo?.releaseUrl}
-                  target="_blank"
-                  rel="noreferrer"
-                  className="mt-1 inline-block text-xs text-indigo-600 underline dark:text-indigo-400"
+              ) : (
+                <button
+                  type="button"
+                  onClick={() => void startDownload()}
+                  disabled={isDownloading || isStarting}
+                  data-testid="update-download"
+                  className="inline-flex items-center gap-2 rounded-lg bg-green-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-green-700 disabled:opacity-50"
                 >
-                  {t('sections.updates.available.openRelease')}
-                </a>
-              </div>
-            ) : (
-              <button
-                type="button"
-                onClick={() => void startDownload()}
-                disabled={isDownloading || isStarting}
-                data-testid="update-download"
-                className="inline-flex items-center gap-2 rounded-lg bg-green-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-green-700 disabled:opacity-50"
+                  {isDownloading || isStarting ? (
+                    <Loader2 size={16} className="animate-spin" />
+                  ) : (
+                    <Download size={16} />
+                  )}
+                  {error
+                    ? t('sections.updates.available.retry')
+                    : t('sections.updates.available.download')}
+                </button>
+              )}
+
+              <a
+                href={updateInfo?.releaseUrl}
+                target="_blank"
+                rel="noreferrer"
+                className="inline-flex items-center gap-1 text-xs text-indigo-600 hover:underline dark:text-indigo-400"
               >
-                {isDownloading || isStarting ? (
-                  <Loader2 size={16} className="animate-spin" />
-                ) : (
-                  <Download size={16} />
-                )}
-                {t('sections.updates.available.download')}
-              </button>
-            )}
-          </div>
+                <ExternalLink size={12} />
+                {t('sections.updates.available.openRelease')}
+              </a>
+            </div>
+          </VersionNotesCard>
         </div>
       )}
 

--- a/app/apps/client/src/features/app-update/components/__tests__/UpdatePanel.test.tsx
+++ b/app/apps/client/src/features/app-update/components/__tests__/UpdatePanel.test.tsx
@@ -1,0 +1,148 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { render, screen } from '../../../../test/test-utils'
+import { UpdatePanel } from '../UpdatePanel'
+
+const mockUseAppUpdate = vi.fn()
+const mockUseUpdateDownload = vi.fn()
+const mockUseReleaseNotes = vi.fn()
+
+vi.mock('../../hooks/useAppUpdate', () => ({
+  useAppUpdate: () => mockUseAppUpdate(),
+}))
+vi.mock('../../hooks/useUpdateDownload', () => ({
+  useUpdateDownload: () => mockUseUpdateDownload(),
+}))
+vi.mock('../../services/updateDownloadService', () => ({
+  getUpdateConfig: vi.fn().mockResolvedValue(null),
+  setUpdateDownloadDir: vi.fn(),
+}))
+vi.mock('~/utils/isTauri', () => ({ isTauri: () => true }))
+vi.mock('~/ui/toast', () => ({ useToast: () => ({ showToast: vi.fn() }) }))
+vi.mock('~/features/release-notes', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('~/features/release-notes')>()),
+  useReleaseNotes: () => mockUseReleaseNotes(),
+}))
+
+const RELEASE_BODY = [
+  "## What's Changed",
+  '### ✨ Features',
+  '- **songs**: transpose from the stage view',
+  '### 🐛 Bug Fixes',
+  '- **bible**: verse search ignored diacritics',
+].join('\n')
+
+function downloadState(overrides: Record<string, unknown> = {}) {
+  return {
+    state: null,
+    progress: null,
+    isDownloading: false,
+    isReady: false,
+    isInstalling: false,
+    error: null,
+    errorCode: null,
+    startDownload: vi.fn(),
+    isStarting: false,
+    dismissError: vi.fn().mockResolvedValue(undefined),
+    install: vi.fn(),
+    ...overrides,
+  }
+}
+
+function renderPanel() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  return render(
+    <QueryClientProvider client={client}>
+      <UpdatePanel />
+    </QueryClientProvider>,
+  )
+}
+
+beforeEach(() => {
+  mockUseAppUpdate.mockReturnValue({
+    updateInfo: {
+      currentVersion: '0.1.91',
+      latestVersion: '0.1.92',
+      hasUpdate: true,
+      releaseUrl:
+        'https://github.com/radio-crestin/church-hub/releases/tag/v0.1.92',
+      releaseNotes: RELEASE_BODY,
+      downloadUrl:
+        'https://example.invalid/church-hub-macos-arm64-v-0.1.92.dmg',
+      publishedAt: '2026-08-23T10:00:00Z',
+    },
+    isLoading: false,
+    checkNow: vi.fn(),
+  })
+  mockUseReleaseNotes.mockReturnValue({ data: [] })
+  mockUseUpdateDownload.mockReturnValue(downloadState())
+})
+
+describe('UpdatePanel', () => {
+  it('renders the new version from the release body when the history has not caught up', () => {
+    renderPanel()
+
+    const card = screen.getByTestId('update-version-notes')
+    expect(card).toHaveTextContent('v0.1.92')
+    expect(card).toHaveTextContent('songs: transpose from the stage view')
+    expect(card).toHaveTextContent('bible: verse search ignored diacritics')
+    expect(card).not.toHaveTextContent('**')
+    expect(card).not.toHaveTextContent('##')
+    expect(screen.getByTestId('update-download')).toBeInTheDocument()
+  })
+
+  it('explains a network failure and offers to try again', () => {
+    mockUseUpdateDownload.mockReturnValue(
+      downloadState({
+        error: 'ConnectionRefused: Unable to connect.',
+        errorCode: 'network',
+      }),
+    )
+    renderPanel()
+
+    const alert = screen.getByTestId('update-error')
+    expect(alert).toHaveTextContent(/GitHub/)
+    expect(alert).toHaveTextContent('ConnectionRefused: Unable to connect.')
+    expect(screen.getByTestId('update-download')).toHaveTextContent(
+      /Try again|Încearcă din nou/,
+    )
+  })
+
+  it('points a filesystem failure at the folder, not the connection', () => {
+    mockUseUpdateDownload.mockReturnValue(
+      downloadState({
+        error: 'EACCES: permission denied',
+        errorCode: 'filesystem',
+      }),
+    )
+    renderPanel()
+
+    const alert = screen.getByTestId('update-error')
+    expect(alert).toHaveTextContent(/folder/)
+    expect(alert).not.toHaveTextContent(/internet|connection|conexiune/i)
+  })
+
+  it('dismisses a failure once the operator leaves the page', () => {
+    const dismissError = vi.fn().mockResolvedValue(undefined)
+    mockUseUpdateDownload.mockReturnValue(
+      downloadState({ error: 'HTTP 503', errorCode: 'http', dismissError }),
+    )
+    const { unmount } = renderPanel()
+    expect(dismissError).not.toHaveBeenCalled()
+
+    unmount()
+    expect(dismissError).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not clear anything when there was no failure to see', () => {
+    const dismissError = vi.fn()
+    mockUseUpdateDownload.mockReturnValue(downloadState({ dismissError }))
+    const { unmount } = renderPanel()
+
+    unmount()
+    expect(dismissError).not.toHaveBeenCalled()
+  })
+})

--- a/app/apps/client/src/features/app-update/hooks/useAppUpdate.ts
+++ b/app/apps/client/src/features/app-update/hooks/useAppUpdate.ts
@@ -1,11 +1,7 @@
 import { useCallback, useEffect, useState } from 'react'
 
 import type { UpdateInfo } from '../services/versionService'
-import {
-  checkForUpdates,
-  getCurrentVersion,
-  openDownloadUrl,
-} from '../services/versionService'
+import { checkForUpdates, getCurrentVersion } from '../services/versionService'
 
 const UPDATE_DISMISSED_KEY = 'update-dismissed-version'
 const CHECK_INTERVAL = 1000 * 60 * 60 // Check every hour
@@ -21,7 +17,6 @@ interface UseAppUpdateResult {
   isLoading: boolean
   error: string | null
   isDismissed: boolean
-  isDownloading: boolean
   isDevInstance: boolean
   /**
    * Runs the check. Pressing the button in the UI always reaches GitHub, even
@@ -29,7 +24,6 @@ interface UseAppUpdateResult {
    */
   checkNow: () => Promise<void>
   dismissUpdate: () => void
-  downloadUpdate: () => Promise<void>
 }
 
 export function useAppUpdate(): UseAppUpdateResult {
@@ -37,7 +31,6 @@ export function useAppUpdate(): UseAppUpdateResult {
   const [isLoading, setIsLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [isDismissed, setIsDismissed] = useState(false)
-  const [isDownloading, setIsDownloading] = useState(false)
 
   /**
    * Fills in the current version without contacting GitHub. Used for the
@@ -93,20 +86,6 @@ export function useAppUpdate(): UseAppUpdateResult {
     }
   }, [updateInfo?.latestVersion])
 
-  const downloadUpdate = useCallback(async () => {
-    if (!updateInfo) return
-
-    setIsDownloading(true)
-    try {
-      const url = updateInfo.downloadUrl || updateInfo.releaseUrl
-      await openDownloadUrl(url)
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to open download')
-    } finally {
-      setIsDownloading(false)
-    }
-  }, [updateInfo])
-
   // On mount a dev instance only shows its own version; the operator can still
   // press "Check now" to reach GitHub deliberately.
   useEffect(() => {
@@ -133,9 +112,7 @@ export function useAppUpdate(): UseAppUpdateResult {
     error,
     isDevInstance: IS_DEV_INSTANCE,
     isDismissed,
-    isDownloading,
     checkNow,
     dismissUpdate,
-    downloadUpdate,
   }
 }

--- a/app/apps/client/src/features/app-update/hooks/useUpdateDownload.ts
+++ b/app/apps/client/src/features/app-update/hooks/useUpdateDownload.ts
@@ -43,6 +43,15 @@ export function useUpdateDownload(
       if (!assetUrl) throw new Error('no_asset')
       return startUpdateDownload(assetUrl, version ?? '')
     },
+    // A status poll already in flight when the button was pressed would land
+    // after the "downloading" answer and overwrite it with the stale idle or
+    // error state it set out to read — which stopped the polling and left a
+    // failure from an earlier attempt on screen while the download ran.
+    onMutate: async () => {
+      await queryClient.cancelQueries({
+        queryKey: [...STATUS_KEY, assetUrl, version],
+      })
+    },
     onSuccess: (next) => {
       queryClient.setQueryData([...STATUS_KEY, assetUrl, version], next)
     },
@@ -87,9 +96,15 @@ export function useUpdateDownload(
     isReady: state?.phase === 'ready',
     isInstalling: state?.phase === 'installing',
     error: state?.phase === 'error' ? state.error : null,
+    errorCode: state?.phase === 'error' ? state.errorCode : null,
     startDownload: download.mutateAsync,
     isStarting: download.isPending,
-    cancelDownload: cancel.mutateAsync,
+    /**
+     * Clears a failure once it has been seen. The sidecar keeps the last
+     * outcome for as long as it runs, so without this a download that failed
+     * hours ago would greet the operator as a fresh error on every visit.
+     */
+    dismissError: cancel.mutateAsync,
     install,
   }
 }

--- a/app/apps/client/src/features/app-update/index.ts
+++ b/app/apps/client/src/features/app-update/index.ts
@@ -7,5 +7,4 @@ export type { GithubRelease, UpdateInfo } from './services/versionService'
 export {
   checkForUpdates,
   getCurrentVersion,
-  openDownloadUrl,
 } from './services/versionService'

--- a/app/apps/client/src/features/app-update/services/updateDownloadService.ts
+++ b/app/apps/client/src/features/app-update/services/updateDownloadService.ts
@@ -12,6 +12,16 @@ export type UpdateDownloadPhase =
   | 'installing'
   | 'error'
 
+/**
+ * Why a download failed — mirrors the sidecar's classification so the panel
+ * can tell "GitHub unreachable" from "the folder cannot be written to".
+ */
+export type UpdateDownloadErrorCode =
+  | 'network'
+  | 'http'
+  | 'filesystem'
+  | 'unknown'
+
 export interface UpdateDownloadState {
   phase: UpdateDownloadPhase
   version: string | null
@@ -20,6 +30,7 @@ export interface UpdateDownloadState {
   receivedBytes: number
   totalBytes: number | null
   error: string | null
+  errorCode: UpdateDownloadErrorCode | null
 }
 
 export interface UpdateDownloadConfig {
@@ -87,6 +98,7 @@ export async function startUpdateDownload(
   return res.data ?? null
 }
 
+/** Aborts a download in flight, or clears a failure that has been seen. */
 export async function cancelUpdateDownload(): Promise<void> {
   await fetcher('/api/app-update/cancel', { method: 'POST' })
 }

--- a/app/apps/client/src/features/app-update/services/versionService.ts
+++ b/app/apps/client/src/features/app-update/services/versionService.ts
@@ -182,15 +182,3 @@ export async function checkForUpdates(): Promise<UpdateInfo> {
     }
   }
 }
-
-/**
- * Opens the download URL or release page
- */
-export async function openDownloadUrl(url: string): Promise<void> {
-  if (isTauri) {
-    const { openUrl } = await import('@tauri-apps/plugin-opener')
-    await openUrl(url)
-  } else {
-    window.open(url, '_blank')
-  }
-}

--- a/app/apps/client/src/features/release-notes/components/ReleaseNotesSection.tsx
+++ b/app/apps/client/src/features/release-notes/components/ReleaseNotesSection.tsx
@@ -46,7 +46,9 @@ export function ReleaseNotesSection({
           <VersionNotesCard
             key={notes.version}
             notes={notes}
-            isCurrent={notes.version === normalizedCurrent}
+            variant={
+              notes.version === normalizedCurrent ? 'current' : 'default'
+            }
           />
         ))}
       </div>

--- a/app/apps/client/src/features/release-notes/components/VersionNotesCard.tsx
+++ b/app/apps/client/src/features/release-notes/components/VersionNotesCard.tsx
@@ -1,12 +1,38 @@
 import { Bug, Sparkles, Wrench } from 'lucide-react'
+import type { ReactNode } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { ChangeCategoryList } from './ChangeCategoryList'
 import type { VersionNotes } from '../types'
 
+/**
+ * How the card is framed: a past version, the one running now, or one that is
+ * waiting to be installed. Same layout in all three so an update reads exactly
+ * like the history below it.
+ */
+export type VersionNotesVariant = 'default' | 'current' | 'available'
+
 interface VersionNotesCardProps {
   notes: VersionNotes
-  isCurrent: boolean
+  variant?: VersionNotesVariant
+  /** Rendered under the notes, separated by a rule — actions, progress, etc. */
+  children?: ReactNode
+  'data-testid'?: string
+}
+
+const FRAME: Record<VersionNotesVariant, string> = {
+  default:
+    'border-gray-200 dark:border-gray-800 bg-gray-50 dark:bg-gray-800/50',
+  current:
+    'border-indigo-300 dark:border-indigo-700 bg-indigo-50/50 dark:bg-indigo-900/10',
+  available:
+    'border-green-300 dark:border-green-700 bg-green-50/50 dark:bg-green-900/10',
+}
+
+const RULE: Record<VersionNotesVariant, string> = {
+  default: 'border-gray-200 dark:border-gray-700',
+  current: 'border-indigo-200 dark:border-indigo-800',
+  available: 'border-green-200 dark:border-green-800',
 }
 
 function formatDate(date: string | null, language: string): string {
@@ -20,7 +46,12 @@ function formatDate(date: string | null, language: string): string {
   })
 }
 
-export function VersionNotesCard({ notes, isCurrent }: VersionNotesCardProps) {
+export function VersionNotesCard({
+  notes,
+  variant = 'default',
+  children,
+  'data-testid': testId,
+}: VersionNotesCardProps) {
   const { t, i18n } = useTranslation('releaseNotes')
 
   const isEmpty =
@@ -29,19 +60,21 @@ export function VersionNotesCard({ notes, isCurrent }: VersionNotesCardProps) {
 
   return (
     <div
-      className={`p-4 rounded-lg border ${
-        isCurrent
-          ? 'border-indigo-300 dark:border-indigo-700 bg-indigo-50/50 dark:bg-indigo-900/10'
-          : 'border-gray-200 dark:border-gray-800 bg-gray-50 dark:bg-gray-800/50'
-      }`}
+      className={`p-4 rounded-lg border ${FRAME[variant]}`}
+      data-testid={testId}
     >
       <div className="flex items-center gap-2 mb-3 flex-wrap">
         <span className="text-base font-bold text-gray-900 dark:text-white">
           v{notes.version}
         </span>
-        {isCurrent && (
+        {variant === 'current' && (
           <span className="px-2 py-0.5 text-xs font-medium rounded-full bg-indigo-600 text-white">
             {t('current')}
+          </span>
+        )}
+        {variant === 'available' && (
+          <span className="px-2 py-0.5 text-xs font-medium rounded-full bg-green-600 text-white">
+            {t('available')}
           </span>
         )}
         {formattedDate && (
@@ -76,6 +109,10 @@ export function VersionNotesCard({ notes, isCurrent }: VersionNotesCardProps) {
             entries={notes.changes}
           />
         </div>
+      )}
+
+      {children && (
+        <div className={`mt-4 border-t pt-4 ${RULE[variant]}`}>{children}</div>
       )}
     </div>
   )

--- a/app/apps/client/src/i18n/locales/en/releaseNotes.json
+++ b/app/apps/client/src/i18n/locales/en/releaseNotes.json
@@ -2,6 +2,7 @@
   "title": "Release Notes",
   "description": "What's new in each version of Church Hub — features, bug fixes, and other changes.",
   "current": "Current",
+  "available": "New",
   "empty": "No notable changes.",
   "showAll": "Show all {{count}} versions",
   "showLess": "Show less",

--- a/app/apps/client/src/i18n/locales/en/settings.json
+++ b/app/apps/client/src/i18n/locales/en/settings.json
@@ -1229,25 +1229,22 @@
         "upToDate": "You are on the latest version (v{{version}})",
         "available": "Version {{version}} is available"
       },
-      "categories": {
-        "features": "New",
-        "bugFixes": "Fixed",
-        "changes": "Changed"
-      },
       "available": {
-        "title": "Version {{version}} is available",
-        "current": "You are running v{{version}}",
-        "noNotes": "No release notes for this version.",
         "download": "Download",
+        "retry": "Try again",
         "downloading": "Downloading...",
         "readyToInstall": "Ready to install",
         "install": "Install and restart",
         "installFailed": "The install could not start ({{reason}}). A development instance cannot replace itself — try it from an installed build.",
         "installing": "Installing...",
-        "later": "Later",
-        "failed": "The download failed. Check the folder and your connection, then try again.",
         "unavailable": "Could not work out which installer fits this machine, so there is nothing to download automatically.",
-        "openRelease": "Open the release on GitHub"
+        "openRelease": "Open the release on GitHub",
+        "errors": {
+          "network": "Could not reach GitHub to fetch the installer. Check that this computer is online (and that no proxy or firewall is in the way), then try again.",
+          "http": "GitHub did not hand over the installer. Wait a moment and try again.",
+          "filesystem": "The installer could not be saved to the download folder. Choose another folder below and try again.",
+          "unknown": "The download failed."
+        }
       }
     },
     "about": {
@@ -1257,8 +1254,7 @@
       "checkForUpdates": "Check for updates",
       "updateAvailable": "Update Available",
       "updateDescription": "A new version is available. Download and install to get the latest features and fixes.",
-      "downloadUpdate": "Download Update",
-      "downloading": "Opening...",
+      "openUpdates": "Open the updates page",
       "upToDate": "You are running the latest version.",
       "viewReleaseNotes": "View release notes on GitHub",
       "devInstance": "Development instance",

--- a/app/apps/client/src/i18n/locales/en/sidebar.json
+++ b/app/apps/client/src/i18n/locales/en/sidebar.json
@@ -22,19 +22,12 @@
     "closeMenu": "Close menu"
   },
   "version": {
-    "current": "Current version",
-    "checkForUpdates": "Check for updates",
     "updateAvailable": "v{{version}} available",
-    "clickToDownload": "Click to download the latest version",
-    "download": "Download Update",
-    "downloading": "Opening...",
     "readyToInstall": "v{{version}} ready to install",
     "clickToOpenUpdates": "Open the updates page",
     "clickToInstall": "Downloaded — install it now",
     "viewUpdate": "See what's new",
     "install": "Install now",
-    "dismiss": "Dismiss",
-    "dev": "Dev",
-    "devInstanceHint": "Running a dev instance — update checks are disabled"
+    "dismiss": "Dismiss"
   }
 }

--- a/app/apps/client/src/i18n/locales/ro/releaseNotes.json
+++ b/app/apps/client/src/i18n/locales/ro/releaseNotes.json
@@ -2,6 +2,7 @@
   "title": "Note de lansare",
   "description": "Ce este nou în fiecare versiune Church Hub — funcționalități, corectări de erori și alte modificări.",
   "current": "Curentă",
+  "available": "Nouă",
   "empty": "Nicio modificare notabilă.",
   "showAll": "Afișează toate cele {{count}} versiuni",
   "showLess": "Afișează mai puțin",

--- a/app/apps/client/src/i18n/locales/ro/settings.json
+++ b/app/apps/client/src/i18n/locales/ro/settings.json
@@ -1212,44 +1212,41 @@
       }
     },
     "updates": {
-      "title": "Actualizari",
-      "description": "Unde se descarca versiunile noi si cum se actualizeaza aplicatia.",
+      "title": "Actualizări",
+      "description": "Unde se descarcă versiunile noi și cum se actualizează aplicația.",
       "folder": {
-        "title": "Folderul descarcarilor",
-        "description": "Versiunile noi se descarca aici. Implicit este folderul Downloads.",
+        "title": "Folderul descărcărilor",
+        "description": "Versiunile noi se descarcă aici. Implicit este folderul Downloads.",
         "choose": "Alege folder",
-        "reset": "Foloseste implicit",
-        "usingDefault": "Se foloseste folderul Downloads al sistemului.",
-        "saved": "Folderul descarcarilor a fost salvat",
-        "failed": "Folderul descarcarilor nu a putut fi salvat"
+        "reset": "Folosește implicit",
+        "usingDefault": "Se folosește folderul Downloads al sistemului.",
+        "saved": "Folderul descărcărilor a fost salvat",
+        "failed": "Folderul descărcărilor nu a putut fi salvat"
       },
-      "whatsNew": "Ce e nou in v{{version}}",
+      "whatsNew": "Ce e nou în v{{version}}",
       "status": {
         "title": "Versiune",
-        "check": "Verifica acum",
-        "checking": "Se verifica...",
+        "check": "Verifică acum",
+        "checking": "Se verifică...",
         "upToDate": "Ai ultima versiune (v{{version}})",
-        "available": "Versiunea {{version}} este disponibila"
-      },
-      "categories": {
-        "features": "Noutati",
-        "bugFixes": "Reparatii",
-        "changes": "Modificari"
+        "available": "Versiunea {{version}} este disponibilă"
       },
       "available": {
-        "title": "Versiunea {{version}} este disponibila",
-        "current": "Rulezi v{{version}}",
-        "noNotes": "Nu exista note de lansare pentru aceasta versiune.",
-        "download": "Descarca",
-        "downloading": "Se descarca...",
+        "download": "Descarcă",
+        "retry": "Încearcă din nou",
+        "downloading": "Se descarcă...",
         "readyToInstall": "Gata de instalare",
-        "install": "Instaleaza si reporneste",
-        "installFailed": "Instalarea nu a putut porni ({{reason}}). O instanta de dezvoltare nu se poate inlocui pe sine - incearca dintr-o versiune instalata.",
-        "installing": "Se instaleaza...",
-        "later": "Mai tarziu",
-        "failed": "Descarcarea a esuat. Verifica folderul si conexiunea, apoi incearca din nou.",
-        "unavailable": "Nu s-a putut determina ce installer se potriveste acestei masini, deci nu exista ce descarca automat.",
-        "openRelease": "Deschide release-ul pe GitHub"
+        "install": "Instalează și repornește",
+        "installFailed": "Instalarea nu a putut porni ({{reason}}). O instanță de dezvoltare nu se poate înlocui pe sine — încearcă dintr-o versiune instalată.",
+        "installing": "Se instalează...",
+        "unavailable": "Nu s-a putut determina ce installer se potrivește acestei mașini, deci nu există ce descărca automat.",
+        "openRelease": "Deschide release-ul pe GitHub",
+        "errors": {
+          "network": "Nu s-a putut ajunge la GitHub pentru a descărca programul de instalare. Verifică dacă acest calculator este conectat la internet (și că niciun proxy sau firewall nu blochează), apoi încearcă din nou.",
+          "http": "GitHub nu a livrat programul de instalare. Așteaptă puțin și încearcă din nou.",
+          "filesystem": "Programul de instalare nu a putut fi salvat în folderul de descărcare. Alege alt folder mai jos și încearcă din nou.",
+          "unknown": "Descărcarea a eșuat."
+        }
       }
     },
     "about": {
@@ -1259,8 +1256,7 @@
       "checkForUpdates": "Verifică actualizări",
       "updateAvailable": "Actualizare Disponibilă",
       "updateDescription": "O nouă versiune este disponibilă. Descarcă și instalează pentru a obține cele mai noi funcționalități și corecții.",
-      "downloadUpdate": "Descarcă Actualizarea",
-      "downloading": "Se deschide...",
+      "openUpdates": "Deschide pagina de actualizări",
       "upToDate": "Rulezi cea mai recentă versiune.",
       "viewReleaseNotes": "Vezi notele versiunii pe GitHub",
       "devInstance": "Instanță de dezvoltare",

--- a/app/apps/client/src/i18n/locales/ro/sidebar.json
+++ b/app/apps/client/src/i18n/locales/ro/sidebar.json
@@ -22,19 +22,12 @@
     "closeMenu": "Închide meniu"
   },
   "version": {
-    "current": "Versiunea curentă",
-    "checkForUpdates": "Verifică actualizări",
     "updateAvailable": "v{{version}} disponibilă",
-    "clickToDownload": "Apasă pentru a descărca ultima versiune",
-    "download": "Descarcă Actualizarea",
-    "downloading": "Se deschide...",
     "readyToInstall": "v{{version}} gata de instalare",
     "clickToOpenUpdates": "Deschide pagina de actualizari",
     "clickToInstall": "Descarcata - instaleaz-o acum",
     "viewUpdate": "Vezi ce e nou",
     "install": "Instaleaza acum",
-    "dismiss": "Închide",
-    "dev": "Dev",
-    "devInstanceHint": "Rulează o instanță de dezvoltare — verificarea actualizărilor este dezactivată"
+    "dismiss": "Închide"
   }
 }

--- a/app/apps/server/src/db/migrations/rebuild-fts-single-char-fix.ts
+++ b/app/apps/server/src/db/migrations/rebuild-fts-single-char-fix.ts
@@ -1,5 +1,4 @@
 import type { Database } from 'bun:sqlite'
-
 import { rebuildSearchIndex } from '../../service/songs/search'
 
 const DEBUG = process.env.DEBUG === 'true'
@@ -10,14 +9,17 @@ function log(level: 'debug' | 'info' | 'warning' | 'error', message: string) {
   console.log(`[migrate-fts-single-char:${level}] ${message}`)
 }
 
-// Bumped from v1 → v2 because the v1 rebuild dropped single-char tokens
-// from the index ("cand isus hristos m a mantuit" → "cand isus hristos
-// mantuit"), which lost linguistic signal for Romanian clitics. The v2
-// rebuild reinstates them — single chars now flow through normalizeForIndex
-// untouched and are filtered defensively only where they cause noise (the
-// broad-OR tier of buildSearchQuery + meaningful-term denominator in the
-// title score). Any dev DB that already ran v1 still needs this re-rebuild.
-const MIGRATION_KEY = 'rebuild_fts_clitic_aware_v2'
+// Bump the key whenever normalizeForIndex changes what it emits — every
+// existing database then re-indexes once on its next boot.
+//
+// v2: the v1 rebuild dropped single-char tokens from the index ("cand isus
+//     hristos m a mantuit" → "cand isus hristos mantuit"), which lost
+//     linguistic signal for Romanian clitics; v2 reinstated them.
+// v3: HTML entities in slide content are decoded (an escaped apostrophe
+//     used to index as a stray "039" that split phrases), and every
+//     hyphen/apostrophe word is also indexed in its joined spellings so
+//     "ne-ncetat", "ne'ncetat", "nencetat" and "neîncetat" find each other.
+const MIGRATION_KEY = 'rebuild_fts_word_spellings_v3'
 
 /**
  * Re-runs rebuildSearchIndex once with the current normalizeForIndex so the

--- a/app/apps/server/src/index.ts
+++ b/app/apps/server/src/index.ts
@@ -2111,7 +2111,7 @@ async function startRealServer(): Promise<void> {
         }
       }
 
-      // POST /api/app-update/cancel - Abort a download in flight
+      // POST /api/app-update/cancel - Abort a download in flight / dismiss a failure
       if (req.method === 'POST' && url.pathname === '/api/app-update/cancel') {
         const guard = updateLocalhostGuard()
         if (guard) return guard

--- a/app/apps/server/src/openapi/paths/app-update.ts
+++ b/app/apps/server/src/openapi/paths/app-update.ts
@@ -19,7 +19,18 @@ const downloadState = {
     fileName: { type: 'string', nullable: true },
     receivedBytes: { type: 'integer' },
     totalBytes: { type: 'integer', nullable: true },
-    error: { type: 'string', nullable: true },
+    error: {
+      type: 'string',
+      nullable: true,
+      description: 'What went wrong, when phase is `error`',
+    },
+    errorCode: {
+      type: 'string',
+      nullable: true,
+      enum: ['network', 'http', 'filesystem', 'unknown', null],
+      description:
+        'Why the download failed: GitHub unreachable (`network`), GitHub answered with an error status (`http`), or the download folder could not be written to (`filesystem`)',
+    },
   },
 }
 
@@ -163,7 +174,9 @@ export const appUpdatePaths: Record<string, Record<string, unknown>> = {
   '/api/app-update/cancel': {
     post: {
       tags: ['App update'],
-      summary: 'Abort a download in flight',
+      summary: 'Abort a download in flight, or dismiss a failure',
+      description:
+        'Aborts the download and removes the partial file. When the last download failed, clears that failure so the next status read is idle again. Transient failures (connection dropped, 5xx from GitHub) are retried up to three times before being reported.',
       responses: {
         '200': {
           description: 'Download state after aborting',

--- a/app/apps/server/src/service/app-update/HttpStatusError.ts
+++ b/app/apps/server/src/service/app-update/HttpStatusError.ts
@@ -1,0 +1,7 @@
+/** GitHub answered, but not with the artifact. */
+export class HttpStatusError extends Error {
+  constructor(readonly status: number) {
+    super(`HTTP ${status}`)
+    this.name = 'HttpStatusError'
+  }
+}

--- a/app/apps/server/src/service/app-update/__tests__/downloadUpdate.test.ts
+++ b/app/apps/server/src/service/app-update/__tests__/downloadUpdate.test.ts
@@ -1,0 +1,161 @@
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterAll, beforeEach, describe, expect, it, mock } from 'bun:test'
+
+// The download folder comes from the settings table; point it at a temp dir
+// instead of opening the database.
+let downloadDir = mkdtempSync(join(tmpdir(), 'church-hub-update-test-'))
+mock.module('../updateConfig', () => ({
+  resolveDownloadDir: () => downloadDir,
+}))
+
+const { cancelDownload, getDownloadState, startDownload } = await import(
+  '../downloadUpdate'
+)
+const { classifyDownloadError } = await import('../classifyDownloadError')
+const { HttpStatusError } = await import('../HttpStatusError')
+
+// A stand-in for GitHub's CDN whose behaviour is scripted per test.
+let responses: Array<() => Response> = []
+let hits = 0
+const server = Bun.serve({
+  port: 0,
+  fetch: () => {
+    const next = responses[Math.min(hits, responses.length - 1)]
+    hits++
+    return next ? next() : new Response('no script', { status: 500 })
+  },
+})
+const assetUrl = `http://127.0.0.1:${server.port}/releases/church-hub-test-v-9.9.9.dmg`
+
+const ok = () => new Response('installer bytes', { status: 200 })
+const status = (code: number) => () => new Response('', { status: code })
+
+async function waitForSettled(timeoutMs = 10_000) {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    const state = getDownloadState()
+    if (state.phase !== 'downloading') return state
+    await Bun.sleep(25)
+  }
+  throw new Error('download did not settle')
+}
+
+beforeEach(() => {
+  cancelDownload()
+  hits = 0
+  rmSync(downloadDir, { recursive: true, force: true })
+  downloadDir = mkdtempSync(join(tmpdir(), 'church-hub-update-test-'))
+})
+
+afterAll(() => {
+  server.stop(true)
+  rmSync(downloadDir, { recursive: true, force: true })
+})
+
+describe('classifyDownloadError', () => {
+  it('treats a 5xx from GitHub as worth retrying, a 404 as not', () => {
+    expect(classifyDownloadError(new HttpStatusError(503))).toMatchObject({
+      code: 'http',
+      retryable: true,
+    })
+    expect(classifyDownloadError(new HttpStatusError(404))).toMatchObject({
+      code: 'http',
+      message: 'HTTP 404',
+      retryable: false,
+    })
+  })
+
+  it('recognises a folder that cannot be written to', () => {
+    const error = Object.assign(new Error('permission denied'), {
+      code: 'EACCES',
+    })
+    expect(classifyDownloadError(error)).toEqual({
+      code: 'filesystem',
+      message: 'EACCES: permission denied',
+      retryable: false,
+    })
+  })
+
+  it('puts everything else down to the network, naming the cause', () => {
+    const error = new Error('fetch() failed', {
+      cause: new Error('getaddrinfo ENOTFOUND github.com'),
+    })
+    expect(classifyDownloadError(error)).toEqual({
+      code: 'network',
+      message: 'fetch() failed (getaddrinfo ENOTFOUND github.com)',
+      retryable: true,
+    })
+  })
+})
+
+describe('startDownload', () => {
+  it('retries through a transient 503 and ends up ready', async () => {
+    responses = [status(503), status(503), ok]
+
+    await startDownload(assetUrl, '9.9.9')
+    const state = await waitForSettled()
+
+    expect(hits).toBe(3)
+    expect(state.phase).toBe('ready')
+    expect(state.filePath).toBe(
+      join(downloadDir, 'church-hub-test-v-9.9.9.dmg'),
+    )
+    expect(await Bun.file(state.filePath!).text()).toBe('installer bytes')
+  })
+
+  it('reports an http failure without retrying a 404', async () => {
+    responses = [status(404)]
+
+    await startDownload(assetUrl, '9.9.9')
+    const state = await waitForSettled()
+
+    expect(hits).toBe(1)
+    expect(state.phase).toBe('error')
+    expect(state.errorCode).toBe('http')
+    expect(state.error).toBe('HTTP 404')
+  })
+
+  it('gives up after three network failures', async () => {
+    // Nothing listens here; every attempt is refused.
+    const closed = Bun.serve({ port: 0, fetch: () => new Response('') })
+    const deadUrl = `http://127.0.0.1:${closed.port}/x.dmg`
+    closed.stop(true)
+
+    await startDownload(deadUrl, '9.9.9')
+    const state = await waitForSettled()
+
+    expect(state.phase).toBe('error')
+    expect(state.errorCode).toBe('network')
+  }, 15_000)
+
+  it('a failure is dismissed by cancel, so the next visit starts idle', async () => {
+    responses = [status(404)]
+    await startDownload(assetUrl, '9.9.9')
+    await waitForSettled()
+    expect(getDownloadState().phase).toBe('error')
+
+    cancelDownload()
+
+    expect(getDownloadState()).toMatchObject({
+      phase: 'idle',
+      error: null,
+      errorCode: null,
+    })
+  })
+
+  it('reports a folder it cannot write to as a filesystem problem', async () => {
+    responses = [ok]
+    // A file where the folder should be: mkdir -p then fails with ENOTDIR/EEXIST.
+    rmSync(downloadDir, { recursive: true, force: true })
+    await Bun.write(downloadDir, 'not a folder')
+
+    await startDownload(assetUrl, '9.9.9')
+    const state = await waitForSettled()
+
+    expect(state.phase).toBe('error')
+    expect(state.errorCode).toBe('filesystem')
+  })
+})

--- a/app/apps/server/src/service/app-update/classifyDownloadError.ts
+++ b/app/apps/server/src/service/app-update/classifyDownloadError.ts
@@ -1,0 +1,81 @@
+import { HttpStatusError } from './HttpStatusError'
+import type { UpdateDownloadErrorCode } from './types'
+
+// Codes Node/Bun put on errors raised by the file-system calls we make
+// (mkdir, write stream, copy). Anything else that goes wrong while streaming
+// is the connection to GitHub.
+const FILESYSTEM_CODES = new Set([
+  'EACCES',
+  'EPERM',
+  'ENOENT',
+  'EEXIST',
+  'ENOSPC',
+  'EDQUOT',
+  'EROFS',
+  'EISDIR',
+  'ENOTDIR',
+  'ENAMETOOLONG',
+  'EMFILE',
+  'EBUSY',
+  'EIO',
+])
+
+/** "ENOSPC: no space left" rather than "ENOSPC: ENOSPC: no space left". */
+function withCode(code: string | undefined, message: string): string {
+  if (!code || message.startsWith(code)) return message
+  return `${code}: ${message}`
+}
+
+export interface ClassifiedDownloadError {
+  code: UpdateDownloadErrorCode
+  message: string
+  /** Worth another attempt without the operator doing anything. */
+  retryable: boolean
+}
+
+/**
+ * Turns whatever a failed download threw into a code the UI can explain and a
+ * verdict on whether retrying on its own makes sense. A flaky connection or a
+ * 5xx from GitHub's CDN is retried; a folder that cannot be written to, or a
+ * 404 because the asset is gone, is reported straight away.
+ */
+export function classifyDownloadError(error: unknown): ClassifiedDownloadError {
+  if (error instanceof HttpStatusError) {
+    const retryable =
+      error.status >= 500 || error.status === 429 || error.status === 408
+    return { code: 'http', message: error.message, retryable }
+  }
+
+  if (!(error instanceof Error)) {
+    return { code: 'unknown', message: String(error), retryable: false }
+  }
+
+  const { code, syscall } = error as Error & {
+    code?: unknown
+    syscall?: unknown
+  }
+  const errorCode = typeof code === 'string' ? code : undefined
+  // File-system errors name the call that failed (mkdir, open, write);
+  // Bun's socket errors carry a code and the URL, never a syscall.
+  if (
+    (errorCode && FILESYSTEM_CODES.has(errorCode)) ||
+    typeof syscall === 'string'
+  ) {
+    return {
+      code: 'filesystem',
+      message: withCode(errorCode, error.message),
+      retryable: false,
+    }
+  }
+
+  // Bun reports socket/DNS/TLS problems with its own codes (ConnectionRefused,
+  // FailedToOpenSocket, ...) or as a bare "fetch() failed" — all of them are
+  // the network, and the `cause`, when present, names the real reason.
+  const cause = error.cause instanceof Error ? error.cause.message : null
+  const detail = cause && cause !== error.message ? ` (${cause})` : ''
+  return {
+    code: 'network',
+    message: `${withCode(errorCode, error.message)}${detail}`,
+    retryable: true,
+  }
+}

--- a/app/apps/server/src/service/app-update/downloadUpdate.ts
+++ b/app/apps/server/src/service/app-update/downloadUpdate.ts
@@ -1,14 +1,19 @@
-import { createWriteStream } from 'node:fs'
 import { mkdir, stat, unlink } from 'node:fs/promises'
 import { basename, join } from 'node:path'
-import { Readable } from 'node:stream'
-import { pipeline } from 'node:stream/promises'
 
+import { classifyDownloadError } from './classifyDownloadError'
+import { fetchArtifact } from './fetchArtifact'
 import type { UpdateDownloadState } from './types'
 import { resolveDownloadDir } from './updateConfig'
 import { createLogger } from '../../utils/logger'
 
 const logger = createLogger('app-update')
+
+// A dropped connection or a hiccup on GitHub's CDN should not leave the
+// operator staring at an error they then fix by pressing the same button
+// again. Three attempts, with a short pause between them.
+const MAX_ATTEMPTS = 3
+const RETRY_DELAYS_MS = [1_000, 3_000]
 
 /**
  * One download at a time, held in module state.
@@ -26,6 +31,7 @@ let state: UpdateDownloadState = {
   receivedBytes: 0,
   totalBytes: null,
   error: null,
+  errorCode: null,
 }
 
 let abortController: AbortController | null = null
@@ -68,6 +74,7 @@ export async function findDownloadedArtifact(
       receivedBytes: info.size,
       totalBytes: info.size,
       error: null,
+      errorCode: null,
     }
   } catch {
     return null
@@ -112,8 +119,10 @@ export async function startDownload(
     receivedBytes: 0,
     totalBytes: null,
     error: null,
+    errorCode: null,
   }
-  abortController = new AbortController()
+  const controller = new AbortController()
+  abortController = controller
 
   // Run detached from the request: the route answers immediately and the
   // client follows progress by polling.
@@ -121,27 +130,38 @@ export async function startDownload(
     try {
       await mkdir(dir, { recursive: true })
 
-      const response = await fetch(url, {
-        signal: abortController?.signal,
-        redirect: 'follow',
-      })
-      if (!response.ok || !response.body) {
-        throw new Error(`Download failed: ${response.status}`)
+      let received = 0
+      for (let attempt = 1; ; attempt++) {
+        try {
+          received = await fetchArtifact(url, partPath, controller.signal, {
+            onTotalBytes: (total) => {
+              state = { ...state, totalBytes: total }
+            },
+            onReceivedBytes: (bytes) => {
+              state = { ...state, receivedBytes: bytes }
+            },
+          })
+          break
+        } catch (error) {
+          await unlink(partPath).catch(() => {})
+          const failure = classifyDownloadError(error)
+          const delay = RETRY_DELAYS_MS[attempt - 1]
+          if (
+            controller.signal.aborted ||
+            !failure.retryable ||
+            attempt >= MAX_ATTEMPTS ||
+            delay === undefined
+          ) {
+            throw error
+          }
+          logger.warning(
+            `Update download attempt ${attempt}/${MAX_ATTEMPTS} failed (${failure.message}); retrying in ${delay}ms`,
+          )
+          state = { ...state, receivedBytes: 0, totalBytes: null }
+          await Bun.sleep(delay)
+        }
       }
 
-      const length = response.headers.get('content-length')
-      state = { ...state, totalBytes: length ? Number(length) : null }
-
-      let received = 0
-      const source = Readable.fromWeb(
-        response.body as Parameters<typeof Readable.fromWeb>[0],
-      )
-      source.on('data', (chunk: Buffer) => {
-        received += chunk.length
-        state = { ...state, receivedBytes: received }
-      })
-
-      await pipeline(source, createWriteStream(partPath))
       await Bun.write(filePath, Bun.file(partPath))
       await unlink(partPath).catch(() => {})
 
@@ -154,24 +174,45 @@ export async function startDownload(
         totalBytes: state.totalBytes ?? received,
       }
     } catch (error) {
-      const message = error instanceof Error ? error.message : 'Unknown error'
-      logger.error(`Update download failed: ${message}`)
       await unlink(partPath).catch(() => {})
-      state = { ...state, phase: 'error', error: message }
+      // A cancel already put the state back to idle; nothing to report.
+      if (controller.signal.aborted) return
+      const failure = classifyDownloadError(error)
+      logger.error(
+        `Update download failed [${failure.code}]: ${failure.message}`,
+      )
+      state = {
+        ...state,
+        phase: 'error',
+        error: failure.message,
+        errorCode: failure.code,
+      }
     } finally {
-      abortController = null
+      if (abortController === controller) abortController = null
     }
   })()
 
   return getDownloadState()
 }
 
-/** Aborts a download in flight and clears the partial file. */
+/**
+ * Aborts a download in flight and clears the partial file. Also dismisses a
+ * failure once the operator has seen it: the state lives for as long as the
+ * sidecar does, and an error from hours ago greeting them on the next visit
+ * read as "the download you just asked for failed".
+ */
 export function cancelDownload(): void {
   abortController?.abort()
   abortController = null
-  if (state.phase === 'downloading') {
-    state = { ...state, phase: 'idle', receivedBytes: 0, error: null }
+  if (state.phase === 'downloading' || state.phase === 'error') {
+    state = {
+      ...state,
+      phase: 'idle',
+      receivedBytes: 0,
+      totalBytes: null,
+      error: null,
+      errorCode: null,
+    }
   }
 }
 

--- a/app/apps/server/src/service/app-update/downloadUpdate.ts
+++ b/app/apps/server/src/service/app-update/downloadUpdate.ts
@@ -1,4 +1,4 @@
-import { mkdir, stat, unlink } from 'node:fs/promises'
+import { mkdir, rename, stat, unlink } from 'node:fs/promises'
 import { basename, join } from 'node:path'
 
 import { classifyDownloadError } from './classifyDownloadError'
@@ -162,8 +162,9 @@ export async function startDownload(
         }
       }
 
-      await Bun.write(filePath, Bun.file(partPath))
-      await unlink(partPath).catch(() => {})
+      // One atomic step, same directory: the finished name only ever points
+      // at a complete file, and there is no copy to be interrupted halfway.
+      await rename(partPath, filePath)
 
       logger.info(`Update ${version} downloaded to ${filePath}`)
       state = {

--- a/app/apps/server/src/service/app-update/fetchArtifact.ts
+++ b/app/apps/server/src/service/app-update/fetchArtifact.ts
@@ -1,0 +1,42 @@
+import { createWriteStream } from 'node:fs'
+import { Readable } from 'node:stream'
+import { pipeline } from 'node:stream/promises'
+
+import { HttpStatusError } from './HttpStatusError'
+
+export interface FetchArtifactProgress {
+  onTotalBytes: (total: number | null) => void
+  onReceivedBytes: (received: number) => void
+}
+
+/**
+ * One attempt at streaming the artifact into `partPath`. Resolves with the
+ * number of bytes written; rejects with the underlying error so the caller
+ * can decide whether another attempt is worthwhile.
+ */
+export async function fetchArtifact(
+  url: string,
+  partPath: string,
+  signal: AbortSignal,
+  progress: FetchArtifactProgress,
+): Promise<number> {
+  const response = await fetch(url, { signal, redirect: 'follow' })
+  if (!response.ok || !response.body) {
+    throw new HttpStatusError(response.status)
+  }
+
+  const length = response.headers.get('content-length')
+  progress.onTotalBytes(length ? Number(length) : null)
+
+  let received = 0
+  const source = Readable.fromWeb(
+    response.body as Parameters<typeof Readable.fromWeb>[0],
+  )
+  source.on('data', (chunk: Buffer) => {
+    received += chunk.length
+    progress.onReceivedBytes(received)
+  })
+
+  await pipeline(source, createWriteStream(partPath))
+  return received
+}

--- a/app/apps/server/src/service/app-update/types.ts
+++ b/app/apps/server/src/service/app-update/types.ts
@@ -17,7 +17,19 @@ export interface UpdateDownloadState {
   /** Null while the server has not been told a Content-Length. */
   totalBytes: number | null
   error: string | null
+  /**
+   * Why the last attempt failed, so the client can say something more useful
+   * than "check your connection": the network was unreachable, GitHub answered
+   * with an error status, or the folder could not be written to.
+   */
+  errorCode: UpdateDownloadErrorCode | null
 }
+
+export type UpdateDownloadErrorCode =
+  | 'network'
+  | 'http'
+  | 'filesystem'
+  | 'unknown'
 
 export interface UpdateConfig {
   /**

--- a/app/apps/server/src/service/songs/search.test.ts
+++ b/app/apps/server/src/service/songs/search.test.ts
@@ -1,8 +1,11 @@
 import {
+  buildScoringTermLists,
   buildSearchQuery,
+  buildTitleSearchQuery,
   calculateBestPhraseScoreNormalized,
   calculateTitleScoreNormalized,
   createFuzzyHighlightedSnippet,
+  extractQueryVariants,
   extractSearchTerms,
   getValidTerms,
   highlightWithDiacritics,
@@ -45,9 +48,14 @@ describe('extractSearchTerms', () => {
     // leading "1." is a hymn number that the user remembers — drop it
     // from the query. The "m" and "a" from "m-a", however, are clitic
     // tokens that need to survive so the title phrase still matches.
-    expect(
-      extractSearchTerms('1. Cand Isus Hristos m-a mantuit'),
-    ).toEqual(['cand', 'isus', 'hristos', 'm', 'a', 'mantuit'])
+    expect(extractSearchTerms('1. Cand Isus Hristos m-a mantuit')).toEqual([
+      'cand',
+      'isus',
+      'hristos',
+      'm',
+      'a',
+      'mantuit',
+    ])
   })
 
   test('strips hymn-number prefixes with various separators', () => {
@@ -207,14 +215,18 @@ describe('highlightWithDiacritics - literal-substring path (rawQuery)', () => {
       '<mark>Când Isus Hristos m-a</mark> mântuit',
     )
     // Leading hymn-number prefix is dropped for the highlight too
-    expect(
-      highlightWithDiacritics(title, [], '1. cand isus hristos m-a'),
-    ).toBe('<mark>Când Isus Hristos m-a</mark> mântuit')
+    expect(highlightWithDiacritics(title, [], '1. cand isus hristos m-a')).toBe(
+      '<mark>Când Isus Hristos m-a</mark> mântuit',
+    )
   })
 
   test('"m-am departat de Mântuitorul" marks exactly that phrase', () => {
     const title = 'M-am depărtat de Mântuitorul ce m-a salvat'
-    const out = highlightWithDiacritics(title, [], 'm-am departat de mantuitorul')
+    const out = highlightWithDiacritics(
+      title,
+      [],
+      'm-am departat de mantuitorul',
+    )
     // M- prefix is included; trailing "ce m-a salvat" is not touched.
     expect(out).toBe('<mark>M-am depărtat de Mântuitorul</mark> ce m-a salvat')
   })
@@ -243,10 +255,12 @@ describe('highlightWithDiacritics - per-term fallback', () => {
 
   test('does not nest <mark> tags when a shorter term overlaps a longer one', () => {
     // Pre-existing artefact regression guard.
-    const out = highlightWithDiacritics(
-      'M-am depărtat de Mântuitorul',
-      ['am', 'departat', 'de', 'mantuitorul'],
-    )
+    const out = highlightWithDiacritics('M-am depărtat de Mântuitorul', [
+      'am',
+      'departat',
+      'de',
+      'mantuitorul',
+    ])
     expect(out).not.toMatch(/<mark><mark>/)
     expect(out).not.toMatch(/<\/mark><\/mark>/)
   })
@@ -354,5 +368,109 @@ describe('scoring - exact phrase matching across punctuation', () => {
 
     // Full match should score higher than partial match
     expect(fullScore).toBeGreaterThan(partialScore)
+  })
+})
+
+describe('normalizeForIndex - spellings of one word', () => {
+  test('decodes HTML entities so an escaped apostrophe does not split the word', () => {
+    const normalized = normalizeForIndex(
+      '<p>Te-nconjoară, Isuse, ne&#039;ncetat</p>',
+    )
+    expect(normalized).not.toContain('039')
+    expect(normalized).toContain('ne ncetat')
+  })
+
+  test('appends the joined spellings after the text, keeping the phrase intact', () => {
+    const normalized = normalizeForIndex('Doamne ne-ncetat Te lăudăm')
+    expect(normalized.startsWith('Doamne ne ncetat')).toBe(true)
+    expect(normalized).toContain('Te laudam')
+    expect(normalized.split(' ')).toEqual(
+      expect.arrayContaining(['nencetat', 'neincetat']),
+    )
+    // Phrase scoring still sees the words in order.
+    expect(normalized).toContain('ne ncetat cetat Te laudam')
+  })
+})
+
+describe('extractQueryVariants', () => {
+  test('yields the other spellings of hyphen words and of elided words', () => {
+    expect(extractQueryVariants('Te laudam ne-ncetat')).toEqual([
+      'nencetat',
+      'neincetat',
+    ])
+    expect(extractQueryVariants('te laudam neîncetat')).toEqual(['nencetat'])
+    expect(extractQueryVariants('1. Isus Hristos')).toEqual([])
+  })
+})
+
+describe('buildSearchQuery / buildTitleSearchQuery - spelling variants', () => {
+  test('a single hyphen word searches its split phrase and its joined spellings', () => {
+    const variants = extractQueryVariants('ne-ncetat')
+    const query = buildSearchQuery('ne-ncetat', undefined, variants)
+    expect(query).toContain('("ne ncetat")')
+    expect(query).toContain('("nencetat"* OR "neincetat"*)')
+  })
+
+  test('the title query carries the same tiers restricted to the title column', () => {
+    const variants = extractQueryVariants('laudam ne-ncetat')
+    const query = buildTitleSearchQuery('laudam ne-ncetat', variants)
+    expect(query.startsWith('title : (')).toBe(true)
+    expect(query).toContain('("laudam ne ncetat")')
+    expect(query).toContain('"nencetat"*')
+    expect(query).toContain('NEAR("laudam" "ne" "ncetat", 10)')
+  })
+})
+
+describe('highlighting - signs and entities', () => {
+  test('the title mark covers the hyphen or apostrophe, whatever was typed', () => {
+    expect(
+      highlightWithDiacritics(
+        'Te lăudăm neîncetat',
+        ['ne', 'ncetat'],
+        'ne-ncetat',
+      ),
+    ).toBe('Te lăudăm <mark>neîncetat</mark>')
+    expect(
+      highlightWithDiacritics("Ne'ncetat mă-nveți", ['neincetat'], 'neîncetat'),
+    ).toBe("<mark>Ne'ncetat</mark> mă-nveți")
+  })
+
+  test('the snippet marks the escaped apostrophe word as one word', () => {
+    const snippet = createFuzzyHighlightedSnippet(
+      '<p>Mulţimea Te-nconjoară, Isuse, ne&#039;ncetat, privirea Ție-e dorită</p>',
+      ['ne', 'ncetat'],
+      150,
+      'ne-ncetat',
+    )
+    expect(snippet).toContain('<mark>ne&#039;ncetat</mark>')
+  })
+})
+
+describe('buildScoringTermLists', () => {
+  test('swaps each other spelling into the typed terms', () => {
+    const terms = extractSearchTerms('te laudam ne-ncetat')
+    expect(buildScoringTermLists('te laudam ne-ncetat', terms)).toEqual([
+      ['te', 'laudam', 'ne', 'ncetat'],
+      ['te', 'laudam', 'nencetat'],
+      ['te', 'laudam', 'neincetat'],
+    ])
+    expect(buildScoringTermLists('neincetat', ['neincetat'])).toEqual([
+      ['neincetat'],
+      ['nencetat'],
+    ])
+    expect(buildScoringTermLists('nencetat', ['nencetat'])).toEqual([
+      ['nencetat'],
+      ['neincetat'],
+    ])
+  })
+
+  test('a title in another spelling scores as a full title match', () => {
+    const lists = buildScoringTermLists('ne-ncetat', ['ne', 'ncetat'])
+    const best = Math.max(
+      ...lists.map((terms) =>
+        calculateTitleScoreNormalized('te laudam neincetat', terms),
+      ),
+    )
+    expect(best).toBeGreaterThanOrEqual(95)
   })
 })

--- a/app/apps/server/src/service/songs/search.ts
+++ b/app/apps/server/src/service/songs/search.ts
@@ -1,4 +1,8 @@
 import { getHiddenCategoryIds } from './categories'
+import { decodeHtmlEntities } from './text/decodeHtmlEntities'
+import { elisionVariants } from './text/elisionVariants'
+import { findHighlightRanges, wrapRanges } from './text/findHighlightRanges'
+import { joinedWordVariants } from './text/joinedWordVariants'
 import type { SongSearchResult } from './types'
 import { getRawDatabase } from '../../db'
 import { getSetting } from '../settings'
@@ -45,6 +49,7 @@ const SEARCH_CACHE_TTL_MS = 5 * 60 * 1000 // 5 minutes
  * back in, which is how an exact title match went missing on a large library.
  */
 const FTS_CANDIDATE_LIMIT = 400
+const TITLE_CANDIDATE_LIMIT = 200
 const TRIGRAM_CANDIDATE_LIMIT = 150
 
 const searchResultsCache = new Map<string, SearchCacheEntry>()
@@ -208,26 +213,57 @@ function foldTerm(text: string): string {
 }
 
 /**
+ * A title as the operator would type it: diacritics folded, lowercase,
+ * punctuation as spaces — and nothing else added, unlike the indexed form.
+ */
+function foldForScore(text: string): string {
+  return removeDiacritics(decodeHtmlEntities(text))
+    .toLowerCase()
+    .replace(/[^\p{L}\p{N}]+/gu, ' ')
+    .trim()
+}
+
+/**
  * Normalizes text for FTS indexing:
- * - Replaces hyphens with spaces (so "să-nfăptuiesc" becomes "să nfăptuiesc")
+ * - Decodes HTML entities (slide content is stored escaped, so an apostrophe
+ *   arrives as `&#039;` and would otherwise tokenise into a stray "039")
+ * - Replaces punctuation with spaces (so "să-nfăptuiesc" becomes "să nfăptuiesc")
+ * - Adds the joined spellings of hyphen/apostrophe words, so "ne-ncetat",
+ *   "ne'ncetat", "nencetat" and "neîncetat" all find each other
  * - Expands Romanian contractions (n- prefix) for better searchability
  * - Diacritics are handled by the FTS5 tokenizer (remove_diacritics 2)
  *
  * Romanian linguistic patterns handled:
- * - "să-nfăptuiesc" → "sa nfaptuiesc faptuiesc" (n- is contraction of "în")
- * - "n-am" → "n am am" (expands contraction)
+ * - "să-nfăptuiesc" → "sa nfaptuiesc faptuiesc … sanfaptuiesc sainfaptuiesc"
+ * - "ne-ncetat" → "ne ncetat cetat … nencetat neincetat"
+ * - "n-am" → "n am am" (expands contraction; too short to join)
  * - "s-a" → "s a" (reflexive pronoun contraction)
  */
 export function normalizeForIndex(text: string): string {
-  let normalized = removeDiacritics(text)
-    .replace(/<[^>]+>/g, ' ') // Strip HTML tags before normalization
-    .replace(/[^\p{L}\p{N}\s]/gu, ' ') // Replace ALL punctuation (commas, hyphens, periods, etc.) with spaces
-    .replace(/\s+/g, ' ') // Collapse multiple spaces
-    .trim()
+  const plain = removeDiacritics(
+    decodeHtmlEntities(text.replace(/<[^>]+>/g, ' ')),
+  )
+
+  // Joined spellings are appended after the text rather than inserted next
+  // to their word, so the phrase order of the original stays intact for
+  // phrase queries and phrase scoring.
+  const words: string[] = []
+  const joined: string[] = []
+  for (const token of plain.split(/\s+/)) {
+    // Replace ALL punctuation (commas, hyphens, periods, etc.) with spaces
+    const pieces = token
+      .replace(/[^\p{L}\p{N}]+/gu, ' ')
+      .trim()
+      .split(' ')
+      .filter((piece) => piece.length > 0)
+    words.push(...pieces)
+    if (pieces.length > 1) {
+      joined.push(...joinedWordVariants(token.toLowerCase()))
+    }
+  }
 
   // Expand Romanian n- contractions: words starting with "n" followed by consonant
   // are often contractions of "în" + word (e.g., "nfaptuiesc" = "infaptuiesc" → also index "faptuiesc")
-  const words = normalized.split(' ')
   const expandedWords: string[] = []
 
   for (const word of words) {
@@ -246,7 +282,7 @@ export function normalizeForIndex(text: string): string {
   // tokenization ("m-a" → "m a") and a user typing the exact title needs
   // those tokens to land an exact phrase match in FTS. Per-term scoring
   // protects itself with ordered indexOf in calculateTitleScoreNormalized.
-  return expandedWords.join(' ')
+  return [...expandedWords, ...joined].join(' ')
 }
 
 /**
@@ -576,8 +612,9 @@ export function extractSearchTerms(queryText: string): string[] {
   // so internal numbers (e.g. song lyrics containing dates) survive.
   const dehymned = queryText.replace(/^\s*\d+[.\-]?\s+/, '')
 
+  // Every sign — apostrophes included — separates, exactly as in the index,
+  // so "ne'ncetat" and "ne-ncetat" both become ["ne", "ncetat"].
   const sanitized = removeDiacritics(dehymned)
-    .replace(/['"]/g, '')
     .replace(/[^\p{L}\p{N}\s]/gu, ' ') // Replace ALL non-letter, non-number, non-space chars with space
     .replace(/\s+/g, ' ')
     .trim()
@@ -587,6 +624,70 @@ export function extractSearchTerms(queryText: string): string[] {
 
   // Deduplicate terms (e.g. "Isus,Isus" → ["isus", "isus"] → ["isus"])
   return [...new Set(terms)]
+}
+
+/** One query word: the split pieces it searches as, and its other spellings. */
+interface QueryWordSpellings {
+  pieces: string[]
+  variants: string[]
+}
+
+function extractQueryWordSpellings(queryText: string): QueryWordSpellings[] {
+  const dehymned = queryText.replace(/^\s*\d+[.\-]?\s+/, '')
+  const spellings: QueryWordSpellings[] = []
+  for (const word of removeDiacritics(dehymned).toLowerCase().split(/\s+/)) {
+    const variants = [...joinedWordVariants(word), ...elisionVariants(word)]
+    if (variants.length === 0) continue
+    spellings.push({ pieces: extractSearchTerms(word), variants })
+  }
+  return spellings
+}
+
+/**
+ * The other spellings of each query word, e.g. "ne-ncetat" → ["nencetat",
+ * "neincetat"] and "neincetat" → ["nencetat"]. These go into the FTS query
+ * and the highlighter alongside the split terms, so however the operator
+ * writes a word — with a sign, without, or with the elided "î" back in —
+ * it finds songs that write it any other way.
+ */
+export function extractQueryVariants(queryText: string): string[] {
+  const variants = new Set<string>()
+  for (const word of extractQueryWordSpellings(queryText)) {
+    for (const variant of word.variants) variants.add(variant)
+  }
+  return Array.from(variants)
+}
+
+/**
+ * The term lists a song is scored against: the typed terms, plus one list
+ * per other spelling with that word swapped in — so a title written
+ * "neîncetat" scores as a full match for "ne-ncetat" and vice versa.
+ */
+export function buildScoringTermLists(
+  queryText: string,
+  terms: string[],
+): string[][] {
+  const lists: string[][] = [terms]
+  for (const word of extractQueryWordSpellings(queryText)) {
+    const at = findSequence(terms, word.pieces)
+    if (at === -1) continue
+    for (const variant of word.variants) {
+      lists.push([
+        ...terms.slice(0, at),
+        variant,
+        ...terms.slice(at + word.pieces.length),
+      ])
+    }
+  }
+  return lists
+}
+
+function findSequence(haystack: string[], needle: string[]): number {
+  if (needle.length === 0) return -1
+  for (let i = 0; i + needle.length <= haystack.length; i++) {
+    if (needle.every((piece, j) => haystack[i + j] === piece)) return i
+  }
+  return -1
 }
 
 /**
@@ -687,6 +788,44 @@ export function getValidTerms(terms: string[]): { validTerms: string[] } {
 }
 
 /**
+ * The shared tiers of the FTS query, most specific first. Order matters
+ * because BM25 sums score contributions across all matched sub-clauses, so
+ * the most-specific tier first gives true phrase matches a decisive boost.
+ *
+ * - "<phrase>" : exact phrase, synonym-aware.
+ * - variants : a hyphen/apostrophe word in its other spellings —
+ *     "ne-ncetat" must reach "nencetat" and "neîncetat", which the split
+ *     phrase cannot.
+ * - NEAR(terms, 10) : proximity fallback.
+ * - prefix OR (multi-char terms only) : broad recall. Single-char prefixes
+ *     like "a"* match every word starting with "a" — they are excluded here
+ *     to avoid drowning specific matches in noise.
+ */
+function buildQueryTiers(
+  effectiveTerms: string[],
+  joinedVariants: string[],
+): string[] {
+  const variantClause =
+    joinedVariants.length > 0
+      ? `(${joinedVariants.map((v) => `"${v}"*`).join(' OR ')})`
+      : null
+
+  if (effectiveTerms.length === 1) {
+    const single = `"${effectiveTerms[0]}"*`
+    return variantClause ? [single, variantClause] : [single]
+  }
+
+  const broadOrTerms = effectiveTerms.filter((t) => t.length > 1)
+  const tiers: string[] = [`("${effectiveTerms.join(' ')}")`]
+  if (variantClause) tiers.push(variantClause)
+  tiers.push(`(NEAR(${effectiveTerms.map((t) => `"${t}"`).join(' ')}, 10))`)
+  if (broadOrTerms.length > 0) {
+    tiers.push(`(${broadOrTerms.map((t) => `"${t}"*`).join(' OR ')})`)
+  }
+  return tiers
+}
+
+/**
  * Builds a simple FTS5 query optimized for performance
  * Uses OR for broad matching, letting post-processing handle ranking
  *
@@ -710,43 +849,50 @@ export function buildSearchQuery(
    * don't expand.
    */
   originalTerms?: string[],
+  /**
+   * Other spellings of the query words (see `extractQueryVariants`),
+   * matched as their own prefix terms.
+   */
+  joinedVariants: string[] = [],
 ): string {
   const effectiveTerms = extractSearchTerms(queryText)
 
   if (effectiveTerms.length === 0) return ''
 
-  if (effectiveTerms.length === 1) {
-    return `"${effectiveTerms[0]}"*`
-  }
+  const tiers = buildQueryTiers(effectiveTerms, joinedVariants)
+  if (effectiveTerms.length === 1) return tiers.join(' OR ')
 
-  // Tiered query. Order matters because BM25 sums score contributions
-  // across all matched sub-clauses, so the most-specific tier first
-  // gives true title matches a decisive boost.
-  //
-  // - title:"<original phrase>" : exact title match (incl. clitic
-  //     single-letter tokens like "m a", so "Cand Isus Hristos m-a
-  //     mantuit" indexes/matches identically). Built from the user's
-  //     ORIGINAL terms only — synonyms (e.g. cristos) must not appear
-  //     in the title clause or it never matches a real title.
-  // - "<expanded phrase>" : exact phrase in any column, synonym-aware.
-  // - NEAR(expanded, 10) : proximity fallback.
-  // - prefix OR (multi-char terms only) : broad recall. Single-char
-  //     prefixes like "a"* match every word starting with "a" — they
-  //     are excluded here to avoid drowning specific matches in noise.
+  // title:"<original phrase>" : exact title match (incl. clitic
+  // single-letter tokens like "m a", so "Cand Isus Hristos m-a mantuit"
+  // indexes/matches identically). Built from the user's ORIGINAL terms
+  // only — synonyms (e.g. cristos) must not appear in the title clause or
+  // it never matches a real title.
   const titlePhraseTerms = originalTerms ?? effectiveTerms
-  const broadOrTerms = effectiveTerms.filter((t) => t.length > 1)
-
   const clauses: string[] = []
   if (titlePhraseTerms.length > 1) {
     clauses.push(`(title:"${titlePhraseTerms.join(' ')}")`)
   }
-  clauses.push(`("${effectiveTerms.join(' ')}")`)
-  clauses.push(`(NEAR(${effectiveTerms.map((t) => `"${t}"`).join(' ')}, 10))`)
-  if (broadOrTerms.length > 0) {
-    clauses.push(`(${broadOrTerms.map((t) => `"${t}"*`).join(' OR ')})`)
-  }
+  clauses.push(...tiers)
 
   return clauses.join(' OR ')
+}
+
+/**
+ * The same tiers restricted to the title column. Run on its own, before
+ * the general query, so that every song whose TITLE matches is a candidate
+ * no matter how many songs merely sing the words: the general query's
+ * candidate cut is taken by BM25 rank, and a few hundred lyric phrase
+ * matches can push a title spelled "neîncetat" out of it when the operator
+ * typed "ne-ncetat".
+ */
+export function buildTitleSearchQuery(
+  queryText: string,
+  joinedVariants: string[] = [],
+): string {
+  const effectiveTerms = extractSearchTerms(queryText)
+  if (effectiveTerms.length === 0) return ''
+  const tiers = buildQueryTiers(effectiveTerms, joinedVariants)
+  return `title : (${tiers.join(' OR ')})`
 }
 
 /**
@@ -937,201 +1083,30 @@ function extractFuzzySubstrings(term: string): string[] {
 }
 
 /**
- * Finds the word containing a fuzzy substring match
- * Returns the full word that contains the matching substring
- */
-function findFuzzyMatchWord(
-  content: string,
-  term: string,
-): { word: string; index: number } | null {
-  if (term.length < 5) return null
-
-  const words = content.match(/[\p{L}\p{N}]+/gu) || []
-
-  for (let len = Math.min(5, term.length - 1); len >= 4; len--) {
-    for (let start = 1; start <= term.length - len; start++) {
-      const sub = term.substring(start, start + len).toLowerCase()
-      for (const word of words) {
-        if (word.toLowerCase().includes(sub)) {
-          const index = content.toLowerCase().indexOf(word.toLowerCase())
-          return { word, index }
-        }
-      }
-    }
-  }
-
-  return null
-}
-
-/**
- * Builds a regex pattern where each character also matches its diacritical variants.
- * e.g., "a" matches "a", "ă", "â" so that a diacritic-stripped search word
- * highlights the original text that contains diacritics.
- */
-function buildDiacriticInsensitivePattern(word: string): string {
-  // Romanian s and t exist in two Unicode forms: the canonical comma-below
-  // (ș U+0219, ț U+021B) and the older cedilla (ş U+015F, ţ U+0163). Both
-  // are sprinkled through real texts, so the pattern must accept either
-  // when highlighting a diacritic-stripped search token.
-  const diacriticMap: Record<string, string> = {
-    a: '[aăâ]',
-    i: '[iî]',
-    s: '[sșş]',
-    t: '[tțţ]',
-  }
-  return word
-    .split('')
-    .map((ch) => {
-      const lower = ch.toLowerCase()
-      if (diacriticMap[lower]) return diacriticMap[lower]
-      return ch.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
-    })
-    .join('')
-}
-
-/**
- * Highlights search terms in text with diacritic-insensitive matching.
- * Operates on original text (with diacritics) so highlighted output preserves them.
+ * Highlights search terms in text, diacritic- and punctuation-insensitive.
+ * Operates on the original text so the highlighted output keeps its
+ * diacritics, entities and signs — "ne-ncetat" typed marks the whole
+ * "ne'ncetat" or "neîncetat" in the title, sign included.
  *
- * When a term match sits inside a hyphenated word (e.g. "am" inside
- * "m-am" or "te-aşteptăm"), the highlight is extended across the whole
- * hyphen-joined chunk. This keeps short Romanian clitic contractions
- * ("m-am", "te-a", "ne-am", "n-a") visually together in the title even
- * though the leading single-letter segment is dropped from the search
- * tokens for ranking purposes.
+ * Literal typing wins: while the user types "Cand Isus Hristos m" → "m-" →
+ * "m-a" the mark widens one character at a time. Only when the typed text
+ * is not a literal substring does it fall back to spelling variants, then
+ * to per-term marks merged across whitespace / clitic gaps.
  */
-/**
- * Returns true if the gap between two highlight ranges should be swallowed
- * into a single merged range — pure whitespace, a hyphen, or a short
- * Romanian clitic contraction (e.g. "m-a", "te-a", "ne-am", "s-a", "n-am").
- * Plain words like "a" or "este" between two matches stay un-merged so we
- * don't blob everything together.
- */
-function isMergeableGap(gap: string): boolean {
-  if (gap.length === 0) return true
-  const trimmed = gap.trim()
-  if (trimmed === '') return true
-  return (
-    trimmed.length <= 6 && trimmed.includes('-') && /^[\p{L}-]+$/u.test(trimmed)
-  )
-}
-
-/**
- * Normalises the raw user query into the literal phrase we try to find as a
- * substring of the text being highlighted. Strips the leading hymn-number
- * prefix (mirrors extractSearchTerms), removes diacritics, lowercases and
- * collapses whitespace. Keeps internal hyphens so an incremental typing
- * pass like "Cand Isus Hristos m" → "m-" → "m-a" naturally widens the
- * highlight by one character at a time.
- */
-function cleanQueryForHighlight(rawQuery: string): string {
-  return removeDiacritics(rawQuery)
-    .replace(/^\s*\d+[.\-]?\s+/, '')
-    .toLowerCase()
-    .replace(/\s+/g, ' ')
-    .trim()
-}
-
-/**
- * If the cleaned user query appears verbatim inside the (diacritic-stripped,
- * lowercased) text, returns the text with that exact span wrapped in a
- * single <mark>. Returns null otherwise so callers can fall back to per-
- * term highlighting.
- */
-function tryExactPhraseHighlight(
-  text: string,
-  rawQuery: string,
-): string | null {
-  const cleaned = cleanQueryForHighlight(rawQuery)
-  if (cleaned.length === 0) return null
-  // removeDiacritics + toLowerCase preserve character count for the
-  // Romanian alphabet (NFD splits "ă" into base + combining mark, the
-  // combining mark is stripped, length stays the same) so we can map
-  // positions 1:1 back to the original text.
-  const normText = removeDiacritics(text).toLowerCase()
-  const pos = normText.indexOf(cleaned)
-  if (pos === -1) return null
-  return (
-    text.slice(0, pos) +
-    `<mark>${text.slice(pos, pos + cleaned.length)}</mark>` +
-    text.slice(pos + cleaned.length)
-  )
-}
-
 export function highlightWithDiacritics(
   text: string,
   searchTerms: string[],
   rawQuery?: string,
 ): string {
   if (!searchTerms.length && !rawQuery) return text
-
-  // 1. Literal substring match against the user's typed query. This is the
-  //    common path while the user types incrementally — "Cand Isus Hristos
-  //    m" → "m-" → "m-a" widens the mark one character at a time, exactly
-  //    matching what they typed. Title and content highlighters share this
-  //    code so the two stay visually in sync.
-  if (rawQuery !== undefined && rawQuery.length > 0) {
-    const exact = tryExactPhraseHighlight(text, rawQuery)
-    if (exact !== null) return exact
-  }
-
-  // 2. Fallback: per-term marking when the query is not a literal substring
-  //    of the text (different word order, partial phrase, typo). Collects
-  //    every term's positions in one pass, then merges adjacent ranges
-  //    across whitespace / hyphen / clitic-contraction gaps to avoid a
-  //    sea of single-word marks.
-  const ranges: Array<{ start: number; end: number }> = []
-  for (const term of searchTerms) {
-    if (term.length === 0) continue
-    const normalized = removeDiacritics(term).toLowerCase()
-    const diacriticPattern = buildDiacriticInsensitivePattern(normalized)
-    // Short terms (≤ 2 chars) must be word-bounded — otherwise "a" matches
-    // inside "cAnd" and "m" matches inside half the corpus. Longer terms
-    // can match literally so partial typing like "isu" still highlights
-    // the "Isu" in "Isus" without bleeding past it.
-    const pattern =
-      term.length <= 2
-        ? new RegExp(`\\b${diacriticPattern}\\b`, 'giu')
-        : new RegExp(diacriticPattern, 'giu')
-    let m: RegExpExecArray | null
-    while ((m = pattern.exec(text)) !== null) {
-      if (m[0].length === 0) {
-        pattern.lastIndex++
-        continue
-      }
-      ranges.push({ start: m.index, end: m.index + m[0].length })
-    }
-  }
-  if (ranges.length === 0) return text
-
-  ranges.sort((a, b) => a.start - b.start || a.end - b.end)
-  const merged: Array<{ start: number; end: number }> = []
-  for (const r of ranges) {
-    const last = merged[merged.length - 1]
-    if (last && r.start <= last.end) {
-      last.end = Math.max(last.end, r.end)
-    } else if (last && isMergeableGap(text.slice(last.end, r.start))) {
-      last.end = r.end
-    } else {
-      merged.push({ ...r })
-    }
-  }
-
-  let out = ''
-  let cursor = 0
-  for (const r of merged) {
-    out += text.slice(cursor, r.start)
-    out += `<mark>${text.slice(r.start, r.end)}</mark>`
-    cursor = r.end
-  }
-  out += text.slice(cursor)
-  return out
+  const ranges = findHighlightRanges(text, searchTerms, { rawQuery })
+  return ranges.length === 0 ? text : wrapRanges(text, ranges)
 }
 
 /**
- * Creates highlighted content with fuzzy match support
- * Highlights both exact matches and fuzzy matches (e.g., "Hristos" -> "Cristos")
- * Supports diacritic-insensitive matching (e.g., "in" matches "în")
+ * Creates a highlighted content snippet around the best match. Shares the
+ * range finder with the title highlighter so the two always mark the same
+ * thing; additionally lights up fuzzy matches (e.g. "Hristos" → "Cristos").
  */
 export function createFuzzyHighlightedSnippet(
   content: string,
@@ -1142,176 +1117,47 @@ export function createFuzzyHighlightedSnippet(
   // Strip HTML tags for cleaner processing
   const plainContent = content.replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ')
 
-  // 1. Literal substring match against the user's typed query. Matches the
-  //    title highlighter so the two stay visually in sync — when the user
-  //    types "Cand Isus Hristos m" the snippet marks exactly the same span
-  //    as the title, never extending into the trailing "-a" until the user
-  //    actually types those characters.
-  if (rawQuery !== undefined && rawQuery.length > 0) {
-    const cleaned = cleanQueryForHighlight(rawQuery)
-    if (cleaned.length > 0) {
-      const normFull = removeDiacritics(plainContent).toLowerCase()
-      const pos = normFull.indexOf(cleaned)
-      if (pos !== -1) {
-        const matchEnd = pos + cleaned.length
-        const windowStart = Math.max(0, pos - 30)
-        const rawEnd = Math.min(plainContent.length, windowStart + maxLength)
-        // Make sure the matched span is fully inside the window
-        const windowEnd = Math.max(rawEnd, matchEnd)
-        const snippet = plainContent.slice(windowStart, windowEnd)
-        const localStart = pos - windowStart
-        const localEnd = matchEnd - windowStart
-        const marked =
-          snippet.slice(0, localStart) +
-          `<mark>${snippet.slice(localStart, localEnd)}</mark>` +
-          snippet.slice(localEnd)
-        const prefix = windowStart > 0 ? '...' : ''
-        const suffix = windowEnd < plainContent.length ? '...' : ''
-        return `${prefix}${marked}${suffix}`
-      }
-    }
-  }
+  const ranges = findHighlightRanges(plainContent, queryTerms, {
+    rawQuery,
+    fuzzy: true,
+  })
 
-  // Normalize content for diacritic-insensitive matching
-  const normalizedContent = removeDiacritics(plainContent).toLowerCase()
-
-  // Find all matches (exact and fuzzy) with their positions
-  const matches: Array<{ start: number; end: number; length: number }> = []
-
-  for (const term of queryTerms) {
-    const normalizedTerm = removeDiacritics(term).toLowerCase()
-
-    // For short terms (< 3 chars), only match whole words to avoid false positives
-    // e.g., "in" should match "in" or "în" but not the "in" inside "furtuni"
-    if (term.length < 3) {
-      // Use word boundary regex for short terms
-      const wordRegex = new RegExp(`\\b${normalizedTerm}\\b`, 'gi')
-      let match: RegExpExecArray | null
-      while ((match = wordRegex.exec(normalizedContent)) !== null) {
-        // Find the actual position in original content (may differ due to diacritics)
-        const actualWord = plainContent.substring(
-          match.index,
-          match.index + match[0].length,
-        )
-        matches.push({
-          start: match.index,
-          end: match.index + actualWord.length,
-          length: actualWord.length,
-        })
-      }
-    } else {
-      // For longer terms, find all occurrences
-      let pos = 0
-      while ((pos = normalizedContent.indexOf(normalizedTerm, pos)) !== -1) {
-        // Get actual length from original content (may be different due to composed chars)
-        let actualEnd = pos + normalizedTerm.length
-        // Adjust for any length differences in original content
-        while (
-          actualEnd < plainContent.length &&
-          removeDiacritics(plainContent.substring(pos, actualEnd)).toLowerCase()
-            .length < normalizedTerm.length
-        ) {
-          actualEnd++
-        }
-        matches.push({
-          start: pos,
-          end: actualEnd,
-          length: actualEnd - pos,
-        })
-        pos += 1
-      }
-
-      // Find fuzzy matches (for terms >= 5 chars)
-      if (term.length >= 5) {
-        const fuzzyMatch = findFuzzyMatchWord(plainContent, term)
-        if (fuzzyMatch && !matches.some((m) => m.start === fuzzyMatch.index)) {
-          matches.push({
-            start: fuzzyMatch.index,
-            end: fuzzyMatch.index + fuzzyMatch.word.length,
-            length: fuzzyMatch.word.length,
-          })
-        }
-      }
-    }
-  }
-
-  if (matches.length === 0) {
+  if (ranges.length === 0) {
     // No matches, return start of content
     return plainContent.length > maxLength
       ? `${plainContent.substring(0, maxLength)}...`
       : plainContent
   }
 
-  // (No backward / forward hyphen-word extension here — the exact-phrase
-  // path above already covers the literal-typing case, and per-term
-  // marks are merged through hyphen / clitic gaps below, which gives the
-  // same visual result for queries that span an "m-a" without claiming
-  // characters the user never typed.)
-
-  // Sort matches by position, then by length (longer matches first)
-  matches.sort((a, b) => a.start - b.start || b.length - a.length)
-
-  // Merge overlapping and adjacent matches. Gaps that are pure whitespace
-  // OR a short Romanian clitic contraction (m-a, te-a, ne-am, s-a, …) are
-  // swallowed into a single range so users see a continuous highlight on
-  // queries like "cand isus hristos m-a mantuit" — the "m-a" sits between
-  // two matched terms and visibly belongs to the same phrase.
-  const mergedMatches: Array<{ start: number; end: number }> = []
-  for (const match of matches) {
-    const adjacent = mergedMatches.find((m) => {
-      if (match.start < m.end && match.end > m.start) return true // overlapping
-      const gap =
-        match.start >= m.end
-          ? plainContent.substring(m.end, match.start)
-          : plainContent.substring(match.end, m.start)
-      return isMergeableGap(gap)
-    })
-    if (adjacent) {
-      adjacent.start = Math.min(adjacent.start, match.start)
-      adjacent.end = Math.max(adjacent.end, match.end)
-    } else {
-      mergedMatches.push({ start: match.start, end: match.end })
-    }
-  }
-
-  // Find the best snippet window (area with most highlighted characters)
+  // Find the best snippet window (area with most highlighted characters),
+  // always wide enough to hold the match it is anchored on in full.
   let bestStart = 0
+  let bestEnd = Math.min(plainContent.length, maxLength)
   let bestHighlightChars = 0
-
-  for (const match of mergedMatches) {
-    const windowStart = Math.max(0, match.start - 30)
-    const windowEnd = windowStart + maxLength
-    const highlightChars = mergedMatches
-      .filter((m) => m.start >= windowStart && m.end <= windowEnd)
-      .reduce((sum, m) => sum + (m.end - m.start), 0)
+  for (const range of ranges) {
+    const windowStart = Math.max(0, range.start - 30)
+    const windowEnd = Math.min(
+      plainContent.length,
+      Math.max(windowStart + maxLength, range.end),
+    )
+    const highlightChars = ranges
+      .filter((r) => r.start >= windowStart && r.end <= windowEnd)
+      .reduce((sum, r) => sum + (r.end - r.start), 0)
     if (highlightChars > bestHighlightChars) {
       bestHighlightChars = highlightChars
       bestStart = windowStart
+      bestEnd = windowEnd
     }
   }
 
-  // Extract snippet
-  let snippet = plainContent.substring(bestStart, bestStart + maxLength)
+  const snippet = plainContent.slice(bestStart, bestEnd)
+  const local = ranges
+    .filter((r) => r.start >= bestStart && r.end <= bestEnd)
+    .map((r) => ({ start: r.start - bestStart, end: r.end - bestStart }))
 
-  // Get matches within snippet and adjust positions
-  const snippetMatches = mergedMatches
-    .filter((m) => m.start >= bestStart && m.end <= bestStart + maxLength)
-    .map((m) => ({ start: m.start - bestStart, end: m.end - bestStart }))
-    .sort((a, b) => b.start - a.start) // Sort descending for safe replacement
-
-  // Apply highlighting (from end to start to preserve positions)
-  for (const match of snippetMatches) {
-    const before = snippet.substring(0, match.start)
-    const term = snippet.substring(match.start, match.end)
-    const after = snippet.substring(match.end)
-    snippet = `${before}<mark>${term}</mark>${after}`
-  }
-
-  // Add ellipsis
   const prefix = bestStart > 0 ? '...' : ''
-  const suffix = bestStart + maxLength < plainContent.length ? '...' : ''
-
-  return `${prefix}${snippet}${suffix}`
+  const suffix = bestEnd < plainContent.length ? '...' : ''
+  return `${prefix}${wrapRanges(snippet, local)}${suffix}`
 }
 
 /**
@@ -1482,7 +1328,16 @@ export function searchSongs(
     // Build FTS query using expanded terms for broader results, but pass the
     // pre-expansion terms separately so the title-restricted clause matches
     // the user's literal title query without diluting on synonym variants.
-    const ftsQuery = buildSearchQuery(expandedTerms.join(' '), validTerms)
+    const joinedVariants = extractQueryVariants(query)
+    const ftsQuery = buildSearchQuery(
+      expandedTerms.join(' '),
+      validTerms,
+      joinedVariants,
+    )
+    const titleQuery = buildTitleSearchQuery(
+      expandedTerms.join(' '),
+      joinedVariants,
+    )
 
     if (!ftsQuery) {
       return []
@@ -1512,11 +1367,7 @@ export function searchSongs(
     }
     const extraFilter =
       extraConditions.length > 0 ? `AND ${extraConditions.join(' AND ')}` : ''
-    const standardQueryParams = [ftsQuery, ...categoryParams]
-
-    const standardResults = db
-      .query(
-        `
+    const candidateSql = (limit: number) => `
       SELECT
         s.id,
         s.title,
@@ -1534,10 +1385,9 @@ export function searchSongs(
       LEFT JOIN song_categories sc ON s.category_id = sc.id
       WHERE songs_fts MATCH ? ${extraFilter}
       ORDER BY rank
-      LIMIT ${FTS_CANDIDATE_LIMIT}
-    `,
-      )
-      .all(...standardQueryParams) as Array<{
+      LIMIT ${limit}
+    `
+    type CandidateRow = {
       id: number
       title: string
       category_id: number | null
@@ -1549,7 +1399,21 @@ export function searchSongs(
       fts_title: string
       original_content: string
       bm25_rank: number
-    }>
+    }
+
+    // Phase 1a: titles first. An operator typing a title wants that song,
+    // so every title match is a candidate before the lyrics are looked at.
+    const titleResults = titleQuery
+      ? (db
+          .query(candidateSql(TITLE_CANDIDATE_LIMIT))
+          .all(titleQuery, ...categoryParams) as CandidateRow[])
+      : []
+    logger.debug(`Phase 1a (title): Found ${titleResults.length} results`)
+
+    // Phase 1b: Standard FTS5 search across title + content
+    const standardResults = db
+      .query(candidateSql(FTS_CANDIDATE_LIMIT))
+      .all(ftsQuery, ...categoryParams) as CandidateRow[]
 
     const phase1Elapsed = performance.now() - startTime
     logger.debug(
@@ -1558,7 +1422,10 @@ export function searchSongs(
 
     // Phase 2: Trigram search for fuzzy matches (use expanded terms)
     let phase2Elapsed = phase1Elapsed
-    const trigramQuery = buildTrigramQuery(expandedTerms)
+    const trigramQuery = buildTrigramQuery([
+      ...expandedTerms,
+      ...joinedVariants,
+    ])
     let trigramResults: Array<{
       id: number
       title: string
@@ -1626,9 +1493,11 @@ export function searchSongs(
       }
     >()
 
-    // Add standard results first
-    for (const r of standardResults) {
-      candidateMap.set(r.id, { ...r, fromTrigram: false })
+    // Title matches first, then the general results
+    for (const r of [...titleResults, ...standardResults]) {
+      if (!candidateMap.has(r.id)) {
+        candidateMap.set(r.id, { ...r, fromTrigram: false })
+      }
     }
 
     // Add trigram results (without overwriting standard results)
@@ -1659,6 +1528,13 @@ export function searchSongs(
     // never overlap.
     const TITLE_MATCH_THRESHOLD = 50
     const TITLE_BAND_OFFSET = 200
+    // The index carries every spelling of a word ("ne ncetat … nencetat
+    // neincetat"), so a title written "neîncetat" and one written
+    // "ne-ncetat" score the same for either query. The one spelled the way
+    // the operator typed it goes first.
+    const EXACT_SPELLING_BONUS = 2
+    const typedPhrase = validTerms.join(' ')
+    const scoringTermLists = buildScoringTermLists(query, validTerms)
     // Category priority is an unbounded, operator-editable integer. Used raw
     // as a multiplier it dwarfs every other signal — a weak lyric hit in a
     // priority-5 category outranked an exact title match in a priority-1 one.
@@ -1677,11 +1553,20 @@ export function searchSongs(
       // Synonyms broaden FTS recall — they should not be appended to the
       // queryTerms used for phrase / order detection or the joined exact
       // phrase will never match a real title.
-      const titleScore = calculateTitleScoreNormalized(r.fts_title, validTerms)
+      const baseTitleScore = Math.max(
+        ...scoringTermLists.map((terms) =>
+          calculateTitleScoreNormalized(r.fts_title, terms),
+        ),
+      )
+      const titleScore =
+        baseTitleScore > 0 && foldForScore(r.title).includes(typedPhrase)
+          ? baseTitleScore + EXACT_SPELLING_BONUS
+          : baseTitleScore
 
-      const contentScore = calculateBestPhraseScoreNormalized(
-        r.full_content,
-        validTerms,
+      const contentScore = Math.max(
+        ...scoringTermLists.map((terms) =>
+          calculateBestPhraseScoreNormalized(r.full_content, terms),
+        ),
       )
 
       // A real title match lands in the upper band; everything else keeps its

--- a/app/apps/server/src/service/songs/text/__tests__/text.test.ts
+++ b/app/apps/server/src/service/songs/text/__tests__/text.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, test } from 'bun:test'
+import { decodeHtmlEntities } from '../decodeHtmlEntities'
+import { elisionVariants } from '../elisionVariants'
+import { findHighlightRanges, wrapRanges } from '../findHighlightRanges'
+import { foldText } from '../foldText'
+import { joinedWordVariants } from '../joinedWordVariants'
+
+describe('decodeHtmlEntities', () => {
+  test('decodes the entities slide content is stored with', () => {
+    expect(
+      decodeHtmlEntities('Vin&#039; la Isus &amp; cântă &quot;da&quot;'),
+    ).toBe('Vin\' la Isus & cântă "da"')
+    expect(decodeHtmlEntities('a&#x27;b &nbsp;c')).toBe("a'b  c")
+  })
+})
+
+describe('joinedWordVariants', () => {
+  test('joins a hyphen or apostrophe word, with and without the elided î', () => {
+    expect(joinedWordVariants('ne-ncetat')).toEqual(['nencetat', 'neincetat'])
+    expect(joinedWordVariants("ne'ncetat")).toEqual(['nencetat', 'neincetat'])
+    expect(joinedWordVariants('ne’ncetat')).toEqual(['nencetat', 'neincetat'])
+    expect(joinedWordVariants('sa-nfaptuiesc')).toEqual([
+      'sanfaptuiesc',
+      'sainfaptuiesc',
+    ])
+    expect(joinedWordVariants('te-asteptam')).toEqual(['teasteptam'])
+    expect(joinedWordVariants('s-o-nvat')).toEqual(['sonvat', 'soinvat'])
+  })
+
+  test('ignores plain words, trailing punctuation and clitic contractions', () => {
+    expect(joinedWordVariants('isus')).toEqual([])
+    expect(joinedWordVariants('ne-ncetat,')).toEqual(['nencetat', 'neincetat'])
+    expect(joinedWordVariants('m-a')).toEqual([])
+    expect(joinedWordVariants('s-a')).toEqual([])
+    expect(joinedWordVariants('n-am')).toEqual([])
+    expect(joinedWordVariants('a-b.c')).toEqual([])
+  })
+})
+
+describe('elisionVariants', () => {
+  test('drops the î a clitic elides, or puts it back', () => {
+    expect(elisionVariants('neincetat')).toEqual(['nencetat'])
+    expect(elisionVariants('sainfaptuiesc')).toEqual(['sanfaptuiesc'])
+    expect(elisionVariants('teinconjoara')).toEqual(['tenconjoara'])
+    expect(elisionVariants('nencetat')).toEqual(['neincetat'])
+    expect(elisionVariants('sanfaptuiesc')).toEqual(['sainfaptuiesc'])
+  })
+
+  test('leaves ordinary words alone', () => {
+    expect(elisionVariants('inima')).toEqual([])
+    expect(elisionVariants('cainta')).toEqual([])
+    expect(elisionVariants('painea')).toEqual([])
+    expect(elisionVariants('sfinte')).toEqual([])
+    expect(elisionVariants('cuvinte')).toEqual([])
+    expect(elisionVariants('pentru')).toEqual([])
+    expect(elisionVariants('tine')).toEqual([])
+    expect(elisionVariants('binecuvantare')).toEqual([])
+  })
+})
+
+describe('foldText', () => {
+  test('folds diacritics, entities and punctuation, mapping back to the original', () => {
+    const text = 'Închină–te Lui &#039;ici, pe pământ'
+    const dropped = foldText(text, { dropJoiners: true })
+    expect(dropped.folded).toBe('inchinate lui ici pe pamant')
+    const kept = foldText(text, { dropJoiners: false })
+    expect(kept.folded).toBe('inchina–te lui ici pe pamant')
+
+    // "inchinate" spans the original "Închină–te", dash included.
+    const pos = dropped.folded.indexOf('inchinate')
+    expect(text.slice(dropped.starts[pos], dropped.ends[pos + 8])).toBe(
+      'Închină–te',
+    )
+  })
+
+  test('a joiner between letters folds away; elsewhere it separates', () => {
+    expect(foldText('ne&#039;ncetat', { dropJoiners: true }).folded).toBe(
+      'nencetat',
+    )
+    expect(foldText("- ne'ncetat -", { dropJoiners: true }).folded).toBe(
+      'nencetat',
+    )
+  })
+})
+
+describe('findHighlightRanges — one word, every spelling', () => {
+  const mark = (text: string, terms: string[], rawQuery: string) =>
+    wrapRanges(text, findHighlightRanges(text, terms, { rawQuery }))
+
+  test('"ne-ncetat" typed marks the whole word however it is written', () => {
+    const terms = ['ne', 'ncetat']
+    expect(mark('Doamne ne-ncetat Te lăudăm', terms, 'ne-ncetat')).toBe(
+      'Doamne <mark>ne-ncetat</mark> Te lăudăm',
+    )
+    expect(mark("Isuse, ne'ncetat privirea", terms, 'ne-ncetat')).toBe(
+      "Isuse, <mark>ne'ncetat</mark> privirea",
+    )
+    expect(mark('Isuse, ne&#039;ncetat privirea', terms, 'ne-ncetat')).toBe(
+      'Isuse, <mark>ne&#039;ncetat</mark> privirea',
+    )
+    expect(mark('Spune-ți nencetat la toți', terms, 'ne-ncetat')).toBe(
+      'Spune-ți <mark>nencetat</mark> la toți',
+    )
+    expect(mark('Te lăudăm neîncetat', terms, 'ne-ncetat')).toBe(
+      'Te lăudăm <mark>neîncetat</mark>',
+    )
+  })
+
+  test('"neîncetat" typed lights up the hyphenated spelling too', () => {
+    expect(mark('Doamne ne-ncetat Te lăudăm', ['neincetat'], 'neîncetat')).toBe(
+      'Doamne <mark>ne-ncetat</mark> Te lăudăm',
+    )
+    expect(mark('Spune-ți nencetat la toți', ['neincetat'], 'neincetat')).toBe(
+      'Spune-ți <mark>nencetat</mark> la toți',
+    )
+  })
+
+  test('a phrase with a hyphen word marks the phrase, sign included', () => {
+    expect(
+      mark(
+        'Te lăudăm neîncetat',
+        ['laudam', 'ne', 'ncetat'],
+        'laudam ne-ncetat',
+      ),
+    ).toBe('Te <mark>lăudăm neîncetat</mark>')
+    expect(
+      mark('Sa ne speli de-orice pacat', ['de', 'orice'], 'de orice'),
+    ).toBe('Sa ne speli <mark>de-orice</mark> pacat')
+  })
+
+  test('a hyphen word also lights up its two-word spelling with the î kept', () => {
+    expect(
+      mark('Numai bine să înfăptuiesc', ['sa', 'nfaptuiesc'], 'sa-nfaptuiesc'),
+    ).toBe('Numai bine <mark>să înfăptuiesc</mark>')
+  })
+
+  test('partial typing of a hyphen word still marks from the start of the word', () => {
+    expect(mark('Te lăudăm neîncetat', ['ne', 'nc'], 'ne-nc')).toBe(
+      'Te lăudăm <mark>neînc</mark>etat',
+    )
+  })
+})

--- a/app/apps/server/src/service/songs/text/decodeHtmlEntities.ts
+++ b/app/apps/server/src/service/songs/text/decodeHtmlEntities.ts
@@ -1,0 +1,34 @@
+const NAMED: Record<string, string> = {
+  amp: '&',
+  lt: '<',
+  gt: '>',
+  quot: '"',
+  apos: "'",
+  nbsp: ' ',
+}
+
+const ENTITY_SOURCE = '&(#x[0-9a-f]+|#\\d+|amp|lt|gt|quot|apos|nbsp);'
+export const HTML_ENTITY_RE = new RegExp(ENTITY_SOURCE, 'giu')
+/** Matches an entity only at the very start of the string it is run on. */
+export const LEADING_HTML_ENTITY_RE = new RegExp(`^${ENTITY_SOURCE}`, 'iu')
+
+/** Decodes one entity match (e.g. `&#039;`, `&amp;`) to its character. */
+export function decodeHtmlEntity(entity: string): string {
+  const body = entity.slice(1, -1).toLowerCase()
+  if (body.startsWith('#x')) {
+    return String.fromCodePoint(Number.parseInt(body.slice(2), 16))
+  }
+  if (body.startsWith('#')) {
+    return String.fromCodePoint(Number.parseInt(body.slice(1), 10))
+  }
+  return NAMED[body] ?? entity
+}
+
+/**
+ * Slide content is stored HTML-escaped, so an apostrophe arrives as
+ * `&#039;`. Left as-is it tokenises into a stray "039" that splits phrases
+ * ("ne&#039;ncetat" → "ne 039 ncetat"); decode before normalising.
+ */
+export function decodeHtmlEntities(text: string): string {
+  return text.replace(HTML_ENTITY_RE, (entity) => decodeHtmlEntity(entity))
+}

--- a/app/apps/server/src/service/songs/text/elisionVariants.ts
+++ b/app/apps/server/src/service/songs/text/elisionVariants.ts
@@ -13,10 +13,12 @@
  * Input is expected to be diacritic-free and lowercase.
  */
 export function elisionVariants(word: string): string[] {
-  const withI = word.match(/^(\p{L}?[aeiou])in(?=[^aeiou])(\p{L}{3,})$/u)
+  // The tail must be a consonant followed by at least three more letters —
+  // short tails ("pentru", "cainta") are ordinary words, not contractions.
+  const withI = word.match(/^(\p{L}?[aeiou])in(?=[^aeiou])(\p{L}{4,})$/u)
   if (withI) return [`${withI[1]}n${withI[2]}`]
 
-  const withoutI = word.match(/^(\p{L}?[aeiou])n(?=[^aeiou])(\p{L}{3,})$/u)
+  const withoutI = word.match(/^(\p{L}?[aeiou])n(?=[^aeiou])(\p{L}{4,})$/u)
   if (withoutI) return [`${withoutI[1]}in${withoutI[2]}`]
 
   return []

--- a/app/apps/server/src/service/songs/text/elisionVariants.ts
+++ b/app/apps/server/src/service/songs/text/elisionVariants.ts
@@ -1,0 +1,23 @@
+/**
+ * The spellings of a word that differ by an elided "î". In Romanian songs a
+ * short clitic (1–2 letters, vowel-final) swallows the "î" of the word it
+ * leans on — "ne încetat" is sung and written "ne-ncetat", "nencetat" or,
+ * with the vowel kept, "neîncetat" — so whichever one the operator types,
+ * the other one is searched too:
+ *
+ *   "neincetat" → ["nencetat"]     (drop the elided î)
+ *   "nencetat"  → ["neincetat"]    (put it back)
+ *   "cainta"    → []               (the tail is too short to be a word)
+ *   "inima"     → []               (no clitic in front)
+ *
+ * Input is expected to be diacritic-free and lowercase.
+ */
+export function elisionVariants(word: string): string[] {
+  const withI = word.match(/^(\p{L}?[aeiou])in(?=[^aeiou])(\p{L}{3,})$/u)
+  if (withI) return [`${withI[1]}n${withI[2]}`]
+
+  const withoutI = word.match(/^(\p{L}?[aeiou])n(?=[^aeiou])(\p{L}{3,})$/u)
+  if (withoutI) return [`${withoutI[1]}in${withoutI[2]}`]
+
+  return []
+}

--- a/app/apps/server/src/service/songs/text/findHighlightRanges.ts
+++ b/app/apps/server/src/service/songs/text/findHighlightRanges.ts
@@ -1,0 +1,266 @@
+import { elisionVariants } from './elisionVariants'
+import { foldText } from './foldText'
+import { joinedWordVariants, WORD_JOINERS } from './joinedWordVariants'
+
+export interface TextRange {
+  start: number
+  end: number
+}
+
+export interface FindHighlightRangesOptions {
+  /** The query as the user typed it; tried first as a literal phrase. */
+  rawQuery?: string
+  /**
+   * Also mark a word that merely contains the middle of a long term — a
+   * loose net for the content snippet ("Hristos" lighting up "Cristos").
+   */
+  fuzzy?: boolean
+}
+
+function removeDiacritics(text: string): string {
+  return text.normalize('NFD').replace(/[\u0300-\u036f]/g, '')
+}
+
+function escapeRegExp(text: string): string {
+  return text.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+const JOINER_SPLIT_RE = new RegExp(`[${WORD_JOINERS}]+`, 'u')
+
+/**
+ * Normalises the raw user query into the literal phrase looked for as a
+ * substring of the text. Strips the leading hymn-number prefix (mirrors
+ * extractSearchTerms), removes diacritics, lowercases and collapses
+ * whitespace. Keeps internal hyphens so incremental typing like
+ * "Cand Isus Hristos m" → "m-" → "m-a" widens the mark one character at a
+ * time.
+ */
+function cleanQueryForHighlight(rawQuery: string): string {
+  return removeDiacritics(rawQuery)
+    .replace(/^\s*\d+[.\-]?\s+/, '')
+    .toLowerCase()
+    .replace(/\s+/g, ' ')
+    .trim()
+}
+
+/**
+ * Returns true if the gap between two highlight ranges should be swallowed
+ * into a single merged range — pure whitespace, a hyphen, or a short
+ * Romanian clitic contraction (e.g. "m-a", "te-a", "ne-am", "s-a", "n-am").
+ * Plain words like "a" or "este" between two matches stay un-merged so we
+ * don't blob everything together.
+ */
+function isMergeableGap(gap: string): boolean {
+  const trimmed = gap.trim()
+  if (trimmed === '') return true
+  return (
+    trimmed.length <= 6 && trimmed.includes('-') && /^[\p{L}-]+$/u.test(trimmed)
+  )
+}
+
+function mergeRanges(text: string, ranges: TextRange[]): TextRange[] {
+  const sorted = [...ranges].sort((a, b) => a.start - b.start || a.end - b.end)
+  const merged: TextRange[] = []
+  for (const range of sorted) {
+    const last = merged[merged.length - 1]
+    if (last && range.start <= last.end) {
+      last.end = Math.max(last.end, range.end)
+    } else if (last && isMergeableGap(text.slice(last.end, range.start))) {
+      last.end = Math.max(last.end, range.end)
+    } else {
+      merged.push({ ...range })
+    }
+  }
+  return merged
+}
+
+/** The other spellings of one query word, beyond its own joined form. */
+function spellingVariants(word: string): string[] {
+  return [...joinedWordVariants(word), ...elisionVariants(word)]
+}
+
+/**
+ * A hyphen word whose second piece elides "î" may be written as two words
+ * with the vowel kept: "să-nfăptuiesc" → "să înfăptuiesc". Folded: "sa
+ * infaptuiesc". Only meaningful as a phrase, so only the highlighter uses it.
+ */
+function spacedElisionForm(word: string): string | null {
+  const parts = word.split(JOINER_SPLIT_RE).filter((part) => part.length > 0)
+  const at = parts.findIndex(
+    (part, index) => index > 0 && /^n[^aeiou]/u.test(part),
+  )
+  if (at === -1) return null
+  return `${parts.slice(0, at).join('')} i${parts.slice(at).join('')}`
+}
+
+/** Every spelling of one query word that should light up the same text. */
+function wordAlternatives(word: string): string[] {
+  const joined = word.replace(JOINER_SPLIT_RE, '')
+  const alternatives = new Set<string>([joined, ...spellingVariants(word)])
+  const spaced = spacedElisionForm(word)
+  if (spaced) alternatives.add(spaced)
+  alternatives.delete('')
+  return Array.from(alternatives)
+}
+
+/**
+ * The literal user query as a substring of the diacritic-folded text.
+ * removeDiacritics + toLowerCase preserve character count for the Romanian
+ * alphabet, so positions map 1:1 back to the original.
+ */
+function findLiteralPhrase(text: string, rawQuery: string): TextRange | null {
+  const cleaned = cleanQueryForHighlight(rawQuery)
+  if (cleaned.length === 0) return null
+  const pos = removeDiacritics(text).toLowerCase().indexOf(cleaned)
+  if (pos === -1) return null
+  return { start: pos, end: pos + cleaned.length }
+}
+
+/**
+ * The whole query as a phrase in the joiner-dropped fold, each word in any
+ * of its spellings — so "ne-ncetat" lands on "ne'ncetat", "nencetat" and
+ * "neîncetat" alike, and the mark covers the whole word including the
+ * hyphen or apostrophe.
+ */
+function findFoldedPhrase(text: string, rawQuery: string): TextRange | null {
+  const words = cleanQueryForHighlight(rawQuery)
+    .split(/\s+/)
+    .map((word) => word.replace(/^[^\p{L}\p{N}]+|[^\p{L}\p{N}]+$/gu, ''))
+    .filter((word) => word.length > 0)
+  if (words.length === 0) return null
+
+  const folded = foldText(text, { dropJoiners: true })
+  const pattern = words
+    .map((word) => `(?:${wordAlternatives(word).map(escapeRegExp).join('|')})`)
+    .join(' ')
+  const match = new RegExp(pattern, 'u').exec(folded.folded)
+  if (!match || match[0].length === 0) return null
+  return {
+    start: folded.starts[match.index],
+    end: folded.ends[match.index + match[0].length - 1],
+  }
+}
+
+/**
+ * Finds the word containing a fuzzy substring match
+ * Returns the full word that contains the matching substring
+ */
+function findFuzzyMatchWord(
+  content: string,
+  term: string,
+): { word: string; index: number } | null {
+  if (term.length < 5) return null
+
+  const words = content.match(/[\p{L}\p{N}]+/gu) || []
+
+  for (let len = Math.min(5, term.length - 1); len >= 4; len--) {
+    for (let start = 1; start <= term.length - len; start++) {
+      const sub = term.substring(start, start + len).toLowerCase()
+      for (const word of words) {
+        if (word.toLowerCase().includes(sub)) {
+          const index = content.toLowerCase().indexOf(word.toLowerCase())
+          return { word, index }
+        }
+      }
+    }
+  }
+
+  return null
+}
+
+/**
+ * Where the search terms appear in `text`, as ranges of the ORIGINAL string
+ * (diacritics, entities and punctuation intact) ready to be wrapped in
+ * <mark>. Title and snippet share this so they always agree.
+ *
+ * 1. The typed query as a literal substring — while typing, the mark grows
+ *    one character at a time and matches exactly what was typed.
+ * 2. The typed query as a phrase, punctuation-blind and across spellings.
+ * 3. Per-term marks, merged across whitespace and clitic gaps.
+ */
+export function findHighlightRanges(
+  text: string,
+  terms: string[],
+  options: FindHighlightRangesOptions = {},
+): TextRange[] {
+  const { rawQuery, fuzzy = false } = options
+
+  if (rawQuery !== undefined && rawQuery.length > 0) {
+    const literal = findLiteralPhrase(text, rawQuery)
+    if (literal) return [literal]
+    const phrase = findFoldedPhrase(text, rawQuery)
+    if (phrase) return [phrase]
+  }
+
+  const ranges: TextRange[] = []
+
+  // Plain terms in the joiner-preserving fold, so short terms stay
+  // word-bounded ("am" marks "am" inside "m-am", not half the corpus).
+  const kept = foldText(text, { dropJoiners: false })
+  for (const term of terms) {
+    const folded = removeDiacritics(term).toLowerCase().trim()
+    if (folded.length === 0) continue
+    const escaped = escapeRegExp(folded)
+    const pattern =
+      folded.length <= 2
+        ? new RegExp(`(?<![\\p{L}\\p{N}])${escaped}(?![\\p{L}\\p{N}])`, 'gu')
+        : new RegExp(escaped, 'gu')
+    let match: RegExpExecArray | null
+    while ((match = pattern.exec(kept.folded)) !== null) {
+      if (match[0].length === 0) {
+        pattern.lastIndex++
+        continue
+      }
+      ranges.push({
+        start: kept.starts[match.index],
+        end: kept.ends[match.index + match[0].length - 1],
+      })
+    }
+  }
+
+  // The other spellings of each typed word, against the joiner-dropped fold
+  // so the whole word — sign included — is marked: "ne-ncetat" lights up
+  // "ne'ncetat" and "neîncetat", and "neîncetat" lights up "ne-ncetat".
+  if (rawQuery !== undefined && rawQuery.length > 0) {
+    const dropped = foldText(text, { dropJoiners: true })
+    for (const word of cleanQueryForHighlight(rawQuery).split(/\s+/)) {
+      for (const variant of spellingVariants(word)) {
+        let pos = dropped.folded.indexOf(variant)
+        while (pos !== -1) {
+          ranges.push({
+            start: dropped.starts[pos],
+            end: dropped.ends[pos + variant.length - 1],
+          })
+          pos = dropped.folded.indexOf(variant, pos + 1)
+        }
+      }
+    }
+  }
+
+  if (fuzzy) {
+    for (const term of terms) {
+      const found = findFuzzyMatchWord(text, term)
+      if (found && !ranges.some((range) => range.start === found.index)) {
+        ranges.push({
+          start: found.index,
+          end: found.index + found.word.length,
+        })
+      }
+    }
+  }
+
+  if (ranges.length === 0) return []
+  return mergeRanges(text, ranges)
+}
+
+/** Wraps each range in <mark>, leaving the rest of the text untouched. */
+export function wrapRanges(text: string, ranges: TextRange[]): string {
+  let out = ''
+  let cursor = 0
+  for (const range of ranges) {
+    out += text.slice(cursor, range.start)
+    out += `<mark>${text.slice(range.start, range.end)}</mark>`
+    cursor = range.end
+  }
+  return out + text.slice(cursor)
+}

--- a/app/apps/server/src/service/songs/text/foldText.ts
+++ b/app/apps/server/src/service/songs/text/foldText.ts
@@ -1,0 +1,116 @@
+import { decodeHtmlEntity, LEADING_HTML_ENTITY_RE } from './decodeHtmlEntities'
+import { WORD_JOINERS } from './joinedWordVariants'
+
+const JOINER_CHAR_RE = new RegExp(`^[${WORD_JOINERS}]$`, 'u')
+const WORD_CHAR_RE = /^[\p{L}\p{N}]$/u
+
+export interface FoldedText {
+  /** Lowercase, diacritic-free, entity-decoded text with punctuation as spaces. */
+  folded: string
+  /** For each folded index, where that character starts in the original. */
+  starts: number[]
+  /** For each folded index, where that character ends (exclusive) in the original. */
+  ends: number[]
+}
+
+export interface FoldOptions {
+  /**
+   * Drop hyphens/apostrophes that sit between letters, so "ne-ncetat" and
+   * "ne&#039;ncetat" both fold to "nencetat". Off, they are kept as-is so
+   * word boundaries inside "m-am" still exist.
+   */
+  dropJoiners: boolean
+}
+
+function foldChar(char: string): string {
+  return char
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+}
+
+/**
+ * Folds text for matching while remembering where every folded character
+ * came from, so a match found in the folded string can be mapped back to
+ * the exact span of the original — entities, diacritics, joiners and all.
+ */
+export function foldText(text: string, options: FoldOptions): FoldedText {
+  const folded: string[] = []
+  const starts: number[] = []
+  const ends: number[] = []
+
+  let i = 0
+  while (i < text.length) {
+    let char: string
+    let length: number
+    if (text[i] === '&') {
+      const entity = text.slice(i).match(LEADING_HTML_ENTITY_RE)
+      if (entity) {
+        char = decodeHtmlEntity(entity[0])
+        length = entity[0].length
+      } else {
+        char = '&'
+        length = 1
+      }
+    } else {
+      const codePoint = text.codePointAt(i) ?? 0
+      char = String.fromCodePoint(codePoint)
+      length = char.length
+    }
+
+    const start = i
+    const end = i + length
+    i = end
+
+    const lowered = foldChar(char)
+    const isWord = WORD_CHAR_RE.test(lowered)
+    const isJoiner = JOINER_CHAR_RE.test(lowered)
+
+    if (isWord) {
+      folded.push(lowered)
+      starts.push(start)
+      ends.push(end)
+      continue
+    }
+
+    if (isJoiner) {
+      const previous = folded[folded.length - 1]
+      const betweenLetters =
+        previous !== undefined &&
+        WORD_CHAR_RE.test(previous) &&
+        WORD_CHAR_RE.test(foldChar(nextChar(text, end)))
+      if (betweenLetters) {
+        if (options.dropJoiners) continue
+        folded.push(lowered)
+        starts.push(start)
+        ends.push(end)
+        continue
+      }
+    }
+
+    // Everything else separates words; runs collapse into one space.
+    if (folded.length > 0 && folded[folded.length - 1] !== ' ') {
+      folded.push(' ')
+      starts.push(start)
+      ends.push(end)
+    }
+  }
+
+  // A trailing separator carries nothing.
+  if (folded[folded.length - 1] === ' ') {
+    folded.pop()
+    starts.pop()
+    ends.pop()
+  }
+
+  return { folded: folded.join(''), starts, ends }
+}
+
+function nextChar(text: string, at: number): string {
+  if (at >= text.length) return ''
+  if (text[at] === '&') {
+    const entity = text.slice(at).match(LEADING_HTML_ENTITY_RE)
+    if (entity) return decodeHtmlEntity(entity[0])
+  }
+  return String.fromCodePoint(text.codePointAt(at) ?? 0)
+}

--- a/app/apps/server/src/service/songs/text/joinedWordVariants.ts
+++ b/app/apps/server/src/service/songs/text/joinedWordVariants.ts
@@ -1,0 +1,42 @@
+/**
+ * Characters that glue two word pieces together inside one Romanian word:
+ * the hyphen family and the apostrophe family. "ne-ncetat", "ne'ncetat" and
+ * "ne’ncetat" are all the same word as "nencetat" (and, with the elided "î"
+ * restored, "neîncetat").
+ */
+export const WORD_JOINERS =
+  "\\-\u2010\u2011\u2012\u2013\u2014'\u2019\u2018\u02BC`\u00B4"
+const JOINER_RE = new RegExp(`[${WORD_JOINERS}]+`, 'u')
+const OUTER_PUNCT_RE = /^[^\p{L}\p{N}]+|[^\p{L}\p{N}]+$/gu
+
+/**
+ * The joined spellings of a word written with a hyphen or apostrophe, so
+ * every way the same word is written in a songbook finds the others:
+ *
+ *   "ne-ncetat"  → ["nencetat", "neincetat"]
+ *   "te-asteptam" → ["teasteptam"]
+ *   "s-a"         → ["sa"]
+ *
+ * A piece that starts with "n" + consonant is the elided "în…" ("ne-ncetat"
+ * is "ne încetat"), so that spelling is produced too. Input is expected to
+ * be diacritic-free and lowercase; plain words yield nothing, and neither do
+ * the shortest clitic contractions ("m-a", "s-a", "n-am") — joined, those
+ * are just other common words ("ma", "sa") and would only add noise.
+ */
+export function joinedWordVariants(word: string): string[] {
+  const core = word.replace(OUTER_PUNCT_RE, '')
+  const parts = core.split(JOINER_RE).filter((part) => part.length > 0)
+  if (parts.length < 2) return []
+  if (!parts.every((part) => /^[\p{L}\p{N}]+$/u.test(part))) return []
+  if (parts.join('').length < 4) return []
+
+  const variants = new Set<string>()
+  variants.add(parts.join(''))
+
+  const withElidedI = parts.map((part, index) =>
+    index > 0 && /^n[^aeiou]/iu.test(part) ? `i${part}` : part,
+  )
+  variants.add(withElidedI.join(''))
+
+  return Array.from(variants)
+}


### PR DESCRIPTION
## Summary

Three operator-facing problems, two features:

### 1. "A new version is available" did not look like the rest of the app
The update page now presents the new version with the same `VersionNotesCard` the release-notes history uses — version, a "New" badge and the publish date, then New / Fixed / Changed grouped with their scopes — with the download / progress / install controls in the card's footer. Settings → About no longer offers a browser download; it links to the updates page where the in-app flow lives.

### 2. "Download failed — check your connection" on a machine that was online
Root causes, all fixed:
- The sidecar kept the last failure in memory for as long as it ran, so a download that failed hours earlier (sleep, a real outage, a GitHub blip) greeted the operator as a fresh error on every later visit. A failure is now dismissed once the page that showed it is left (`POST /api/app-update/cancel` clears an error state).
- A status poll already in flight when Download was pressed could land after the "downloading" answer and overwrite it with the stale idle/error it set out to read — which stopped the polling and left the old error on screen while the download actually ran. The mutation now cancels the in-flight query first.
- Every failure was reported with the same "check the folder and your connection" text. The sidecar now classifies failures (`network` / `http` / `filesystem` / `unknown`, exposed as `errorCode` in the status payload and OpenAPI) and the panel explains each in plain words with the raw error underneath; the button becomes "Try again".
- Transient failures (connection dropped, 5xx/429 from GitHub's CDN) are retried up to three times with a short pause before being reported at all.
- The finished installer is produced by an atomic `rename` of the `.part` file instead of copy + delete.

Also: when the release-notes list has not reached GitHub yet (or was rate-limited), the release body the update check already fetched is parsed with the same parser, so the card never falls back to "no notable changes". Dead code removed (`openDownloadUrl` / `downloadUpdate`, unused i18n keys); Romanian strings for the updates section gained diacritics.

### 3. Song search: "ne-ncetat" found only songs that wrote it with a hyphen
Songbooks also write it `ne'ncetat`, `nencetat` and `neîncetat`; those stayed invisible, as did anything typed the other way round. And slide content is stored HTML-escaped, so an apostrophe sat in the index as a stray `039` (`ne 039 ncetat`) that split phrases in **3,020 of the 25,800** indexed songs.

- **Index**: entities are decoded; every hyphen/apostrophe word is also indexed in its joined spellings (`nencetat`, and with the elided "î" put back, `neincetat`), appended after the text so phrase order stays intact. The FTS rebuild migration key is bumped so existing databases re-index once on next boot (~4 s for 25,800 songs).
- **Query**: the same spellings are produced for whatever the operator typed, in both directions (`neîncetat` → `nencetat`), and searched as their own tier. Apostrophes now separate exactly as hyphens do.
- **Titles first, as a rule**: a dedicated FTS query on the title column runs before the general one, so every song whose title matches is a candidate no matter how many songs merely sing the words — before, a few hundred lyric phrase matches pushed *Te lăudăm neîncetat* out of the candidate cut for `ne-ncetat`. Scoring takes the best over the typed terms and each spelling swapped in, with a small bonus for the spelling actually typed.
- **Highlight covers the whole word, sign included**: highlighting is rebuilt on a folded copy of the text that remembers where every character came from (entities, diacritics, joiners), so `ne-ncetat` typed marks the whole `ne'ncetat`, `ne&#039;ncetat` or `neîncetat`, and `să-nfăptuiesc` lights up `să înfăptuiesc`. Title and snippet share one range finder. Literal typing still wins: `Cand Isus Hristos m` → `m-` → `m-a` widens one character at a time.
- Latency on the 25,800-song library stays in the same range (30–140 ms uncached; the one multi-word phrase query that was 200 ms is unchanged).

## Test plan

- [x] `bun test` (server, 301 pass): download retry/classification/dismiss against a scripted local server; `text/` helpers (entity decode, joined/elision variants, fold map, highlight ranges); search index/query/title-query/scoring-lists; all pre-existing search tests unchanged and green.
- [x] `vitest` (client, 1046 pass): `UpdatePanel` body fallback, network-vs-folder wording, "Try again", dismiss-on-unmount.
- [x] Playwright e2e: mocked GitHub release renders the structured card with no markdown leaking; API `errorCode: network` + dismiss; **new** `search-diacritics.spec.ts` case creating four songs spelled `ne-ncezat` / `ne'ncezat` / `nencezat` / `neîncezat` — each of the four queries finds all four, the three title matches precede the lyrics-only one, and the marks cover the sign.
- [x] Manual probe against a copy of the real 25,800-song library: `ne-ncetat`, `neincetat`, `nencetat`, `ne'ncetat`, `laudam ne-ncetat`, `sa-nfaptuiesc`, `vin' la isus`, `cand isus hristos m-a mantuit`.
- [ ] On an installed build: trigger a download with Wi‑Fi off → network message with reason; Wi‑Fi on → "Try again" succeeds; leave and return → no stale error.
