### PR TITLE
app-update: native progress window for the install, and the app actually comes back

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -313,6 +313,15 @@ jobs:
         shell: bash
         run: bun test src/__tests__/compiled-sidecar.test.ts
 
+      # The update installer helpers are scripts run by osascript / Windows
+      # PowerShell after the app has quit; nothing else executes them. Each
+      # platform's own parser at least vouches for the generated syntax.
+      - name: Parse the generated update-installer helpers
+        if: matrix.os != 'ubuntu-latest'
+        working-directory: app/apps/server
+        shell: bash
+        run: bun test src/service/app-update/__tests__/helper-syntax.test.ts
+
       - name: Upload compiled binary on failure
         if: failure()
         uses: actions/upload-artifact@v5

--- a/app/apps/client/src/features/app-update/components/UpdatePanel.tsx
+++ b/app/apps/client/src/features/app-update/components/UpdatePanel.tsx
@@ -243,7 +243,24 @@ export function UpdatePanel() {
                 <button
                   type="button"
                   onClick={() => {
-                    void install().then((result) => {
+                    const labels = {
+                      title: t('sections.updates.installer.title'),
+                      closing: t('sections.updates.installer.closing'),
+                      installing: t('sections.updates.installer.installing', {
+                        version,
+                      }),
+                      launching: t('sections.updates.installer.launching'),
+                      hint: t('sections.updates.installer.hint'),
+                      failed: t('sections.updates.installer.failed', {
+                        // Left for the installer to fill in.
+                        reason: '{{reason}}',
+                        interpolation: { escapeValue: false },
+                      }),
+                      openManually: t(
+                        'sections.updates.installer.openManually',
+                      ),
+                    }
+                    void install(labels).then((result) => {
                       if (!result.success) {
                         showToast(
                           t('sections.updates.available.installFailed', {

--- a/app/apps/client/src/features/app-update/hooks/useUpdateDownload.ts
+++ b/app/apps/client/src/features/app-update/hooks/useUpdateDownload.ts
@@ -8,6 +8,7 @@ import {
   installUpdate,
   startUpdateDownload,
   type UpdateDownloadState,
+  type UpdateInstallerLabels,
 } from '../services/updateDownloadService'
 
 const STATUS_KEY = ['app-update', 'download-status']
@@ -69,8 +70,8 @@ export function useUpdateDownload(
    * to disappear before it replaces anything, then relaunches — so from the
    * operator's side the app simply restarts on the new version.
    */
-  const install = useCallback(async () => {
-    const result = await installUpdate()
+  const install = useCallback(async (labels: UpdateInstallerLabels) => {
+    const result = await installUpdate(labels)
     if (!result.success) return result
 
     if (isTauri()) {

--- a/app/apps/client/src/features/app-update/services/updateDownloadService.ts
+++ b/app/apps/client/src/features/app-update/services/updateDownloadService.ts
@@ -108,13 +108,32 @@ export async function cancelUpdateDownload(): Promise<void> {
  * the sidecar to exit — which happens when the app quits — before it replaces
  * anything, so nothing is swapped from under a running app.
  */
-export async function installUpdate(): Promise<{
+/**
+ * What the installer window says. It runs after the app has quit, so the
+ * texts travel with the request instead of being looked up there.
+ */
+export interface UpdateInstallerLabels {
+  title: string
+  closing: string
+  installing: string
+  launching: string
+  hint: string
+  /** May contain `{{reason}}`, filled in by the installer. */
+  failed: string
+  openManually: string
+}
+
+export async function installUpdate(labels: UpdateInstallerLabels): Promise<{
   success: boolean
   error?: string
 }> {
   const res = await fetcher<ApiResponse<{ success: boolean }>>(
     '/api/app-update/install',
-    { method: 'POST' },
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ labels }),
+    },
   )
   if (res.error) return { success: false, error: res.error }
   return { success: true }

--- a/app/apps/client/src/i18n/locales/en/settings.json
+++ b/app/apps/client/src/i18n/locales/en/settings.json
@@ -1245,6 +1245,15 @@
           "filesystem": "The installer could not be saved to the download folder. Choose another folder below and try again.",
           "unknown": "The download failed."
         }
+      },
+      "installer": {
+        "title": "Church Hub",
+        "closing": "Closing the app…",
+        "installing": "Installing version {{version}}…",
+        "launching": "Starting the new version…",
+        "hint": "The app reopens by itself when this is done.",
+        "failed": "The update could not be installed: {{reason}}",
+        "openManually": "Open Church Hub yourself; the downloaded installer is in the downloads folder."
       }
     },
     "about": {

--- a/app/apps/client/src/i18n/locales/ro/settings.json
+++ b/app/apps/client/src/i18n/locales/ro/settings.json
@@ -1247,6 +1247,15 @@
           "filesystem": "Programul de instalare nu a putut fi salvat în folderul de descărcare. Alege alt folder mai jos și încearcă din nou.",
           "unknown": "Descărcarea a eșuat."
         }
+      },
+      "installer": {
+        "title": "Church Hub",
+        "closing": "Se închide aplicația…",
+        "installing": "Se instalează versiunea {{version}}…",
+        "launching": "Se pornește noua versiune…",
+        "hint": "Aplicația se redeschide singură când e gata.",
+        "failed": "Actualizarea nu a putut fi instalată: {{reason}}",
+        "openManually": "Deschide Church Hub manual; programul de instalare descărcat este în folderul de descărcări."
       }
     },
     "about": {

--- a/app/apps/server/src/index.ts
+++ b/app/apps/server/src/index.ts
@@ -2147,7 +2147,21 @@ async function startRealServer(): Promise<void> {
           )
         }
 
-        const result = await installUpdate(current.filePath)
+        // The installer window runs after the app has quit, so the client
+        // hands over what it should say, in the operator's language.
+        let labels: Record<string, string> = {}
+        try {
+          const body = (await req.json()) as { labels?: Record<string, string> }
+          labels = body.labels ?? {}
+        } catch {
+          // No body: the helper falls back to its English texts.
+        }
+
+        const result = await installUpdate(
+          current.filePath,
+          current.version ?? '',
+          labels,
+        )
         return handleCors(
           req,
           new Response(

--- a/app/apps/server/src/openapi/paths/app-update.ts
+++ b/app/apps/server/src/openapi/paths/app-update.ts
@@ -195,7 +195,36 @@ export const appUpdatePaths: Record<string, Record<string, unknown>> = {
       tags: ['App update'],
       summary: 'Install the downloaded artifact',
       description:
-        'Starts a detached helper that waits for the app to quit, installs without any prompts (bundle swap on macOS, silent NSIS on Windows) and relaunches. User data is untouched: the database lives in the per-user data directory and migrations run on the next boot. Requires settings.edit.',
+        'Starts a detached helper with a native progress window that waits for the app to quit (terminating it after a grace period if it does not), installs without any prompts (bundle swap on macOS, silent NSIS on Windows), relaunches the app, and logs to church-hub-update.log in the data directory. User data is untouched: the database lives in the per-user data directory and migrations run on the next boot. Requires settings.edit.',
+      requestBody: {
+        required: false,
+        content: {
+          'application/json': {
+            schema: {
+              type: 'object',
+              properties: {
+                labels: {
+                  type: 'object',
+                  description:
+                    "What the installer window says, in the operator's language; English defaults otherwise",
+                  properties: {
+                    title: { type: 'string' },
+                    closing: { type: 'string' },
+                    installing: { type: 'string' },
+                    launching: { type: 'string' },
+                    hint: { type: 'string' },
+                    failed: {
+                      type: 'string',
+                      description: 'May contain {{reason}}',
+                    },
+                    openManually: { type: 'string' },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
       responses: {
         '200': {
           description: 'Installer started; the caller should now quit the app',

--- a/app/apps/server/src/service/app-update/__tests__/helper-syntax.test.ts
+++ b/app/apps/server/src/service/app-update/__tests__/helper-syntax.test.ts
@@ -1,0 +1,85 @@
+import { execFileSync } from 'node:child_process'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { describe, expect, test } from 'bun:test'
+import { buildMacUpdater } from '../buildMacUpdater'
+import { buildWindowsUpdater } from '../buildWindowsUpdater'
+import type { UpdateInstallerLabels } from '../types'
+
+/**
+ * The generated helpers are run by osascript / Windows PowerShell, not by
+ * anything this test suite can execute — but each platform's own parser can
+ * at least vouch for the syntax. Runs where the tool exists (macOS, Windows)
+ * and is skipped elsewhere.
+ */
+
+const labels: UpdateInstallerLabels = {
+  title: 'Church Hub',
+  closing: 'Se închide aplicația…',
+  installing: 'Se instalează versiunea 9.9.9…',
+  launching: 'Se pornește noua versiune…',
+  hint: 'Aplicația se redeschide singură când e gata.',
+  failed: 'Actualizarea nu a reușit: {{reason}}',
+  openManually: 'Deschide Church Hub manual.',
+}
+
+const dir = mkdtempSync(join(tmpdir(), 'church-hub-helper-syntax-'))
+
+describe('generated helper scripts parse on their platform', () => {
+  test.skipIf(process.platform !== 'darwin')(
+    'macOS: osacompile accepts the JXA',
+    () => {
+      const script = buildMacUpdater({
+        dmgPath: '/Users/Ion Pop/Downloads/church-hub.dmg',
+        appPath: '/Applications/Church Hub.app',
+        appPid: 1,
+        sidecarPid: 2,
+        version: '9.9.9',
+        logPath: join(dir, 'update.log'),
+        labels,
+      })
+      const file = join(dir, 'church-hub-update.js')
+      writeFileSync(file, script)
+      execFileSync(
+        '/usr/bin/osacompile',
+        ['-l', 'JavaScript', '-o', join(dir, 'compiled.scpt'), file],
+        { stdio: 'pipe', timeout: 30_000 },
+      )
+      rmSync(dir, { recursive: true, force: true })
+    },
+  )
+
+  test.skipIf(process.platform !== 'win32')(
+    'Windows: PowerShell parses the script',
+    () => {
+      const script = buildWindowsUpdater({
+        installerPath: 'C:\\Users\\Ion Pop\\Downloads\\church-hub.exe',
+        installDir: 'C:\\Users\\Ion Pop\\AppData\\Local\\church-hub',
+        launchPath:
+          'C:\\Users\\Ion Pop\\AppData\\Local\\church-hub\\church-hub.exe',
+        appPid: 1,
+        sidecarPid: 2,
+        version: '9.9.9',
+        logPath: join(dir, 'update.log'),
+        labels,
+      })
+      const file = join(dir, 'church-hub-update.ps1')
+      writeFileSync(file, `\ufeff${script}`)
+      const check = [
+        '$errors = $null',
+        `[System.Management.Automation.Language.Parser]::ParseFile('${file.replace(/'/g, "''")}', [ref]$null, [ref]$errors) | Out-Null`,
+        'if ($errors.Count -gt 0) { $errors | ForEach-Object { Write-Error $_.Message }; exit 1 }',
+        "'parse ok'",
+      ].join('; ')
+      const out = execFileSync(
+        'powershell.exe',
+        ['-NoProfile', '-NonInteractive', '-Command', check],
+        { stdio: 'pipe', timeout: 60_000 },
+      ).toString()
+      expect(out).toContain('parse ok')
+      rmSync(dir, { recursive: true, force: true })
+    },
+  )
+})

--- a/app/apps/server/src/service/app-update/__tests__/installers.test.ts
+++ b/app/apps/server/src/service/app-update/__tests__/installers.test.ts
@@ -39,7 +39,12 @@ describe('buildMacUpdater', () => {
   })
 
   test('waits for the app, swaps the bundle from the image and relaunches', () => {
-    expect(script).toContain('waitForExit(P.appPid, 15)')
+    expect(script).toContain('waitForAppToQuit(15)')
+    // Processes are found by executable path; a bare pid is never killed.
+    expect(script).toContain("'/Contents/MacOS/'")
+    expect(script).not.toMatch(/\$\.kill\(P\./)
+    // The new bundle is staged beside the old one before the swap.
+    expect(script).toContain("'.update'")
     expect(script).toContain("'/usr/bin/hdiutil', ['attach'")
     expect(script).toContain("'/usr/bin/ditto'")
     expect(script).toContain("'/usr/bin/open', ['-a', P.appPath]")
@@ -80,7 +85,10 @@ describe('buildWindowsUpdater', () => {
   })
 
   test('waits for the app, runs the installer silently and relaunches', () => {
-    expect(script).toContain('Wait-ForExit $P.appPid 15')
+    expect(script).toContain('Wait-ForAppToExit 15')
+    // Processes are found by executable path; a bare pid is never killed.
+    expect(script).toContain('$P.installDir.TrimEnd($separator) + $separator')
+    expect(script).not.toContain('Stop-Process -Id $P.')
     expect(script).toContain("-ArgumentList '/S'")
     expect(script).toContain('-Verb RunAs')
     expect(script).toContain('Start-Process -FilePath $P.launchPath')

--- a/app/apps/server/src/service/app-update/__tests__/installers.test.ts
+++ b/app/apps/server/src/service/app-update/__tests__/installers.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, test } from 'bun:test'
+import { buildMacUpdater } from '../buildMacUpdater'
+import { buildWindowsUpdater } from '../buildWindowsUpdater'
+import type { UpdateInstallerLabels } from '../types'
+
+const labels: UpdateInstallerLabels = {
+  title: 'Church Hub',
+  closing: 'Se închide aplicația…',
+  installing: 'Se instalează versiunea 9.9.9…',
+  launching: 'Se pornește noua versiune…',
+  hint: 'Aplicația se redeschide singură când e gata.',
+  failed: 'Actualizarea nu a reușit: {{reason}}',
+  openManually: 'Deschide Church Hub manual.',
+}
+
+describe('buildMacUpdater', () => {
+  const script = buildMacUpdater({
+    dmgPath: '/Users/Ion Pop/Downloads/church-hub-macos-arm64-v-9.9.9.dmg',
+    appPath: '/Applications/Church Hub.app',
+    appPid: 1234,
+    sidecarPid: 5678,
+    version: '9.9.9',
+    logPath:
+      '/Users/Ion Pop/Library/Application Support/church-hub/church-hub-update.log',
+    labels,
+  })
+
+  test('bakes the parameters in as JSON, paths with spaces included', () => {
+    const line = script.split('\n').find((l) => l.startsWith('const P = '))
+    expect(line).toBeDefined()
+    const params = JSON.parse(line!.slice('const P = '.length))
+    expect(params.appPath).toBe('/Applications/Church Hub.app')
+    expect(params.appPid).toBe(1234)
+    expect(params.labels.installing).toBe('Se instalează versiunea 9.9.9…')
+  })
+
+  test("never defines osascript's reserved `run` entry point", () => {
+    expect(script).not.toMatch(/function run\(/)
+  })
+
+  test('waits for the app, swaps the bundle from the image and relaunches', () => {
+    expect(script).toContain('waitForExit(P.appPid, 15)')
+    expect(script).toContain("'/usr/bin/hdiutil', ['attach'")
+    expect(script).toContain("'/usr/bin/ditto'")
+    expect(script).toContain("'/usr/bin/open', ['-a', P.appPath]")
+    expect(script).toContain('NSProgressIndicator')
+  })
+})
+
+describe('buildWindowsUpdater', () => {
+  const script = buildWindowsUpdater({
+    installerPath:
+      'C:\\Users\\Ion Pop\\Downloads\\church-hub-windows-x64-v-9.9.9.exe',
+    installDir: 'C:\\Users\\Ion Pop\\AppData\\Local\\church-hub',
+    launchPath:
+      'C:\\Users\\Ion Pop\\AppData\\Local\\church-hub\\church-hub.exe',
+    appPid: 1234,
+    sidecarPid: 5678,
+    version: '9.9.9',
+    logPath:
+      'C:\\Users\\Ion Pop\\AppData\\Roaming\\church-hub\\church-hub-update.log',
+    labels,
+  })
+
+  test('bakes the parameters in as a JSON here-string', () => {
+    const match = script.match(/\$P = @'\n(.*)\n'@ \| ConvertFrom-Json/)
+    expect(match).not.toBeNull()
+    const params = JSON.parse(match![1])
+    expect(params.launchPath).toBe(
+      'C:\\Users\\Ion Pop\\AppData\\Local\\church-hub\\church-hub.exe',
+    )
+    expect(params.labels.failed).toBe('Actualizarea nu a reușit: {{reason}}')
+  })
+
+  test('leaves PowerShell interpolation to PowerShell', () => {
+    // These must survive as PowerShell syntax, not be eaten by the template.
+    expect(script).toContain('after ${graceSeconds}s')
+    expect(script).toContain('${env:ProgramFiles(x86)}')
+    expect(script).not.toContain('undefined')
+  })
+
+  test('waits for the app, runs the installer silently and relaunches', () => {
+    expect(script).toContain('Wait-ForExit $P.appPid 15')
+    expect(script).toContain("-ArgumentList '/S'")
+    expect(script).toContain('-Verb RunAs')
+    expect(script).toContain('Start-Process -FilePath $P.launchPath')
+    expect(script).toContain('<ProgressBar')
+  })
+})

--- a/app/apps/server/src/service/app-update/buildMacUpdater.ts
+++ b/app/apps/server/src/service/app-update/buildMacUpdater.ts
@@ -98,37 +98,69 @@ function show(text, progress) {
 }
 
 // ---- helpers -------------------------------------------------------------
-function isAlive(pid) {
-  return pid > 0 && $.kill(pid, 0) === 0
-}
-
-// Waits for the process to go away on its own; after the grace period it is
-// terminated so the update never stalls on an app that did not quit.
-function waitForExit(pid, graceSeconds) {
-  const deadline = Date.now() + graceSeconds * 1000
-  while (isAlive(pid) && Date.now() < deadline) pump(0.1)
-  if (isAlive(pid)) {
-    log('pid ' + pid + ' still running after ' + graceSeconds + 's; terminating')
-    $.kill(pid, 9)
-    const hardDeadline = Date.now() + 5000
-    while (isAlive(pid) && Date.now() < hardDeadline) pump(0.1)
+// The processes that belong to the installed app: everything whose
+// executable lives inside the bundle (the app itself, the sidecar, helpers).
+// Decided by path, never by a bare process id — an id handed over by the
+// caller is only a hint and is never trusted on its own, so a stale or wrong
+// one can never have some unrelated process terminated.
+function appProcesses() {
+  const prefix = P.appPath.replace(/\\/+$/, '') + '/Contents/MacOS/'
+  // -ww: unlimited width, otherwise the path is cut to a few characters.
+  // command= is argv as launched, which for a bundle is the full path.
+  const listing = runTask('/bin/ps', ['-axww', '-o', 'pid=,command='], { quiet: true })
+  const pids = []
+  for (const line of listing.output.split('\\n')) {
+    const match = line.match(/^\\s*(\\d+)\\s+(.*)$/)
+    if (match && match[2].startsWith(prefix)) pids.push(Number(match[1]))
   }
-  return !isAlive(pid)
+  return pids
 }
 
-function runTask(command, args) {
+// Waits for the app's processes to go away on their own; after the grace
+// period they are terminated so the update never stalls on an app that did
+// not quit.
+function waitForAppToQuit(graceSeconds) {
+  const deadline = Date.now() + graceSeconds * 1000
+  let remaining = appProcesses()
+  while (remaining.length > 0 && Date.now() < deadline) {
+    pump(0.25)
+    remaining = appProcesses()
+  }
+  if (remaining.length > 0) {
+    log('still running after ' + graceSeconds + 's: ' + remaining.join(', ') + '; terminating')
+    for (const pid of remaining) $.kill(pid, 9)
+    const hardDeadline = Date.now() + 5000
+    remaining = appProcesses()
+    while (remaining.length > 0 && Date.now() < hardDeadline) {
+      pump(0.25)
+      remaining = appProcesses()
+    }
+  }
+  return remaining.length === 0
+}
+
+// Output goes to a temp file rather than a pipe: a pipe must be drained
+// while the task runs or a chatty command (ps on a busy Mac) fills it and
+// deadlocks, and draining it would mean not pumping the window meanwhile.
+let taskCounter = 0
+function runTask(command, args, options) {
+  const outputPath = $.NSTemporaryDirectory().js + 'church-hub-update-task-' + $.NSProcessInfo.processInfo.processIdentifier + '-' + (taskCounter++) + '.txt'
+  $.NSFileManager.defaultManager.createFileAtPathContentsAttributes(outputPath, $(), $())
+  const handle = $.NSFileHandle.fileHandleForWritingAtPath(outputPath)
   const task = $.NSTask.alloc.init
   task.launchPath = command
   task.arguments = args
-  const pipe = $.NSPipe.pipe
-  task.standardOutput = pipe
-  task.standardError = pipe
+  task.standardOutput = handle
+  task.standardError = handle
   task.launch
   while (task.isRunning) pump(0.1)
-  const data = pipe.fileHandleForReading.readDataToEndOfFile
-  const output = $.NSString.alloc.initWithDataEncoding(data, $.NSUTF8StringEncoding)
+  handle.closeFile
+  const output = $.NSString.stringWithContentsOfFileEncodingError(outputPath, $.NSUTF8StringEncoding, null)
+  $.NSFileManager.defaultManager.removeItemAtPathError(outputPath, null)
   const text = output.isNil() ? '' : output.js.trim()
-  log('$ ' + command + ' ' + args.join(' ') + ' -> ' + task.terminationStatus + (text ? '\\n' + text : ''))
+  if (!(options && options.quiet)) {
+    log('$ ' + command + ' ' + args.join(' ') + ' -> ' + task.terminationStatus + (text ? '\\n' + text : ''))
+  }
   return { status: task.terminationStatus, output: text }
 }
 
@@ -144,14 +176,10 @@ function fail(reason) {
 }
 
 // ---- the update ----------------------------------------------------------
-log('updating ' + P.appPath + ' to ' + P.version + ' from ' + P.dmgPath)
+log('updating ' + P.appPath + ' to ' + P.version + ' from ' + P.dmgPath + ' (app pid ' + P.appPid + ', sidecar pid ' + P.sidecarPid + ')')
 
 show(P.labels.closing, 10)
-if (!waitForExit(P.appPid, 15)) fail('the running app could not be closed')
-if (isAlive(P.sidecarPid)) {
-  log('sidecar ' + P.sidecarPid + ' outlived the app; terminating')
-  $.kill(P.sidecarPid, 9)
-}
+if (!waitForAppToQuit(15)) fail('the running app could not be closed')
 
 show(P.labels.installing, 30)
 const mountPoint = '/tmp/church-hub-update-' + Date.now()
@@ -174,12 +202,21 @@ if (!newApp) {
 }
 
 show(P.labels.installing, 50)
-runTask('/bin/rm', ['-rf', P.appPath])
+// Copy next to the installed bundle first and only then swap, so a copy that
+// fails halfway (disk full, image gone) leaves the current version in place.
+const staged = P.appPath.replace(/\\/+$/, '') + '.update'
+runTask('/bin/rm', ['-rf', staged])
 // ditto preserves the bundle's structure, symlinks and code signature.
-const copy = runTask('/usr/bin/ditto', [newApp, P.appPath])
+const copy = runTask('/usr/bin/ditto', [newApp, staged])
 runTask('/usr/bin/hdiutil', ['detach', mountPoint, '-quiet'])
 runTask('/bin/rmdir', [mountPoint])
-if (copy.status !== 0) fail('the application could not be copied (' + copy.output + ')')
+if (copy.status !== 0) {
+  runTask('/bin/rm', ['-rf', staged])
+  fail('the application could not be copied (' + copy.output + ')')
+}
+runTask('/bin/rm', ['-rf', P.appPath])
+const swap = runTask('/bin/mv', [staged, P.appPath])
+if (swap.status !== 0) fail('the application could not be moved into place (' + swap.output + ')')
 // Clear the download quarantine so the swapped bundle opens without a prompt.
 runTask('/usr/bin/xattr', ['-dr', 'com.apple.quarantine', P.appPath])
 

--- a/app/apps/server/src/service/app-update/buildMacUpdater.ts
+++ b/app/apps/server/src/service/app-update/buildMacUpdater.ts
@@ -1,0 +1,195 @@
+import type { UpdateInstallerLabels } from './types'
+
+export interface MacUpdaterParams {
+  dmgPath: string
+  appPath: string
+  /** The Tauri app process — the one that has to be gone before the swap. */
+  appPid: number
+  /** The sidecar, normally killed by the app on exit; cleaned up if not. */
+  sidecarPid: number
+  version: string
+  logPath: string
+  labels: UpdateInstallerLabels
+}
+
+/**
+ * The macOS installer helper: a JavaScript-for-Automation script run by
+ * `osascript`, which is on every Mac and needs no compiling. Through the
+ * ObjC bridge it puts up a native AppKit window — title, step, progress
+ * bar — while it waits for the app to quit, swaps the bundle from the .dmg
+ * and relaunches. Nothing the operator sees is a terminal.
+ *
+ * The parameters are baked into the script as JSON, so there is no argument
+ * quoting to get wrong. Note that `run` is osascript's reserved entry point:
+ * no function in here may use that name.
+ */
+export function buildMacUpdater(params: MacUpdaterParams): string {
+  return `ObjC.import('Cocoa')
+ObjC.import('signal')
+ObjC.import('stdlib')
+
+const P = ${JSON.stringify(params)}
+
+// ---- logging -------------------------------------------------------------
+const lines = []
+function log(message) {
+  const stamp = $.NSDate.date.description.js
+  lines.push(stamp + ' ' + message)
+  $(lines.join('\\n') + '\\n').writeToFileAtomicallyEncodingError(P.logPath, true, $.NSUTF8StringEncoding, null)
+}
+
+// ---- window --------------------------------------------------------------
+const app = $.NSApplication.sharedApplication
+app.setActivationPolicy($.NSApplicationActivationPolicyRegular)
+const iconPath = P.appPath + '/Contents/Resources/icon.icns'
+if ($.NSFileManager.defaultManager.fileExistsAtPath(iconPath)) {
+  app.applicationIconImage = $.NSImage.alloc.initWithContentsOfFile(iconPath)
+}
+
+const W = 440
+const H = 230
+const win = $.NSWindow.alloc.initWithContentRectStyleMaskBackingDefer(
+  $.NSMakeRect(0, 0, W, H),
+  $.NSWindowStyleMaskTitled | $.NSWindowStyleMaskFullSizeContentView,
+  $.NSBackingStoreBuffered,
+  false,
+)
+win.titlebarAppearsTransparent = true
+win.titleVisibility = $.NSWindowTitleHidden
+win.movableByWindowBackground = true
+win.backgroundColor = $.NSColor.windowBackgroundColor
+win.level = $.NSFloatingWindowLevel
+win.center
+
+const content = win.contentView
+function label(text, y, size, weight, color) {
+  const field = $.NSTextField.alloc.initWithFrame($.NSMakeRect(32, y, W - 64, size + 10))
+  field.stringValue = text
+  field.editable = false
+  field.bezeled = false
+  field.drawsBackground = false
+  field.selectable = false
+  field.font = $.NSFont.systemFontOfSizeWeight(size, weight)
+  field.textColor = color
+  content.addSubview(field)
+  return field
+}
+label(P.labels.title, H - 78, 22, $.NSFontWeightSemibold, $.NSColor.labelColor)
+const step = label(P.labels.closing, H - 108, 13, $.NSFontWeightRegular, $.NSColor.secondaryLabelColor)
+const bar = $.NSProgressIndicator.alloc.initWithFrame($.NSMakeRect(32, 54, W - 64, 8))
+bar.style = $.NSProgressIndicatorStyleBar
+bar.indeterminate = false
+bar.minValue = 0
+bar.maxValue = 100
+bar.doubleValue = 5
+content.addSubview(bar)
+const hint = label(P.labels.hint, 24, 11, $.NSFontWeightRegular, $.NSColor.tertiaryLabelColor)
+
+win.makeKeyAndOrderFront(null)
+app.activateIgnoringOtherApps(true)
+
+function pump(seconds) {
+  $.NSRunLoop.currentRunLoop.runUntilDate($.NSDate.dateWithTimeIntervalSinceNow(seconds))
+}
+function show(text, progress) {
+  step.stringValue = text
+  bar.doubleValue = progress
+  pump(0.05)
+}
+
+// ---- helpers -------------------------------------------------------------
+function isAlive(pid) {
+  return pid > 0 && $.kill(pid, 0) === 0
+}
+
+// Waits for the process to go away on its own; after the grace period it is
+// terminated so the update never stalls on an app that did not quit.
+function waitForExit(pid, graceSeconds) {
+  const deadline = Date.now() + graceSeconds * 1000
+  while (isAlive(pid) && Date.now() < deadline) pump(0.1)
+  if (isAlive(pid)) {
+    log('pid ' + pid + ' still running after ' + graceSeconds + 's; terminating')
+    $.kill(pid, 9)
+    const hardDeadline = Date.now() + 5000
+    while (isAlive(pid) && Date.now() < hardDeadline) pump(0.1)
+  }
+  return !isAlive(pid)
+}
+
+function runTask(command, args) {
+  const task = $.NSTask.alloc.init
+  task.launchPath = command
+  task.arguments = args
+  const pipe = $.NSPipe.pipe
+  task.standardOutput = pipe
+  task.standardError = pipe
+  task.launch
+  while (task.isRunning) pump(0.1)
+  const data = pipe.fileHandleForReading.readDataToEndOfFile
+  const output = $.NSString.alloc.initWithDataEncoding(data, $.NSUTF8StringEncoding)
+  const text = output.isNil() ? '' : output.js.trim()
+  log('$ ' + command + ' ' + args.join(' ') + ' -> ' + task.terminationStatus + (text ? '\\n' + text : ''))
+  return { status: task.terminationStatus, output: text }
+}
+
+function fail(reason) {
+  log('FAILED: ' + reason)
+  const alert = $.NSAlert.alloc.init
+  alert.messageText = P.labels.failed.replace('{{reason}}', reason)
+  alert.informativeText = P.labels.openManually
+  alert.alertStyle = $.NSAlertStyleWarning
+  win.orderOut(null)
+  alert.runModal
+  $.exit(1)
+}
+
+// ---- the update ----------------------------------------------------------
+log('updating ' + P.appPath + ' to ' + P.version + ' from ' + P.dmgPath)
+
+show(P.labels.closing, 10)
+if (!waitForExit(P.appPid, 15)) fail('the running app could not be closed')
+if (isAlive(P.sidecarPid)) {
+  log('sidecar ' + P.sidecarPid + ' outlived the app; terminating')
+  $.kill(P.sidecarPid, 9)
+}
+
+show(P.labels.installing, 30)
+const mountPoint = '/tmp/church-hub-update-' + Date.now()
+$.NSFileManager.defaultManager.createDirectoryAtPathWithIntermediateDirectoriesAttributesError(mountPoint, true, $(), null)
+const attach = runTask('/usr/bin/hdiutil', ['attach', P.dmgPath, '-nobrowse', '-quiet', '-mountpoint', mountPoint])
+if (attach.status !== 0) fail('the disk image could not be opened (' + attach.output + ')')
+
+let newApp = null
+const entries = $.NSFileManager.defaultManager.contentsOfDirectoryAtPathError(mountPoint, null)
+for (let i = 0; i < entries.count; i++) {
+  const name = entries.objectAtIndex(i).js
+  if (name.endsWith('.app')) {
+    newApp = mountPoint + '/' + name
+    break
+  }
+}
+if (!newApp) {
+  runTask('/usr/bin/hdiutil', ['detach', mountPoint, '-quiet'])
+  fail('no application found in the disk image')
+}
+
+show(P.labels.installing, 50)
+runTask('/bin/rm', ['-rf', P.appPath])
+// ditto preserves the bundle's structure, symlinks and code signature.
+const copy = runTask('/usr/bin/ditto', [newApp, P.appPath])
+runTask('/usr/bin/hdiutil', ['detach', mountPoint, '-quiet'])
+runTask('/bin/rmdir', [mountPoint])
+if (copy.status !== 0) fail('the application could not be copied (' + copy.output + ')')
+// Clear the download quarantine so the swapped bundle opens without a prompt.
+runTask('/usr/bin/xattr', ['-dr', 'com.apple.quarantine', P.appPath])
+
+show(P.labels.launching, 90)
+const launch = runTask('/usr/bin/open', ['-a', P.appPath])
+if (launch.status !== 0) fail('the new version could not be started (' + launch.output + ')')
+
+show(P.labels.launching, 100)
+log('done')
+pump(1.2)
+$.exit(0)
+`
+}

--- a/app/apps/server/src/service/app-update/buildWindowsUpdater.ts
+++ b/app/apps/server/src/service/app-update/buildWindowsUpdater.ts
@@ -1,0 +1,173 @@
+import type { UpdateInstallerLabels } from './types'
+
+export interface WindowsUpdaterParams {
+  installerPath: string
+  installDir: string
+  launchPath: string
+  /** The Tauri app process — the one holding the files the installer replaces. */
+  appPid: number
+  /** The sidecar, normally killed by the app on exit; cleaned up if not. */
+  sidecarPid: number
+  version: string
+  logPath: string
+  labels: UpdateInstallerLabels
+}
+
+/**
+ * The Windows installer helper: a PowerShell script that shows a WPF window —
+ * title, step, progress bar — while it waits for the app to exit, runs the
+ * NSIS installer silently and relaunches. PowerShell and WPF ship with every
+ * Windows, so nothing needs compiling, and with `-WindowStyle Hidden` no
+ * console ever appears.
+ *
+ * The parameters are baked in as JSON inside a single-quoted here-string, so
+ * paths with spaces or odd characters never meet PowerShell's parser.
+ */
+export function buildWindowsUpdater(params: WindowsUpdaterParams): string {
+  const json = JSON.stringify(params)
+  return `$ErrorActionPreference = 'Continue'
+$P = @'
+${json}
+'@ | ConvertFrom-Json
+
+function Log($message) {
+  Add-Content -LiteralPath $P.logPath -Encoding UTF8 -Value ("{0} {1}" -f (Get-Date -Format o), $message) -ErrorAction SilentlyContinue
+}
+
+# ---- window ---------------------------------------------------------------
+Add-Type -AssemblyName PresentationFramework
+Add-Type -AssemblyName PresentationCore
+Add-Type -AssemblyName WindowsBase
+
+[xml]$xaml = @'
+<Window xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Width="440" Height="230" ResizeMode="NoResize" WindowStyle="None"
+        WindowStartupLocation="CenterScreen" Topmost="True" ShowInTaskbar="True"
+        Background="#FFFFFF" FontFamily="Segoe UI">
+  <Border BorderBrush="#E5E7EB" BorderThickness="1">
+    <Grid Margin="32,28,32,24">
+      <Grid.RowDefinitions>
+        <RowDefinition Height="Auto"/>
+        <RowDefinition Height="Auto"/>
+        <RowDefinition Height="*"/>
+        <RowDefinition Height="Auto"/>
+        <RowDefinition Height="Auto"/>
+      </Grid.RowDefinitions>
+      <TextBlock x:Name="Title" Grid.Row="0" FontSize="22" FontWeight="SemiBold" Foreground="#111827"/>
+      <TextBlock x:Name="Step" Grid.Row="1" FontSize="13" Foreground="#6B7280" Margin="0,6,0,0" TextWrapping="Wrap"/>
+      <ProgressBar x:Name="Bar" Grid.Row="3" Height="8" Minimum="0" Maximum="100" Value="5"
+                   Foreground="#4F46E5" Background="#E5E7EB" BorderThickness="0"/>
+      <TextBlock x:Name="Hint" Grid.Row="4" FontSize="11" Foreground="#9CA3AF" Margin="0,14,0,0" TextWrapping="Wrap"/>
+    </Grid>
+  </Border>
+</Window>
+'@
+
+$reader = New-Object System.Xml.XmlNodeReader $xaml
+$window = [Windows.Markup.XamlReader]::Load($reader)
+$title = $window.FindName('Title')
+$step = $window.FindName('Step')
+$bar = $window.FindName('Bar')
+$hint = $window.FindName('Hint')
+$title.Text = $P.labels.title
+$step.Text = $P.labels.closing
+$hint.Text = $P.labels.hint
+$window.Show() | Out-Null
+$window.Activate() | Out-Null
+
+function Pump() {
+  $window.Dispatcher.Invoke([Action]{}, [Windows.Threading.DispatcherPriority]::Background)
+}
+function Show($text, $progress) {
+  $step.Text = $text
+  $bar.Value = $progress
+  Pump
+}
+function Wait-Seconds($seconds) {
+  $until = (Get-Date).AddSeconds($seconds)
+  while ((Get-Date) -lt $until) { Pump; Start-Sleep -Milliseconds 50 }
+}
+
+# ---- helpers --------------------------------------------------------------
+function Is-Alive($processId) {
+  if ($processId -le 0) { return $false }
+  return $null -ne (Get-Process -Id $processId -ErrorAction SilentlyContinue)
+}
+
+# Waits for the process to go away on its own; after the grace period it is
+# terminated so the update never stalls on an app that did not exit.
+function Wait-ForExit($processId, $graceSeconds) {
+  $deadline = (Get-Date).AddSeconds($graceSeconds)
+  while ((Is-Alive $processId) -and ((Get-Date) -lt $deadline)) { Pump; Start-Sleep -Milliseconds 100 }
+  if (Is-Alive $processId) {
+    Log "pid $processId still running after \${graceSeconds}s; terminating"
+    Stop-Process -Id $processId -Force -ErrorAction SilentlyContinue
+    $hardDeadline = (Get-Date).AddSeconds(5)
+    while ((Is-Alive $processId) -and ((Get-Date) -lt $hardDeadline)) { Pump; Start-Sleep -Milliseconds 100 }
+  }
+  return -not (Is-Alive $processId)
+}
+
+function Fail($reason) {
+  Log "FAILED: $reason"
+  $window.Hide()
+  $text = $P.labels.failed.Replace('{{reason}}', $reason) + "\`n\`n" + $P.labels.openManually
+  [Windows.MessageBox]::Show($text, $P.labels.title, 'OK', 'Warning') | Out-Null
+  exit 1
+}
+
+# ---- the update -----------------------------------------------------------
+Log "updating $($P.installDir) to $($P.version) from $($P.installerPath)"
+
+Show $P.labels.closing 10
+if (-not (Wait-ForExit $P.appPid 15)) { Fail 'the running app could not be closed' }
+if (Is-Alive $P.sidecarPid) {
+  Log "sidecar $($P.sidecarPid) outlived the app; terminating"
+  Stop-Process -Id $P.sidecarPid -Force -ErrorAction SilentlyContinue
+}
+# Let Windows release the file locks of the process that just went away.
+Wait-Seconds 1
+
+Show $P.labels.installing 30
+# A per-machine install (Program Files) needs elevation; the silent installer
+# cannot ask for it itself, so the prompt is raised here instead.
+$programFiles = @($env:ProgramFiles, \${env:ProgramFiles(x86)}) | Where-Object { $_ }
+$elevate = $false
+foreach ($root in $programFiles) {
+  if ($P.installDir.StartsWith($root, [System.StringComparison]::OrdinalIgnoreCase)) { $elevate = $true }
+}
+try {
+  if ($elevate) {
+    $installer = Start-Process -FilePath $P.installerPath -ArgumentList '/S' -Verb RunAs -PassThru
+  } else {
+    $installer = Start-Process -FilePath $P.installerPath -ArgumentList '/S' -PassThru
+  }
+} catch {
+  Fail "the installer could not be started ($($_.Exception.Message))"
+}
+$started = Get-Date
+while (-not $installer.HasExited) {
+  Pump
+  Start-Sleep -Milliseconds 100
+  $elapsed = ((Get-Date) - $started).TotalSeconds
+  $bar.Value = [Math]::Min(85, 30 + $elapsed * 2)
+}
+Log "installer exited with $($installer.ExitCode)"
+if ($installer.ExitCode -ne 0) { Fail "the installer reported an error (code $($installer.ExitCode))" }
+if (-not (Test-Path -LiteralPath $P.launchPath)) { Fail "the installed application was not found at $($P.launchPath)" }
+
+Show $P.labels.launching 90
+try {
+  Start-Process -FilePath $P.launchPath -WorkingDirectory $P.installDir | Out-Null
+} catch {
+  Fail "the new version could not be started ($($_.Exception.Message))"
+}
+
+Show $P.labels.launching 100
+Log 'done'
+Wait-Seconds 1.2
+$window.Close()
+exit 0
+`
+}

--- a/app/apps/server/src/service/app-update/buildWindowsUpdater.ts
+++ b/app/apps/server/src/service/app-update/buildWindowsUpdater.ts
@@ -90,23 +90,44 @@ function Wait-Seconds($seconds) {
 }
 
 # ---- helpers --------------------------------------------------------------
-function Is-Alive($processId) {
-  if ($processId -le 0) { return $false }
-  return $null -ne (Get-Process -Id $processId -ErrorAction SilentlyContinue)
+# The processes that belong to the installed app: everything whose executable
+# lives in the install folder (the app itself, the sidecar, helpers). Decided
+# by path, never by a bare process id — the ids handed over by the caller are
+# only a hint and are never trusted on their own, so a stale or wrong one can
+# never have some unrelated process terminated.
+function Get-AppProcesses() {
+  $separator = [System.IO.Path]::DirectorySeparatorChar
+  $prefix = $P.installDir.TrimEnd($separator) + $separator
+  @(Get-Process -ErrorAction SilentlyContinue | Where-Object {
+    $path = $null
+    try { $path = $_.Path } catch { $path = $null }
+    $path -and $path.StartsWith($prefix, [System.StringComparison]::OrdinalIgnoreCase)
+  })
 }
 
-# Waits for the process to go away on its own; after the grace period it is
-# terminated so the update never stalls on an app that did not exit.
-function Wait-ForExit($processId, $graceSeconds) {
+# Waits for the app's processes to go away on their own; after the grace
+# period they are terminated so the update never stalls on an app that did
+# not exit.
+function Wait-ForAppToExit($graceSeconds) {
   $deadline = (Get-Date).AddSeconds($graceSeconds)
-  while ((Is-Alive $processId) -and ((Get-Date) -lt $deadline)) { Pump; Start-Sleep -Milliseconds 100 }
-  if (Is-Alive $processId) {
-    Log "pid $processId still running after \${graceSeconds}s; terminating"
-    Stop-Process -Id $processId -Force -ErrorAction SilentlyContinue
-    $hardDeadline = (Get-Date).AddSeconds(5)
-    while ((Is-Alive $processId) -and ((Get-Date) -lt $hardDeadline)) { Pump; Start-Sleep -Milliseconds 100 }
+  $remaining = Get-AppProcesses
+  while ($remaining.Count -gt 0 -and (Get-Date) -lt $deadline) {
+    Pump
+    Start-Sleep -Milliseconds 250
+    $remaining = Get-AppProcesses
   }
-  return -not (Is-Alive $processId)
+  if ($remaining.Count -gt 0) {
+    Log ("still running after \${graceSeconds}s: " + (($remaining | ForEach-Object { "$($_.ProcessName)($($_.Id))" }) -join ', ') + '; terminating')
+    $remaining | ForEach-Object { Stop-Process -Id $_.Id -Force -ErrorAction SilentlyContinue }
+    $hardDeadline = (Get-Date).AddSeconds(5)
+    $remaining = Get-AppProcesses
+    while ($remaining.Count -gt 0 -and (Get-Date) -lt $hardDeadline) {
+      Pump
+      Start-Sleep -Milliseconds 250
+      $remaining = Get-AppProcesses
+    }
+  }
+  return ($remaining.Count -eq 0)
 }
 
 function Fail($reason) {
@@ -118,14 +139,10 @@ function Fail($reason) {
 }
 
 # ---- the update -----------------------------------------------------------
-Log "updating $($P.installDir) to $($P.version) from $($P.installerPath)"
+Log "updating $($P.installDir) to $($P.version) from $($P.installerPath) (app pid $($P.appPid), sidecar pid $($P.sidecarPid))"
 
 Show $P.labels.closing 10
-if (-not (Wait-ForExit $P.appPid 15)) { Fail 'the running app could not be closed' }
-if (Is-Alive $P.sidecarPid) {
-  Log "sidecar $($P.sidecarPid) outlived the app; terminating"
-  Stop-Process -Id $P.sidecarPid -Force -ErrorAction SilentlyContinue
-}
+if (-not (Wait-ForAppToExit 15)) { Fail 'the running app could not be closed' }
 # Let Windows release the file locks of the process that just went away.
 Wait-Seconds 1
 

--- a/app/apps/server/src/service/app-update/installUpdate.ts
+++ b/app/apps/server/src/service/app-update/installUpdate.ts
@@ -1,4 +1,5 @@
 import { spawn } from 'node:child_process'
+import { closeSync, openSync } from 'node:fs'
 import { chmod, writeFile } from 'node:fs/promises'
 import { dirname, join, resolve } from 'node:path'
 
@@ -124,6 +125,11 @@ export async function installUpdate(
     }
 
     // Detached and fully disowned: this process is about to be replaced.
+    // Whatever the interpreter itself prints — a script-execution policy
+    // refusing the .ps1, osascript rejecting the script — lands in the same
+    // log as the helper's own lines, so a helper that never got going still
+    // leaves a trace instead of the app simply not coming back.
+    const helperOutput = openSync(logPath, 'a')
     const child = isWindows
       ? spawn(
           'powershell.exe',
@@ -138,13 +144,18 @@ export async function installUpdate(
             '-File',
             scriptPath,
           ],
-          { detached: true, stdio: 'ignore', windowsHide: true },
+          {
+            detached: true,
+            stdio: ['ignore', helperOutput, helperOutput],
+            windowsHide: true,
+          },
         )
       : spawn('/usr/bin/osascript', ['-l', 'JavaScript', scriptPath], {
           detached: true,
-          stdio: 'ignore',
+          stdio: ['ignore', helperOutput, helperOutput],
         })
     child.unref()
+    closeSync(helperOutput)
 
     markInstalling()
     logger.info(

--- a/app/apps/server/src/service/app-update/installUpdate.ts
+++ b/app/apps/server/src/service/app-update/installUpdate.ts
@@ -2,8 +2,10 @@ import { spawn } from 'node:child_process'
 import { chmod, writeFile } from 'node:fs/promises'
 import { dirname, join, resolve } from 'node:path'
 
+import { buildMacUpdater } from './buildMacUpdater'
+import { buildWindowsUpdater } from './buildWindowsUpdater'
 import { markInstalling } from './downloadUpdate'
-import type { OperationResult } from './types'
+import type { OperationResult, UpdateInstallerLabels } from './types'
 import { createLogger } from '../../utils/logger'
 import { getDataDir } from '../../utils/paths'
 
@@ -40,84 +42,20 @@ function resolveInstalledApp(): { appPath: string; launchPath: string } | null {
   return null
 }
 
-/**
- * Shell-quotes a path for the helper script. Paths here come from the app's own
- * location and the operator's chosen folder, but both routinely contain spaces
- * ("Church Hub.app", "Application Support"), so quoting is not optional.
- */
-function shQuote(value: string): string {
-  return `'${value.replace(/'/g, `'\\''`)}'`
+const DEFAULT_LABELS: UpdateInstallerLabels = {
+  title: 'Church Hub',
+  closing: 'Closing the app…',
+  installing: 'Installing the update…',
+  launching: 'Starting the new version…',
+  hint: 'The app reopens by itself when this is done.',
+  failed: 'The update could not be installed: {{reason}}',
+  openManually:
+    'Open Church Hub yourself; the downloaded installer is in the downloads folder.',
 }
 
 /**
- * macOS: mount the .dmg, replace the installed bundle, relaunch.
- *
- * Runs as a detached script because it replaces the very application that asks
- * for it — the app has to be gone before its bundle can be swapped. The script
- * waits for the app's process to exit first, so nothing is touched while it is
- * still running.
- */
-function buildMacScript(
-  dmgPath: string,
-  appPath: string,
-  appPid: number,
-): string {
-  return `#!/bin/bash
-set -e
-
-# Wait for the running app to quit before touching its bundle (max ~30s).
-for _ in $(seq 1 300); do
-  kill -0 ${appPid} 2>/dev/null || break
-  sleep 0.1
-done
-
-MOUNT_POINT=$(mktemp -d /tmp/church-hub-update.XXXXXX)
-hdiutil attach ${shQuote(dmgPath)} -nobrowse -quiet -mountpoint "$MOUNT_POINT"
-
-# The bundle inside the image; its name is whatever the release built.
-NEW_APP=$(find "$MOUNT_POINT" -maxdepth 1 -name '*.app' -print -quit)
-
-if [ -n "$NEW_APP" ]; then
-  # ditto preserves the bundle's structure, symlinks and code signature.
-  rm -rf ${shQuote(appPath)}
-  ditto "$NEW_APP" ${shQuote(appPath)}
-  # Clear the download quarantine so the swapped bundle opens without a prompt.
-  xattr -dr com.apple.quarantine ${shQuote(appPath)} 2>/dev/null || true
-fi
-
-hdiutil detach "$MOUNT_POINT" -quiet || true
-rmdir "$MOUNT_POINT" 2>/dev/null || true
-
-open -a ${shQuote(appPath)}
-`
-}
-
-/**
- * Windows: run the NSIS installer silently, then relaunch.
- *
- * `/S` is NSIS's silent switch — no wizard, no prompts. The installer upgrades
- * in place; user data lives in %APPDATA%\\church-hub and is never touched.
- */
-function buildWindowsScript(
-  installerPath: string,
-  launchPath: string,
-  appPid: number,
-): string {
-  return `@echo off
-rem Wait for the running app to exit so its files are no longer locked.
-for /l %%i in (1,1,300) do (
-  tasklist /FI "PID eq ${appPid}" 2>nul | find "${appPid}" >nul || goto :install
-  timeout /t 1 /nobreak >nul
-)
-
-:install
-start /wait "" "${installerPath}" /S
-start "" "${launchPath}"
-`
-}
-
-/**
- * Installs a downloaded artifact without any further interaction.
+ * Installs a downloaded artifact without any further interaction, behind a
+ * native progress window.
  *
  * User data survives by construction rather than by special handling: the
  * database and logs live in the per-user data directory (Application Support /
@@ -125,15 +63,21 @@ start "" "${launchPath}"
  * migrations run on the next boot as they always do.
  *
  * Returns as soon as the helper is running. The caller is expected to quit the
- * app straight after; the helper waits for that before it changes anything.
+ * app straight after; the helper waits for that before it changes anything —
+ * and if the app has not gone within a grace period it is terminated, so the
+ * update never sits behind an app that did not close. The helper then
+ * relaunches the installed app, and writes what it did to
+ * `church-hub-update.log` in the data directory.
  *
- * It waits on *this* process rather than the window's: the sidecar is a child
- * of the Tauri app and dies with it, so its exit is the same signal, and unlike
- * the window's process id it is known here without the client having to supply
- * anything (`@tauri-apps/plugin-process` exposes only `exit`/`relaunch`).
+ * It waits on the Tauri app's process — the sidecar's parent — because that
+ * is what holds the bundle / the locked files. The sidecar itself is killed
+ * by the app on exit; should it outlive the app, the helper cleans it up too.
  */
-export async function installUpdate(filePath: string): Promise<OperationResult> {
-  const appPid = process.pid
+export async function installUpdate(
+  filePath: string,
+  version: string,
+  labels: Partial<UpdateInstallerLabels> = {},
+): Promise<OperationResult> {
   const installed = resolveInstalledApp()
   if (!installed) {
     return {
@@ -143,33 +87,69 @@ export async function installUpdate(filePath: string): Promise<OperationResult> 
   }
 
   const artifact = resolve(filePath)
-  const scriptDir = getDataDir()
+  const dataDir = getDataDir()
+  const logPath = join(dataDir, 'church-hub-update.log')
   const isWindows = process.platform === 'win32'
   const scriptPath = join(
-    scriptDir,
-    isWindows ? 'church-hub-update.cmd' : 'church-hub-update.sh',
+    dataDir,
+    isWindows ? 'church-hub-update.ps1' : 'church-hub-update.js',
   )
+  const params = {
+    appPid: process.ppid,
+    sidecarPid: process.pid,
+    version,
+    logPath,
+    labels: { ...DEFAULT_LABELS, ...labels },
+  }
 
   try {
-    const script = isWindows
-      ? buildWindowsScript(artifact, installed.launchPath, appPid)
-      : buildMacScript(artifact, installed.appPath, appPid)
-
-    await writeFile(scriptPath, script, 'utf8')
-    if (!isWindows) await chmod(scriptPath, 0o755)
+    if (isWindows) {
+      const script = buildWindowsUpdater({
+        ...params,
+        installerPath: artifact,
+        installDir: installed.appPath,
+        launchPath: installed.launchPath,
+      })
+      // Windows PowerShell reads a .ps1 without a BOM as ANSI, which would
+      // mangle the diacritics in the labels.
+      await writeFile(scriptPath, `\ufeff${script}`, 'utf8')
+    } else {
+      const script = buildMacUpdater({
+        ...params,
+        dmgPath: artifact,
+        appPath: installed.appPath,
+      })
+      await writeFile(scriptPath, script, 'utf8')
+      await chmod(scriptPath, 0o644)
+    }
 
     // Detached and fully disowned: this process is about to be replaced.
     const child = isWindows
-      ? spawn('cmd.exe', ['/c', scriptPath], {
+      ? spawn(
+          'powershell.exe',
+          [
+            '-NoProfile',
+            '-NonInteractive',
+            '-ExecutionPolicy',
+            'Bypass',
+            '-STA',
+            '-WindowStyle',
+            'Hidden',
+            '-File',
+            scriptPath,
+          ],
+          { detached: true, stdio: 'ignore', windowsHide: true },
+        )
+      : spawn('/usr/bin/osascript', ['-l', 'JavaScript', scriptPath], {
           detached: true,
           stdio: 'ignore',
-          windowsHide: true,
         })
-      : spawn('/bin/bash', [scriptPath], { detached: true, stdio: 'ignore' })
     child.unref()
 
     markInstalling()
-    logger.info(`Update installer started for ${artifact}`)
+    logger.info(
+      `Update installer started for ${artifact} (app pid ${process.ppid}); log at ${logPath}`,
+    )
     return { success: true }
   } catch (error) {
     const message = error instanceof Error ? error.message : 'Unknown error'

--- a/app/apps/server/src/service/app-update/types.ts
+++ b/app/apps/server/src/service/app-update/types.ts
@@ -41,6 +41,28 @@ export interface UpdateConfig {
   effectiveDownloadDir: string
 }
 
+/**
+ * What the installer window says, in the operator's language. The helper
+ * runs outside the app — after it has quit — so the client hands the texts
+ * over instead of the helper reaching for the app's translations.
+ */
+export interface UpdateInstallerLabels {
+  /** Window heading, e.g. "Church Hub". */
+  title: string
+  /** "Closing the app…" */
+  closing: string
+  /** "Installing version {{version}}…" — already interpolated. */
+  installing: string
+  /** "Starting the new version…" */
+  launching: string
+  /** Small print under the bar: "The app reopens by itself when done." */
+  hint: string
+  /** "The update could not be installed: {{reason}}" — `{{reason}}` is filled by the helper. */
+  failed: string
+  /** What to do after a failure: "Open Church Hub yourself; the installer is in the downloads folder." */
+  openManually: string
+}
+
 export interface OperationResult {
   success: boolean
   error?: string


### PR DESCRIPTION
## Summary

"Install and restart" left the operator looking at a black console on Windows (the helper's `tasklist | find "<pid>"` loop) and at nothing on macOS — and on both platforms the app had to be reopened by hand afterwards.

### Root cause
Both helpers waited on the **sidecar's** process id, with no fallback. If the app did not quit:
- Windows: the `.cmd` sat in its console for **five minutes** (300 × `timeout /t 1`) before touching anything — what the operator saw as "it does nothing".
- macOS: after 30 s the script `rm -rf`'d the bundle of the *still-running* app and then `open -a`'d it, which only activated the instance already running — so nothing new ever came up, and the new version only appeared after a manual quit + reopen.

### What changes
- Both helpers now find the app's processes **by executable path** — everything whose binary lives inside the bundle / install folder (app, sidecar) — give them 15 s to go, terminate what is left, then install, **relaunch**, and write every step to `church-hub-update.log` in the data directory. A process id handed over by the sidecar is logged as a hint and never acted on by itself.
- **macOS**: a JavaScript-for-Automation script run by `osascript` (on every Mac, nothing to compile) shows a native AppKit panel — app icon, title, current step, progress bar — through the ObjC bridge while it mounts the image, copies the new bundle next to the old one, swaps, and relaunches. A copy that fails halfway leaves the current version in place.
- **Windows**: a PowerShell script launched with `-WindowStyle Hidden` shows a WPF window with the same content, runs the NSIS installer silently (elevating when the install lives under Program Files), then starts the new build. No console. Written with a BOM so Windows PowerShell reads the Romanian labels as UTF-8.
- The window's texts come from the client in the operator's language via the install request body (OpenAPI updated); English defaults otherwise. Parameters are baked into each script as JSON — paths with spaces never meet a shell parser.
- On failure the helper shows a dialog with the reason and what to do, instead of disappearing. The interpreter's own output (e.g. a PowerShell execution policy refusing the script) is appended to the same log, so a helper that never got going still leaves a trace.
- CI: the macOS and Windows smoke runners parse the generated helpers with `osacompile` / the PowerShell parser.

### macOS window
Native floating panel, app icon in the Dock while it runs:

> **Church Hub**
> Se instalează versiunea 0.1.93…
> ▰▰▰▰▱▱▱▱▱▱
> Aplicația se redeschide singură când e gata.

## Test plan
- [x] macOS, end to end against the real v0.1.92 `.dmg` with stand-in app/sidecar processes running from inside the bundle: (a) app quits by itself, lingering sidecar terminated after 15 s; (b) neither quits, both terminated — then bundle swapped and the new build relaunched. Log written.
- [x] Windows script: parsed by `pwsh` (no syntax errors; JSON here-string decodes with diacritics); the flow — find by path, wait, terminate after grace, run installer, relaunch — exercised under `pwsh` with the WPF window stubbed, for both paths.
- [x] `bun test` (server, 307+ pass) incl. builder tests and the parser test; `vitest` (client, 1046 pass); Playwright `app-update.spec.ts` (12 pass); full e2e suite green (407).
- [ ] **Windows, on a real machine** (cannot be run here): update v0.1.92 → v0.1.93 from Settings → Updates; expect the WPF window, no console, and the app relaunching. If anything goes wrong, `%APPDATA%\church-hub\church-hub-update.log` says where.
- [ ] macOS, on an installed build: same, from Settings → Updates.
