### PR TITLE
presentation + shortcuts: keyboard stays live after Present; page shortcuts mean their page

### DIFF
--- a/app/apps/client/e2e/page-scoped-shortcuts.spec.ts
+++ b/app/apps/client/e2e/page-scoped-shortcuts.spec.ts
@@ -1,0 +1,175 @@
+import { type APIRequestContext, expect, test } from '@playwright/test'
+
+/**
+ * A page's own presentation shortcut means something only on that page —
+ * "show the selected slide" on Songs, "show the selected verse" on Bible —
+ * so the same key can be bound to both, and a page that is not open never
+ * reacts. The OS-level key registration needs the desktop shell; what is
+ * covered here is everything behind it: the settings that store the
+ * bindings, the conflict rules, and the page-side handling of the event the
+ * shortcut manager raises when a bound key is pressed.
+ */
+
+const SIDEBAR_SETTING = '/api/settings/app_settings/sidebar_configuration'
+
+async function readSidebarConfig(request: APIRequestContext) {
+  const response = await request.get(SIDEBAR_SETTING)
+  if (response.status() === 404) return null
+  const { data } = await response.json()
+  return JSON.parse(data.value) as {
+    items: Array<{
+      type: string
+      builtinId?: string
+      settings?: { pageShortcuts?: Record<string, string[]> }
+    }>
+  }
+}
+
+async function createSong(request: APIRequestContext, title: string) {
+  const response = await request.post('/api/songs', {
+    data: {
+      title,
+      slides: [
+        { content: 'First slide', sortOrder: 0 },
+        { content: 'Second slide', sortOrder: 1 },
+      ],
+    },
+  })
+  expect(response.status()).toBe(201)
+  return (await response.json()).data as { id: number }
+}
+
+async function liveSong(request: APIRequestContext) {
+  const response = await request.get('/api/presentation/state')
+  const { data } = await response.json()
+  return data.temporaryContent?.type === 'song'
+    ? {
+        songId: data.temporaryContent.data.songId as number,
+        slideIndex: data.temporaryContent.data.currentSlideIndex as number,
+      }
+    : null
+}
+
+test.describe('Page-scoped shortcuts', () => {
+  test('the same key can be bound on Songs and on Bible, but not on a global action', async ({
+    page,
+    request,
+  }) => {
+    const before = await request.get(SIDEBAR_SETTING)
+    const original =
+      before.status() === 200
+        ? ((await before.json()).data.value as string)
+        : null
+
+    // Start from pages with no keys of their own, whatever an earlier run left.
+    if (original !== null) {
+      const config = JSON.parse(original) as {
+        items: Array<{ settings?: { pageShortcuts?: unknown } }>
+      }
+      for (const item of config.items) {
+        if (item.settings) item.settings.pageShortcuts = undefined
+      }
+      await request.post('/api/settings/app_settings', {
+        data: { key: 'sidebar_configuration', value: JSON.stringify(config) },
+      })
+    }
+
+    try {
+      await page.goto('/settings/shortcuts')
+      await page.waitForLoadState('networkidle')
+
+      const songs = page.getByTestId('page-shortcuts-songs-showSlide')
+      await expect(songs).toBeVisible({ timeout: 10000 })
+      await songs.getByTestId('page-shortcuts-songs-showSlide-add').click()
+      const songsInput = songs.getByRole('textbox').last()
+      await songsInput.focus()
+      await songsInput.press('F9')
+      await expect(songsInput).toHaveValue(/F9/)
+
+      const bible = page.getByTestId('page-shortcuts-bible-showSlide')
+      await bible.getByTestId('page-shortcuts-bible-showSlide-add').click()
+      const bibleInput = bible.getByRole('textbox').last()
+      await bibleInput.focus()
+      await bibleInput.press('F9')
+      await expect(bibleInput).toHaveValue(/F9/)
+
+      // Both stored, each under its own page.
+      await expect
+        .poll(async () => {
+          const config = await readSidebarConfig(request)
+          const byPage = (id: string) =>
+            config?.items.find(
+              (item) => item.type === 'builtin' && item.builtinId === id,
+            )?.settings?.pageShortcuts?.showSlide ?? []
+          return { songs: byPage('songs'), bible: byPage('bible') }
+        })
+        .toEqual({ songs: ['F9'], bible: ['F9'] })
+
+      // No conflict between the two pages.
+      await expect(songs.getByText(/exist|already|deja/i)).toHaveCount(0)
+      await expect(bible.getByText(/exist|already|deja/i)).toHaveCount(0)
+
+      // The same key on the same page, for another action, is a conflict.
+      const songsNext = page.getByTestId('page-shortcuts-songs-nextSlide')
+      await songsNext.getByTestId('page-shortcuts-songs-nextSlide-add').click()
+      const nextInput = songsNext.getByRole('textbox').last()
+      await nextInput.focus()
+      await nextInput.press('F9')
+      await expect(songsNext.getByText(/exist|already|deja/i)).toHaveCount(1)
+    } finally {
+      if (original !== null) {
+        await request.post('/api/settings/app_settings', {
+          data: { key: 'sidebar_configuration', value: original },
+        })
+      } else {
+        await request.delete(SIDEBAR_SETTING).catch(() => {})
+      }
+    }
+  })
+
+  test('the Songs "show the selected slide" event presents the selected slide — and only on Songs', async ({
+    page,
+    request,
+  }) => {
+    const song = await createSong(request, `E2E Page Shortcut ${Date.now()}`)
+    try {
+      await page.addInitScript(() => {
+        window.localStorage.setItem('song-editor-layout', 'normal')
+      })
+      await page.goto(`/songs/${song.id}`)
+      await page.waitForLoadState('networkidle')
+      await expect(page.getByTestId('song-slide-1')).toBeVisible({
+        timeout: 10000,
+      })
+
+      // Select the second slide with the keyboard (nothing is live yet).
+      await page.keyboard.press('ArrowDown')
+
+      // A key bound to Bible does nothing here.
+      await page.evaluate(() => {
+        window.dispatchEvent(
+          new CustomEvent('page-shortcut', {
+            detail: { pageId: 'bible', action: 'showSlide' },
+          }),
+        )
+      })
+      await page.waitForTimeout(500)
+      expect(await liveSong(request)).toBeNull()
+
+      // The Songs one shows the selected slide.
+      await page.evaluate(() => {
+        window.dispatchEvent(
+          new CustomEvent('page-shortcut', {
+            detail: { pageId: 'songs', action: 'showSlide' },
+          }),
+        )
+      })
+      await expect
+        .poll(() => liveSong(request), { timeout: 10000 })
+        .toEqual({ songId: song.id, slideIndex: 1 })
+    } finally {
+      await request.post('/api/presentation/clear-temporary').catch(() => {})
+      await request.delete(`/api/songs/${song.id}`).catch(() => {})
+    }
+  })
+})

--- a/app/apps/client/e2e/presentation-focus.spec.ts
+++ b/app/apps/client/e2e/presentation-focus.spec.ts
@@ -1,0 +1,145 @@
+import { type APIRequestContext, expect, test } from '@playwright/test'
+
+/**
+ * After "Present" the keyboard has to keep working without a click: the slide
+ * that is live takes focus in the control window, and the projection window
+ * — which is what has the keyboard on a single monitor — drives the same
+ * navigation with the arrow / presenter-remote keys itself.
+ */
+
+async function createSong(request: APIRequestContext, title: string) {
+  const response = await request.post('/api/songs', {
+    data: {
+      title,
+      slides: [
+        { content: 'First slide', sortOrder: 0 },
+        { content: 'Second slide', sortOrder: 1 },
+        { content: 'Third slide', sortOrder: 2 },
+      ],
+    },
+  })
+  expect(response.status()).toBe(201)
+  return (await response.json()).data as { id: number }
+}
+
+async function liveSlideIndex(
+  request: APIRequestContext,
+): Promise<number | null> {
+  const response = await request.get('/api/presentation/state')
+  const { data } = await response.json()
+  return data.temporaryContent?.type === 'song'
+    ? (data.temporaryContent.data.currentSlideIndex as number)
+    : null
+}
+
+test.describe('Keyboard stays live after presenting', () => {
+  test('PowerPoint layout: Present focuses the live thumbnail; projecting a slide does too', async ({
+    page,
+    request,
+  }) => {
+    const song = await createSong(request, `E2E Focus Stage ${Date.now()}`)
+    try {
+      await page.addInitScript(() => {
+        window.localStorage.setItem('song-editor-layout', 'powerpoint')
+      })
+      await page.goto(`/songs/${song.id}`)
+      await page.waitForLoadState('networkidle')
+      const thumbs = page.getByTestId('stage-thumbnail')
+      await expect(thumbs).toHaveCount(3, { timeout: 10000 })
+
+      await page.getByTestId('stage-present').click()
+      await expect(page.getByTestId('stage-hide')).toBeVisible({
+        timeout: 10000,
+      })
+      // The button that was clicked no longer holds the keyboard — the live
+      // slide's thumbnail does.
+      await expect(thumbs.nth(0)).toBeFocused()
+
+      await page.keyboard.press('ArrowRight')
+      await expect.poll(() => liveSlideIndex(request)).toBe(1)
+      await expect(thumbs.nth(1)).toBeFocused()
+
+      // Projecting a slide with its own button (not "Present") hands the
+      // keyboard over as well.
+      await page.getByTestId('stage-hide').click()
+      await expect.poll(() => liveSlideIndex(request)).toBeNull()
+      const project = page.getByTestId('thumb-project').nth(2)
+      await project.click()
+      await expect.poll(() => liveSlideIndex(request)).toBe(2)
+      await expect(page.getByTestId('stage-thumbnail')).toHaveCount(3)
+      await expect(
+        page.locator('[data-testid="stage-thumbnail"]:focus'),
+      ).toHaveCount(1)
+    } finally {
+      await request.post('/api/presentation/clear-temporary').catch(() => {})
+      await request.delete(`/api/songs/${song.id}`).catch(() => {})
+    }
+  })
+
+  test('classic layout: clicking a slide focuses the live slide', async ({
+    page,
+    request,
+  }) => {
+    const song = await createSong(request, `E2E Focus Classic ${Date.now()}`)
+    try {
+      await page.addInitScript(() => {
+        window.localStorage.setItem('song-editor-layout', 'normal')
+      })
+      await page.goto(`/songs/${song.id}`)
+      await page.waitForLoadState('networkidle')
+      await expect(page.getByTestId('song-slide-0')).toBeVisible({
+        timeout: 10000,
+      })
+
+      await page.getByTestId('song-slide-1').click()
+      await expect.poll(() => liveSlideIndex(request)).toBe(1)
+      // Wait for the page to see it live, or the arrow below would move the
+      // local selection instead of the projection.
+      await expect(page.getByTestId('song-slide-1')).toHaveAttribute(
+        'aria-current',
+        'true',
+      )
+      await expect(page.getByTestId('song-slide-1')).toBeFocused()
+
+      await page.keyboard.press('ArrowRight')
+      await expect.poll(() => liveSlideIndex(request)).toBe(2)
+      await expect(page.getByTestId('song-slide-2')).toBeFocused()
+    } finally {
+      await request.post('/api/presentation/clear-temporary').catch(() => {})
+      await request.delete(`/api/songs/${song.id}`).catch(() => {})
+    }
+  })
+
+  test('the projection window navigates with arrows and remote keys', async ({
+    page,
+    request,
+  }) => {
+    const song = await createSong(request, `E2E Focus Screen ${Date.now()}`)
+    const screensResponse = await request.get('/api/screens')
+    const { data: screens } = await screensResponse.json()
+    const screen = screens[0] as { id: number } | undefined
+    test.skip(!screen, 'no screens configured')
+
+    try {
+      await request.post('/api/presentation/temporary-song', {
+        data: { songId: song.id, slideIndex: 0 },
+      })
+      await page.goto(`/screen/${screen?.id}`)
+      await page.waitForLoadState('networkidle')
+
+      await page.keyboard.press('ArrowRight')
+      await expect
+        .poll(() => liveSlideIndex(request), { timeout: 10000 })
+        .toBe(1)
+      await page.keyboard.press('PageDown')
+      await expect.poll(() => liveSlideIndex(request)).toBe(2)
+      await page.keyboard.press('ArrowLeft')
+      await expect.poll(() => liveSlideIndex(request)).toBe(1)
+      await page.keyboard.press('PageUp')
+      await expect.poll(() => liveSlideIndex(request)).toBe(0)
+    } finally {
+      await request.post('/api/presentation/clear-temporary').catch(() => {})
+      await request.delete(`/api/songs/${song.id}`).catch(() => {})
+    }
+  })
+})

--- a/app/apps/client/src/features/keyboard-shortcuts/components/AppShortcutsPanel.tsx
+++ b/app/apps/client/src/features/keyboard-shortcuts/components/AppShortcutsPanel.tsx
@@ -54,11 +54,7 @@ export function AppShortcutsPanel() {
           <p className="mb-4 mt-1 text-sm text-gray-600 dark:text-gray-400">
             {t('sections.shortcuts.groups.pagesDescription')}
           </p>
-          <PageShortcutsSettings
-            pageId={pageId}
-            showHeading={false}
-            includeShowSlide={false}
-          />
+          <PageShortcutsSettings pageId={pageId} showHeading={false} />
         </section>
       ))}
     </div>

--- a/app/apps/client/src/features/keyboard-shortcuts/components/GlobalAppShortcutManager.tsx
+++ b/app/apps/client/src/features/keyboard-shortcuts/components/GlobalAppShortcutManager.tsx
@@ -6,13 +6,17 @@ import {
   useNavigateTemporary,
   useShowSlide,
 } from '~/features/presentation/hooks'
-import { useSidebarItemShortcuts } from '~/features/sidebar-config'
+import {
+  usePageShortcuts,
+  useSidebarItemShortcuts,
+} from '~/features/sidebar-config'
 import { createLogger } from '~/utils/logger'
 import { useShortcutRecording } from '../context'
 import { useAppShortcuts, useGlobalAppShortcuts } from '../hooks'
 import { useMIDILEDFeedback } from '../midi/hooks'
 import { focusMainWindow } from '../utils/focusMainWindow'
 import { emitFocusSearchEvent } from '../utils/focusSearchEvent'
+import { emitPageShortcutEvent } from '../utils/pageShortcutEvent'
 import { useGlobalRecordingState } from '../utils/recordingState'
 
 const logger = createLogger('keyboard-shortcuts:manager')
@@ -29,6 +33,11 @@ export function GlobalAppShortcutManager() {
   const navigateTemporary = useNavigateTemporary()
   const showSlide = useShowSlide()
   const sidebarShortcuts = useSidebarItemShortcuts()
+  const pageShortcuts = usePageShortcuts()
+  const pageShortcutKeys = useMemo(
+    () => pageShortcuts.map((entry) => entry.shortcut),
+    [pageShortcuts],
+  )
 
   // Synchronous guards to prevent multiple rapid triggers (React state can be stale)
   const isStartOperationRef = useRef(false)
@@ -161,11 +170,45 @@ export function GlobalAppShortcutManager() {
     [navigate, location],
   )
 
+  // A page-scoped key means whatever the OPEN page bound it to — and nothing
+  // at all on any other page. So "F5" can show the selected slide on Songs
+  // and the selected verse on Bible, and pressing it on Settings does nothing.
+  const handlePageShortcut = useCallback(
+    (shortcut: string) => {
+      const currentPath = location.pathname.replace(/\/$/, '')
+      const entry = pageShortcuts.find((candidate) => {
+        if (candidate.shortcut !== shortcut) return false
+        const route = candidate.route.replace(/\/$/, '')
+        return currentPath === route || currentPath.startsWith(`${route}/`)
+      })
+      if (!entry) {
+        logger.debug(
+          `Page shortcut ${shortcut} ignored: no page bound to it is open (${location.pathname})`,
+        )
+        return
+      }
+      logger.debug(
+        `Page shortcut ${shortcut} -> ${entry.pageId}.${entry.action}`,
+      )
+      if (entry.action === 'nextSlide') {
+        navigateTemporary.mutate({ direction: 'next' })
+        return
+      }
+      if (entry.action === 'prevSlide') {
+        navigateTemporary.mutate({ direction: 'prev' })
+        return
+      }
+      emitPageShortcutEvent(entry.pageId, entry.action)
+    },
+    [location.pathname, pageShortcuts, navigateTemporary],
+  )
+
   // Register keyboard shortcuts
   useGlobalAppShortcuts({
     shortcuts: isLoading ? { actions: {} as never, version: 1 } : shortcuts,
     sceneShortcuts,
     sidebarShortcuts,
+    pageShortcuts: pageShortcutKeys,
     onStartLive: handleStartLive,
     onStopLive: handleStopLive,
     onShowSlide: handleShowSlide,
@@ -173,6 +216,7 @@ export function GlobalAppShortcutManager() {
     onPrevSlide: handlePrevSlide,
     onSceneSwitch: handleSceneSwitch,
     onSidebarNavigation: handleSidebarNavigation,
+    onPageShortcut: handlePageShortcut,
     isRecordingRef,
     isRecording: isGlobalRecording,
   })

--- a/app/apps/client/src/features/keyboard-shortcuts/components/PageShortcutsSettings.tsx
+++ b/app/apps/client/src/features/keyboard-shortcuts/components/PageShortcutsSettings.tsx
@@ -1,15 +1,17 @@
-import { Keyboard, Plus } from 'lucide-react'
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { Keyboard } from 'lucide-react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { getDefaultSidebarItemSettings } from '~/features/sidebar-config/constants'
 import { useSidebarConfig } from '~/features/sidebar-config/hooks/useSidebarConfig'
-import type {
-  BuiltInMenuItem,
-  BuiltInMenuItemId,
-  SidebarItemSettings,
+import {
+  type BuiltInMenuItem,
+  type BuiltInMenuItemId,
+  PAGE_SHORTCUT_ACTIONS,
+  type PageShortcutAction,
+  type SidebarItemSettings,
 } from '~/features/sidebar-config/types'
-import { ShortcutRecorder } from './ShortcutRecorder'
+import { ShortcutListSection } from './ShortcutListSection'
 import { useAppShortcuts } from '../hooks'
 import type { GlobalShortcutActionId } from '../types'
 import { VALID_ACTION_IDS } from '../utils'
@@ -19,28 +21,46 @@ interface PageShortcutsSettingsProps {
   pageId: BuiltInMenuItemId
   /** Render the internal "Keyboard Shortcuts" heading (default true). */
   showHeading?: boolean
-  /** Include the global "Display Selected Slide" section (default true). */
-  includeShowSlide?: boolean
 }
 
+type PageShortcutLists = Record<PageShortcutAction, string[]>
+
+/** The shortcut-bearing part of a page's settings, comparable as a string. */
+function snapshotOf(settings: SidebarItemSettings): string {
+  return JSON.stringify({
+    shortcuts: settings.shortcuts,
+    focusSearchShortcuts: settings.focusSearchShortcuts ?? [],
+    pageShortcuts: {
+      showSlide: settings.pageShortcuts?.showSlide ?? [],
+      nextSlide: settings.pageShortcuts?.nextSlide ?? [],
+      prevSlide: settings.pageShortcuts?.prevSlide ?? [],
+    },
+  })
+}
+
+const emptyPageLists = (): PageShortcutLists => ({
+  showSlide: [],
+  nextSlide: [],
+  prevSlide: [],
+})
+
 /**
- * Granular shortcut settings for a page (switch, focus search, display slide).
+ * Shortcut settings for one page: switch to it, focus its search, and its own
+ * presentation keys (show the selected slide/verse, next, previous) — which
+ * work only while that page is open, so two pages may bind the same key.
  * Hosted in the consolidated Shortcuts settings page.
  */
 export function PageShortcutsSettings({
   pageId,
   showHeading = true,
-  includeShowSlide = true,
 }: PageShortcutsSettingsProps) {
   const { t } = useTranslation('settings')
   const { config, updateConfig } = useSidebarConfig()
-  const { shortcuts: globalShortcuts, updateActionShortcuts } =
-    useAppShortcuts()
+  const { shortcuts: globalShortcuts } = useAppShortcuts()
 
-  // Local state for the three shortcut types
   const [switchShortcuts, setSwitchShortcuts] = useState<string[]>([])
   const [focusSearchShortcuts, setFocusSearchShortcuts] = useState<string[]>([])
-  const [showSlideShortcuts, setShowSlideShortcuts] = useState<string[]>([])
+  const [pageLists, setPageLists] = useState<PageShortcutLists>(emptyPageLists)
 
   // Find the sidebar item for this page
   const sidebarItem = useMemo(() => {
@@ -52,11 +72,17 @@ export function PageShortcutsSettings({
     )
   }, [config, pageId])
 
-  // Load initial values from config
+  // What this component last wrote. Its own save comes straight back through
+  // the config — without empty rows, which are only ever local — and must not
+  // wipe the row the operator is about to record into.
+  const lastSavedRef = useRef<string | null>(null)
+
+  // Load values from config (initially, and whenever it changes elsewhere)
   useEffect(() => {
     if (!sidebarItem) return
     const settings =
       sidebarItem.settings ?? getDefaultSidebarItemSettings(pageId)
+    if (lastSavedRef.current === snapshotOf(settings)) return
 
     setSwitchShortcuts([...settings.shortcuts])
     // Migrate legacy: if focusSearchOnNavigate was true and no focusSearchShortcuts,
@@ -70,23 +96,36 @@ export function PageShortcutsSettings({
     } else {
       setFocusSearchShortcuts([...(settings.focusSearchShortcuts ?? [])])
     }
+    const lists = emptyPageLists()
+    for (const action of PAGE_SHORTCUT_ACTIONS) {
+      lists[action] = [...(settings.pageShortcuts?.[action] ?? [])]
+    }
+    setPageLists(lists)
+  }, [sidebarItem, pageId])
 
-    // Load showSlide shortcuts from global config
-    const showSlideConfig = globalShortcuts.actions.showSlide
-    setShowSlideShortcuts([...(showSlideConfig?.shortcuts ?? [])])
-  }, [sidebarItem, pageId, globalShortcuts.actions.showSlide])
+  const clean = (list: string[]) => list.filter((s) => s.trim())
 
-  // Save sidebar item shortcuts (switch + focus search)
-  const saveSidebarShortcuts = useCallback(
-    (newSwitch: string[], newFocusSearch: string[]) => {
+  // Persist everything this page owns in one go.
+  const save = useCallback(
+    (
+      nextSwitch: string[],
+      nextFocusSearch: string[],
+      nextPageLists: PageShortcutLists,
+    ) => {
       if (!config || !sidebarItem) return
 
       const settings: SidebarItemSettings = {
         ...(sidebarItem.settings ?? getDefaultSidebarItemSettings(pageId)),
-        shortcuts: newSwitch.filter((s) => s.trim()),
+        shortcuts: clean(nextSwitch),
         focusSearchOnNavigate: false,
-        focusSearchShortcuts: newFocusSearch.filter((s) => s.trim()),
+        focusSearchShortcuts: clean(nextFocusSearch),
+        pageShortcuts: {
+          showSlide: clean(nextPageLists.showSlide),
+          nextSlide: clean(nextPageLists.nextSlide),
+          prevSlide: clean(nextPageLists.prevSlide),
+        },
       }
+      lastSavedRef.current = snapshotOf(settings)
 
       const updatedItems = config.items.map((item) =>
         item.id === sidebarItem.id ? { ...item, settings } : item,
@@ -97,16 +136,46 @@ export function PageShortcutsSettings({
     [config, sidebarItem, pageId, updateConfig],
   )
 
-  // Validate shortcut for conflicts
+  const handleSwitchChange = useCallback(
+    (next: string[]) => {
+      setSwitchShortcuts(next)
+      save(next, focusSearchShortcuts, pageLists)
+    },
+    [save, focusSearchShortcuts, pageLists],
+  )
+
+  const handleFocusSearchChange = useCallback(
+    (next: string[]) => {
+      setFocusSearchShortcuts(next)
+      save(switchShortcuts, next, pageLists)
+    },
+    [save, switchShortcuts, pageLists],
+  )
+
+  const handlePageListChange = useCallback(
+    (action: PageShortcutAction, next: string[]) => {
+      const nextLists = { ...pageLists, [action]: next }
+      setPageLists(nextLists)
+      save(switchShortcuts, focusSearchShortcuts, nextLists)
+    },
+    [save, switchShortcuts, focusSearchShortcuts, pageLists],
+  )
+
+  /**
+   * A key may not be bound twice on this page, nor clash with a global
+   * action (which fires everywhere and would win). It MAY be the same key
+   * another page uses for its own actions — which page is open decides.
+   * Switching to the page and focusing its search are allowed to share a key.
+   */
   const getShortcutError = useCallback(
     (
       shortcut: string,
       index: number,
       sourceList: string[],
+      sourceName: 'switch' | 'focusSearch' | PageShortcutAction,
     ): string | undefined => {
       if (!shortcut) return undefined
 
-      // Check for duplicates within the same list
       const duplicateIndex = sourceList.findIndex(
         (s, i) => i !== index && s === shortcut,
       )
@@ -114,233 +183,112 @@ export function PageShortcutsSettings({
         return t('sections.sidebarItem.shortcuts.duplicateError')
       }
 
-      // Check against global shortcuts (skip showSlide since it's displayed separately)
+      const otherLists: Array<
+        ['switch' | 'focusSearch' | PageShortcutAction, string[]]
+      > = [
+        ['switch', switchShortcuts],
+        ['focusSearch', focusSearchShortcuts],
+        ...PAGE_SHORTCUT_ACTIONS.map(
+          (action) =>
+            [action, pageLists[action]] as [PageShortcutAction, string[]],
+        ),
+      ]
+      const navigation = new Set(['switch', 'focusSearch'])
+      for (const [name, list] of otherLists) {
+        if (name === sourceName) continue
+        if (navigation.has(name) && navigation.has(sourceName)) continue
+        if (list.includes(shortcut)) {
+          return t('sections.sidebarItem.shortcuts.duplicateError')
+        }
+      }
+
       for (const [actionId, actionConfig] of Object.entries(
         globalShortcuts.actions,
       )) {
         if (!VALID_ACTION_IDS.includes(actionId as GlobalShortcutActionId))
           continue
-        if (actionId === 'showSlide') continue // Allow since we show it here
         if (actionConfig.shortcuts.includes(shortcut)) {
           return t('sections.sidebarItem.shortcuts.conflictGlobal', {
-            action: actionId,
+            action: t(`sections.shortcuts.actions.${actionId}.label`),
           })
         }
       }
 
       return undefined
     },
-    [globalShortcuts, t],
+    [switchShortcuts, focusSearchShortcuts, pageLists, globalShortcuts, t],
   )
 
-  // Switch shortcut handlers
-  const handleAddSwitch = useCallback(() => {
-    setSwitchShortcuts((prev) => [...prev, ''])
-  }, [])
-
-  const handleUpdateSwitch = useCallback(
-    (index: number, value: string) => {
-      setSwitchShortcuts((prev) => {
-        const updated = [...prev]
-        updated[index] = value
-        saveSidebarShortcuts(updated, focusSearchShortcuts)
-        return updated
-      })
-    },
-    [focusSearchShortcuts, saveSidebarShortcuts],
-  )
-
-  const handleRemoveSwitch = useCallback(
-    (index: number) => {
-      setSwitchShortcuts((prev) => {
-        const updated = prev.filter((_, i) => i !== index)
-        saveSidebarShortcuts(updated, focusSearchShortcuts)
-        return updated
-      })
-    },
-    [focusSearchShortcuts, saveSidebarShortcuts],
-  )
-
-  // Focus search shortcut handlers
-  const handleAddFocusSearch = useCallback(() => {
-    setFocusSearchShortcuts((prev) => [...prev, ''])
-  }, [])
-
-  const handleUpdateFocusSearch = useCallback(
-    (index: number, value: string) => {
-      setFocusSearchShortcuts((prev) => {
-        const updated = [...prev]
-        updated[index] = value
-        saveSidebarShortcuts(switchShortcuts, updated)
-        return updated
-      })
-    },
-    [switchShortcuts, saveSidebarShortcuts],
-  )
-
-  const handleRemoveFocusSearch = useCallback(
-    (index: number) => {
-      setFocusSearchShortcuts((prev) => {
-        const updated = prev.filter((_, i) => i !== index)
-        saveSidebarShortcuts(switchShortcuts, updated)
-        return updated
-      })
-    },
-    [switchShortcuts, saveSidebarShortcuts],
-  )
-
-  // Show slide shortcut handlers
-  const handleAddShowSlide = useCallback(() => {
-    setShowSlideShortcuts((prev) => [...prev, ''])
-  }, [])
-
-  const handleUpdateShowSlide = useCallback(
-    (index: number, value: string) => {
-      setShowSlideShortcuts((prev) => {
-        const updated = [...prev]
-        updated[index] = value
-        updateActionShortcuts('showSlide', {
-          shortcuts: updated.filter((s) => s.trim()),
-          enabled: true,
-        })
-        return updated
-      })
-    },
-    [updateActionShortcuts],
-  )
-
-  const handleRemoveShowSlide = useCallback(
-    (index: number) => {
-      setShowSlideShortcuts((prev) => {
-        const updated = prev.filter((_, i) => i !== index)
-        updateActionShortcuts('showSlide', {
-          shortcuts: updated.filter((s) => s.trim()),
-          enabled: true,
-        })
-        return updated
-      })
-    },
-    [updateActionShortcuts],
-  )
+  const pageLabel = (
+    action: PageShortcutAction,
+    field: 'title' | 'description',
+  ) =>
+    t(`sections.sidebarItem.shortcuts.page.${pageId}.${action}.${field}`, {
+      defaultValue: t(
+        `sections.sidebarItem.shortcuts.page.default.${action}.${field}`,
+      ),
+    })
 
   return (
     <div className="space-y-4">
       {showHeading && (
-        <div className="flex items-center gap-2 mb-2">
-          <Keyboard className="w-5 h-5 text-gray-600 dark:text-gray-400" />
+        <div className="mb-2 flex items-center gap-2">
+          <Keyboard className="h-5 w-5 text-gray-600 dark:text-gray-400" />
           <h3 className="text-lg font-semibold text-gray-900 dark:text-white">
             {t('sections.sidebarItem.shortcuts.title')}
           </h3>
         </div>
       )}
 
-      {/* Switch to Page Shortcuts */}
-      <div className="space-y-2">
-        <div>
-          <h4 className="text-sm font-medium text-gray-900 dark:text-white">
-            {t('sections.sidebarItem.shortcuts.switchTitle')}
-          </h4>
-          <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
-            {t('sections.sidebarItem.shortcuts.switchDescription')}
-          </p>
-        </div>
+      <ShortcutListSection
+        title={t('sections.sidebarItem.shortcuts.switchTitle')}
+        description={t('sections.sidebarItem.shortcuts.switchDescription')}
+        shortcuts={switchShortcuts}
+        onChange={handleSwitchChange}
+        getError={(s, i, list) => getShortcutError(s, i, list, 'switch')}
+        testId={`page-shortcuts-${pageId}-switch`}
+      />
 
-        <div className="space-y-2">
-          {switchShortcuts.map((shortcut, index) => (
-            <ShortcutRecorder
-              key={`switch-${index}`}
-              value={shortcut}
-              onChange={(value) => handleUpdateSwitch(index, value)}
-              onRemove={() => handleRemoveSwitch(index)}
-              error={getShortcutError(shortcut, index, switchShortcuts)}
-              namespace="settings"
-            />
-          ))}
-        </div>
-
-        <button
-          type="button"
-          onClick={handleAddSwitch}
-          className="flex items-center gap-2 text-sm text-indigo-600 dark:text-indigo-400 hover:text-indigo-700 dark:hover:text-indigo-300"
-        >
-          <Plus size={16} />
-          {t('sections.shortcuts.addShortcut')}
-        </button>
+      <div className="border-gray-200 border-t pt-2 dark:border-gray-700">
+        <ShortcutListSection
+          title={t('sections.sidebarItem.shortcuts.focusSearchTitle')}
+          description={t(
+            'sections.sidebarItem.shortcuts.focusSearchDescription',
+          )}
+          shortcuts={focusSearchShortcuts}
+          onChange={handleFocusSearchChange}
+          getError={(s, i, list) => getShortcutError(s, i, list, 'focusSearch')}
+          testId={`page-shortcuts-${pageId}-focus-search`}
+        />
       </div>
 
-      {/* Focus Search Shortcuts */}
-      <div className="space-y-2 pt-2 border-t border-gray-200 dark:border-gray-700">
-        <div>
-          <h4 className="text-sm font-medium text-gray-900 dark:text-white">
-            {t('sections.sidebarItem.shortcuts.focusSearchTitle')}
-          </h4>
-          <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
-            {t('sections.sidebarItem.shortcuts.focusSearchDescription')}
-          </p>
-        </div>
-
-        <div className="space-y-2">
-          {focusSearchShortcuts.map((shortcut, index) => (
-            <ShortcutRecorder
-              key={`focus-${index}`}
-              value={shortcut}
-              onChange={(value) => handleUpdateFocusSearch(index, value)}
-              onRemove={() => handleRemoveFocusSearch(index)}
-              error={getShortcutError(shortcut, index, focusSearchShortcuts)}
-              namespace="settings"
-            />
-          ))}
-        </div>
-
-        <button
-          type="button"
-          onClick={handleAddFocusSearch}
-          className="flex items-center gap-2 text-sm text-indigo-600 dark:text-indigo-400 hover:text-indigo-700 dark:hover:text-indigo-300"
-        >
-          <Plus size={16} />
-          {t('sections.shortcuts.addShortcut')}
-        </button>
-      </div>
-
-      {/* Display Selected Slide Shortcuts */}
-      {includeShowSlide && (
-        <div className="space-y-2 pt-2 border-t border-gray-200 dark:border-gray-700">
-          <div>
-            <h4 className="text-sm font-medium text-gray-900 dark:text-white">
-              {t('sections.sidebarItem.shortcuts.showSlideTitle')}
-            </h4>
-            <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
-              {t('sections.sidebarItem.shortcuts.showSlideDescription')}
-            </p>
-          </div>
-
-          <div className="space-y-2">
-            {showSlideShortcuts.map((shortcut, index) => (
-              <ShortcutRecorder
-                key={`show-${index}`}
-                value={shortcut}
-                onChange={(value) => handleUpdateShowSlide(index, value)}
-                onRemove={() => handleRemoveShowSlide(index)}
-                error={getShortcutError(shortcut, index, showSlideShortcuts)}
-                namespace="settings"
-              />
-            ))}
-          </div>
-
-          <button
-            type="button"
-            onClick={handleAddShowSlide}
-            className="flex items-center gap-2 text-sm text-indigo-600 dark:text-indigo-400 hover:text-indigo-700 dark:hover:text-indigo-300"
-          >
-            <Plus size={16} />
-            {t('sections.shortcuts.addShortcut')}
-          </button>
-        </div>
-      )}
-
-      <p className="text-xs text-gray-400 dark:text-gray-500 italic">
+      <p className="text-gray-400 text-xs italic dark:text-gray-500">
         {t('sections.sidebarItem.shortcuts.sameShortcutHint')}
       </p>
+
+      {/* Presentation keys that only work while this page is open */}
+      <div className="space-y-4 border-gray-200 border-t pt-3 dark:border-gray-700">
+        <div>
+          <h4 className="font-semibold text-gray-900 text-sm dark:text-white">
+            {t('sections.sidebarItem.shortcuts.page.title')}
+          </h4>
+          <p className="mt-0.5 text-gray-500 text-xs dark:text-gray-400">
+            {t('sections.sidebarItem.shortcuts.page.description')}
+          </p>
+        </div>
+        {PAGE_SHORTCUT_ACTIONS.map((action) => (
+          <ShortcutListSection
+            key={action}
+            title={pageLabel(action, 'title')}
+            description={pageLabel(action, 'description')}
+            shortcuts={pageLists[action]}
+            onChange={(next) => handlePageListChange(action, next)}
+            getError={(s, i, list) => getShortcutError(s, i, list, action)}
+            allowMidi={false}
+            testId={`page-shortcuts-${pageId}-${action}`}
+          />
+        ))}
+      </div>
     </div>
   )
 }

--- a/app/apps/client/src/features/keyboard-shortcuts/components/ShortcutListSection.tsx
+++ b/app/apps/client/src/features/keyboard-shortcuts/components/ShortcutListSection.tsx
@@ -1,0 +1,86 @@
+import { Plus } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+
+import { ShortcutRecorder } from './ShortcutRecorder'
+
+interface ShortcutListSectionProps {
+  title: string
+  description: string
+  shortcuts: string[]
+  onChange: (shortcuts: string[]) => void
+  getError: (
+    shortcut: string,
+    index: number,
+    list: string[],
+  ) => string | undefined
+  /** Whether a MIDI button may be recorded (default true). */
+  allowMidi?: boolean
+  /** Test id of the section; recorders get `${testId}-recorder`. */
+  testId?: string
+}
+
+/**
+ * One titled list of shortcut recorders with an "add" button — the building
+ * block every per-page shortcut group is made of.
+ */
+export function ShortcutListSection({
+  title,
+  description,
+  shortcuts,
+  onChange,
+  getError,
+  allowMidi = true,
+  testId,
+}: ShortcutListSectionProps) {
+  const { t } = useTranslation('settings')
+
+  return (
+    <div className="space-y-2" data-testid={testId}>
+      <div>
+        <h4 className="text-sm font-medium text-gray-900 dark:text-white">
+          {title}
+        </h4>
+        <p className="mt-0.5 text-xs text-gray-500 dark:text-gray-400">
+          {description}
+        </p>
+      </div>
+
+      <div className="space-y-2">
+        {shortcuts.map((shortcut, index) => {
+          const error = getError(shortcut, index, shortcuts)
+          return (
+            <div key={index}>
+              <ShortcutRecorder
+                value={shortcut}
+                onChange={(value) =>
+                  onChange(shortcuts.map((s, i) => (i === index ? value : s)))
+                }
+                onRemove={() =>
+                  onChange(shortcuts.filter((_, i) => i !== index))
+                }
+                error={error}
+                namespace="settings"
+                allowMidi={allowMidi}
+              />
+              {error && (
+                <p className="mt-1 text-red-600 text-xs dark:text-red-400">
+                  {error}
+                </p>
+              )}
+            </div>
+          )
+        })}
+      </div>
+
+      <button
+        type="button"
+        onClick={() => onChange([...shortcuts, ''])}
+        data-testid={testId ? `${testId}-add` : undefined}
+        className="flex items-center gap-2 text-sm text-indigo-600 hover:text-indigo-700 dark:text-indigo-400 dark:hover:text-indigo-300"
+      >
+        <Plus size={16} />
+        {t('sections.shortcuts.addShortcut')}
+      </button>
+    </div>
+  )
+}

--- a/app/apps/client/src/features/keyboard-shortcuts/components/ShortcutRecorder.tsx
+++ b/app/apps/client/src/features/keyboard-shortcuts/components/ShortcutRecorder.tsx
@@ -18,6 +18,11 @@ interface ShortcutRecorderProps {
   onRemove: () => void
   error?: string
   namespace?: string
+  /**
+   * Whether a MIDI button may be recorded here (default true). Off for
+   * bindings only the client can act on — MIDI is dispatched by the server.
+   */
+  allowMidi?: boolean
 }
 
 export function ShortcutRecorder({
@@ -26,6 +31,7 @@ export function ShortcutRecorder({
   onRemove,
   error,
   namespace = 'settings',
+  allowMidi = true,
 }: ShortcutRecorderProps) {
   const { t } = useTranslation(namespace)
   const [isRecording, setIsRecording] = useState(false)
@@ -46,7 +52,7 @@ export function ShortcutRecorder({
 
   // Subscribe to MIDI messages when recording
   useEffect(() => {
-    if (!isRecording || !midi) return
+    if (!isRecording || !midi || !allowMidi) return
 
     // Request MIDI access to ensure WebSocket is connected for recording
     // This works even if MIDI is not globally enabled - we still want to capture shortcuts
@@ -66,7 +72,7 @@ export function ShortcutRecorder({
     })
 
     return unsubscribe
-  }, [isRecording, midi, recording])
+  }, [isRecording, midi, recording, allowMidi])
 
   const translationPrefix =
     namespace === 'livestream' ? 'scenes' : 'sections.shortcuts'
@@ -133,7 +139,7 @@ export function ShortcutRecorder({
         defaultValue: 'Click to record',
       })
     }
-    if (midi?.isEnabled) {
+    if (midi?.isEnabled && allowMidi) {
       return t(`${translationPrefix}.recordShortcutOrMidi`, {
         defaultValue: 'Press key or MIDI button...',
       })

--- a/app/apps/client/src/features/keyboard-shortcuts/hooks/useGlobalAppShortcuts.ts
+++ b/app/apps/client/src/features/keyboard-shortcuts/hooks/useGlobalAppShortcuts.ts
@@ -27,6 +27,12 @@ interface UseGlobalAppShortcutsOptions {
   shortcuts: GlobalShortcutsConfig
   sceneShortcuts: SceneShortcut[]
   sidebarShortcuts: SidebarShortcut[]
+  /**
+   * Keys that pages bound to their own presentation actions. Registered once
+   * each, however many pages share them; the handler gets the key and decides
+   * what it means from the page that is open.
+   */
+  pageShortcuts?: string[]
   onStartLive: () => void
   onStopLive: () => void
   onShowSlide: () => void
@@ -34,6 +40,7 @@ interface UseGlobalAppShortcutsOptions {
   onPrevSlide: () => void
   onSceneSwitch: (sceneName: string) => void
   onSidebarNavigation: (route: string, focusSearch: boolean) => void
+  onPageShortcut?: (shortcut: string) => void
   /** Ref to check if a ShortcutRecorder is currently recording */
   isRecordingRef?: React.RefObject<boolean>
   /** Whether any ShortcutRecorder is currently recording (reactive state) */
@@ -44,6 +51,7 @@ export function useGlobalAppShortcuts({
   shortcuts,
   sceneShortcuts,
   sidebarShortcuts,
+  pageShortcuts = [],
   onStartLive,
   onStopLive,
   onShowSlide,
@@ -51,6 +59,7 @@ export function useGlobalAppShortcuts({
   onPrevSlide,
   onSceneSwitch,
   onSidebarNavigation,
+  onPageShortcut,
   isRecordingRef,
   isRecording = false,
 }: UseGlobalAppShortcutsOptions) {
@@ -63,6 +72,7 @@ export function useGlobalAppShortcuts({
     onPrevSlide,
     onSceneSwitch,
     onSidebarNavigation,
+    onPageShortcut,
   })
 
   // Keep handlers ref updated
@@ -75,6 +85,7 @@ export function useGlobalAppShortcuts({
       onPrevSlide,
       onSceneSwitch,
       onSidebarNavigation,
+      onPageShortcut,
     }
   }, [
     onStartLive,
@@ -84,12 +95,14 @@ export function useGlobalAppShortcuts({
     onPrevSlide,
     onSceneSwitch,
     onSidebarNavigation,
+    onPageShortcut,
   ])
 
   // Use JSON stringified config as dependency to avoid object reference issues
   const shortcutsJson = JSON.stringify(shortcuts)
   const sceneShortcutsJson = JSON.stringify(sceneShortcuts)
   const sidebarShortcutsJson = JSON.stringify(sidebarShortcuts)
+  const pageShortcutsJson = JSON.stringify(pageShortcuts)
 
   useEffect(() => {
     // Skip if not running in Tauri (global shortcuts require Tauri)
@@ -115,6 +128,7 @@ export function useGlobalAppShortcuts({
       const config: GlobalShortcutsConfig = JSON.parse(shortcutsJson)
       const scenes: SceneShortcut[] = JSON.parse(sceneShortcutsJson)
       const sidebarItems: SidebarShortcut[] = JSON.parse(sidebarShortcutsJson)
+      const pageKeys: string[] = JSON.parse(pageShortcutsJson)
 
       try {
         // Unregister all existing shortcuts first
@@ -276,6 +290,33 @@ export function useGlobalAppShortcuts({
           }
         }
 
+        // Register page-scoped shortcuts: one registration per key, whatever
+        // number of pages bound it. A key a global action already owns is
+        // left to that action — the settings refuse such a conflict anyway.
+        for (const shortcut of new Set(pageKeys)) {
+          if (!shortcut || registeredShortcuts.has(shortcut)) continue
+          if (isCancelled) return
+
+          try {
+            await register(shortcut, (event) => {
+              if (event.state === 'Pressed') {
+                if (isGlobalRecordingActive() || isRecordingRef?.current) {
+                  logger.debug(
+                    `Skipping page shortcut ${shortcut} - recording in progress`,
+                  )
+                  return
+                }
+                logger.info(`Page shortcut triggered: ${shortcut}`)
+                handlersRef.current.onPageShortcut?.(shortcut)
+              }
+            })
+            registeredShortcuts.add(shortcut)
+            logger.info(`Registered page shortcut: ${shortcut}`)
+          } catch (error) {
+            logger.error(`Failed to register page shortcut ${shortcut}:`, error)
+          }
+        }
+
         logger.info('All shortcuts registered successfully')
       } catch (error) {
         logger.error('Failed to register shortcuts:', error)
@@ -294,5 +335,11 @@ export function useGlobalAppShortcuts({
         })
       }
     }
-  }, [shortcutsJson, sceneShortcutsJson, sidebarShortcutsJson, isRecording])
+  }, [
+    shortcutsJson,
+    sceneShortcutsJson,
+    sidebarShortcutsJson,
+    pageShortcutsJson,
+    isRecording,
+  ])
 }

--- a/app/apps/client/src/features/keyboard-shortcuts/utils/__tests__/pageShortcutEvent.test.tsx
+++ b/app/apps/client/src/features/keyboard-shortcuts/utils/__tests__/pageShortcutEvent.test.tsx
@@ -1,0 +1,45 @@
+import { renderHook } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import {
+  emitPageShortcutEvent,
+  usePageShortcutEvent,
+} from '../pageShortcutEvent'
+
+describe('page shortcut event', () => {
+  it('reaches only the page and action it was raised for', () => {
+    const songs = vi.fn()
+    const bible = vi.fn()
+    const songsNext = vi.fn()
+    renderHook(() => usePageShortcutEvent('songs', 'showSlide', songs))
+    renderHook(() => usePageShortcutEvent('bible', 'showSlide', bible))
+    renderHook(() => usePageShortcutEvent('songs', 'nextSlide', songsNext))
+
+    emitPageShortcutEvent('songs', 'showSlide')
+
+    expect(songs).toHaveBeenCalledTimes(1)
+    expect(bible).not.toHaveBeenCalled()
+    expect(songsNext).not.toHaveBeenCalled()
+  })
+
+  it('is ignored by a page that is not listening', () => {
+    const songs = vi.fn()
+    renderHook(() => usePageShortcutEvent('songs', 'showSlide', songs, false))
+
+    emitPageShortcutEvent('songs', 'showSlide')
+
+    expect(songs).not.toHaveBeenCalled()
+  })
+
+  it('stops listening once unmounted', () => {
+    const songs = vi.fn()
+    const { unmount } = renderHook(() =>
+      usePageShortcutEvent('songs', 'showSlide', songs),
+    )
+    unmount()
+
+    emitPageShortcutEvent('songs', 'showSlide')
+
+    expect(songs).not.toHaveBeenCalled()
+  })
+})

--- a/app/apps/client/src/features/keyboard-shortcuts/utils/index.ts
+++ b/app/apps/client/src/features/keyboard-shortcuts/utils/index.ts
@@ -1,5 +1,9 @@
 export { emitFocusSearchEvent, useFocusSearchEvent } from './focusSearchEvent'
 export {
+  emitPageShortcutEvent,
+  usePageShortcutEvent,
+} from './pageShortcutEvent'
+export {
   isGlobalRecordingActive,
   setGlobalRecordingState,
   useGlobalRecordingState,

--- a/app/apps/client/src/features/keyboard-shortcuts/utils/pageShortcutEvent.ts
+++ b/app/apps/client/src/features/keyboard-shortcuts/utils/pageShortcutEvent.ts
@@ -1,0 +1,47 @@
+import { useEffect } from 'react'
+
+import type {
+  BuiltInMenuItemId,
+  PageShortcutAction,
+} from '~/features/sidebar-config/types'
+
+/**
+ * How a page-scoped shortcut reaches the page it belongs to. The shortcut
+ * manager resolves the key against the open route and raises this event; the
+ * page that is mounted acts on it with whatever "the selected slide" means
+ * there (a song slide, a verse).
+ */
+const PAGE_SHORTCUT_EVENT = 'page-shortcut'
+
+interface PageShortcutDetail {
+  pageId: BuiltInMenuItemId
+  action: PageShortcutAction
+}
+
+export function emitPageShortcutEvent(
+  pageId: BuiltInMenuItemId,
+  action: PageShortcutAction,
+) {
+  window.dispatchEvent(
+    new CustomEvent<PageShortcutDetail>(PAGE_SHORTCUT_EVENT, {
+      detail: { pageId, action },
+    }),
+  )
+}
+
+export function usePageShortcutEvent(
+  pageId: BuiltInMenuItemId,
+  action: PageShortcutAction,
+  handler: () => void,
+  enabled = true,
+) {
+  useEffect(() => {
+    if (!enabled) return
+    const listener = (event: Event) => {
+      const { detail } = event as CustomEvent<PageShortcutDetail>
+      if (detail.pageId === pageId && detail.action === action) handler()
+    }
+    window.addEventListener(PAGE_SHORTCUT_EVENT, listener)
+    return () => window.removeEventListener(PAGE_SHORTCUT_EVENT, listener)
+  }, [pageId, action, handler, enabled])
+}

--- a/app/apps/client/src/features/presentation/components/rendering/ScreenRenderer.tsx
+++ b/app/apps/client/src/features/presentation/components/rendering/ScreenRenderer.tsx
@@ -10,7 +10,7 @@ import { getBackgroundCSS } from './utils'
 import { getNextVerse } from '../../../bible/service/bible'
 import { useKioskSettings } from '../../../kiosk'
 import { useOBSScenes } from '../../../livestream/hooks'
-import { useClearSlide, useWebSocket } from '../../hooks'
+import { useClearSlide, useNavigateTemporary, useWebSocket } from '../../hooks'
 import { usePresentationContent } from '../../hooks/usePresentationContent'
 import { useScreen } from '../../hooks/useScreen'
 import { useSlideHighlights } from '../../hooks/useSlideHighlights'
@@ -34,6 +34,7 @@ export function ScreenRenderer({ screenId }: ScreenRendererProps) {
   const { data: screenData, isLoading, isError } = useScreen(screenId)
   const { data: kioskSettings } = useKioskSettings()
   const clearSlide = useClearSlide()
+  const navigateTemporary = useNavigateTemporary()
   const { data: slideHighlights } = useSlideHighlights()
   const { currentScene } = useOBSScenes()
 
@@ -509,25 +510,58 @@ export function ScreenRenderer({ screenId }: ScreenRendererProps) {
   }, [isKioskModeScreen, screen])
 
   // Handle keyboard shortcuts. The projection window carries no app chrome and
-  // none of the control window's shortcut registry, so Escape is wired here:
-  // on a single monitor the projection is what has focus after it opens, and
-  // pressing Escape there used to do nothing at all.
+  // none of the control window's shortcut registry, so the keys an operator
+  // (or a presenter remote) presses while THIS window has the keyboard are
+  // wired here: on a single monitor the projection is what has focus after
+  // it opens, and after "Present" the control window is not always handed the
+  // keyboard back. Arrows / PageUp / PageDown / Space drive the same server
+  // navigation the control window uses, so the slide advances whichever of
+  // the two windows the keystroke lands in. Escape hides; "b" / "." (the
+  // remote's black-screen button) hide too while something is live.
+  const hasNavigableContent =
+    !!presentationState?.currentSongSlideId ||
+    !!presentationState?.temporaryContent
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'F11') {
-        e.preventDefault()
-        toggleFullscreen()
-        return
-      }
-      if (e.key === 'Escape') {
-        e.preventDefault()
-        clearSlide.mutate()
+      switch (e.key) {
+        case 'F11':
+          e.preventDefault()
+          toggleFullscreen()
+          return
+        case 'Escape':
+          e.preventDefault()
+          clearSlide.mutate()
+          return
+        case 'ArrowRight':
+        case 'ArrowDown':
+        case 'PageDown':
+        case ' ':
+          e.preventDefault()
+          if (hasNavigableContent)
+            navigateTemporary.mutate({ direction: 'next' })
+          return
+        case 'ArrowLeft':
+        case 'ArrowUp':
+        case 'PageUp':
+          e.preventDefault()
+          if (hasNavigableContent)
+            navigateTemporary.mutate({ direction: 'prev' })
+          return
+        case 'b':
+        case 'B':
+        case '.':
+          if (!hasNavigableContent) return
+          e.preventDefault()
+          clearSlide.mutate()
+          return
+        default:
+          return
       }
     }
 
     window.addEventListener('keydown', handleKeyDown)
     return () => window.removeEventListener('keydown', handleKeyDown)
-  }, [toggleFullscreen, clearSlide])
+  }, [toggleFullscreen, clearSlide, navigateTemporary, hasNavigableContent])
 
   // Clock tick for real-time updates (must be before any early returns)
   const [, setClockTick] = useState(0)

--- a/app/apps/client/src/features/sidebar-config/hooks/index.ts
+++ b/app/apps/client/src/features/sidebar-config/hooks/index.ts
@@ -1,4 +1,6 @@
 export { useAutoOpenPageWindows } from './useAutoOpenPageWindows'
+export type { PageShortcut } from './usePageShortcuts'
+export { usePageShortcuts } from './usePageShortcuts'
 export {
   getIconComponent,
   useResolvedSidebarItems,

--- a/app/apps/client/src/features/sidebar-config/hooks/usePageShortcuts.ts
+++ b/app/apps/client/src/features/sidebar-config/hooks/usePageShortcuts.ts
@@ -1,0 +1,54 @@
+import { useMemo } from 'react'
+
+import { useSidebarConfig } from './useSidebarConfig'
+import { BUILTIN_ITEMS } from '../constants'
+import {
+  type BuiltInMenuItem,
+  type BuiltInMenuItemId,
+  PAGE_SHORTCUT_ACTIONS,
+  type PageShortcutAction,
+} from '../types'
+
+export interface PageShortcut {
+  shortcut: string
+  pageId: BuiltInMenuItemId
+  /** The route the page lives under; the shortcut fires only there. */
+  route: string
+  action: PageShortcutAction
+}
+
+/**
+ * Every presentation shortcut a built-in page bound to itself. The same key
+ * may appear for several pages — that is the point: which one it means is
+ * decided by the page that is open when it is pressed. MIDI bindings are
+ * left out: those are dispatched by the server, which does not know which
+ * page is showing.
+ */
+export function usePageShortcuts(): PageShortcut[] {
+  const { config, isLoading } = useSidebarConfig()
+
+  return useMemo(() => {
+    if (isLoading || !config) return []
+
+    const shortcuts: PageShortcut[] = []
+    for (const item of config.items) {
+      if (item.type !== 'builtin' || !item.settings?.pageShortcuts) continue
+      const { builtinId } = item as BuiltInMenuItem
+      const definition = BUILTIN_ITEMS[builtinId]
+      if (!definition) continue
+
+      for (const action of PAGE_SHORTCUT_ACTIONS) {
+        for (const shortcut of item.settings.pageShortcuts[action] ?? []) {
+          if (!shortcut || shortcut.startsWith('midi:')) continue
+          shortcuts.push({
+            shortcut,
+            pageId: builtinId,
+            route: definition.to,
+            action,
+          })
+        }
+      }
+    }
+    return shortcuts
+  }, [config, isLoading])
+}

--- a/app/apps/client/src/features/sidebar-config/index.ts
+++ b/app/apps/client/src/features/sidebar-config/index.ts
@@ -15,10 +15,11 @@ export {
   SIDEBAR_CONFIG_KEY,
 } from './constants'
 // Hooks
-export type { SidebarShortcut } from './hooks'
+export type { PageShortcut, SidebarShortcut } from './hooks'
 export {
   getIconComponent,
   SIDEBAR_CONFIG_QUERY_KEY,
+  usePageShortcuts,
   useResolvedSidebarItems,
   useSidebarConfig,
   useSidebarItemShortcuts,
@@ -35,14 +36,16 @@ export {
   saveSidebarConfiguration,
   updateCurrentWebviewBounds,
 } from './service'
-// Types
 export type {
   BuiltInItemDefinition,
   BuiltInMenuItem,
   BuiltInMenuItemId,
   CustomPageInput,
   CustomPageMenuItem,
+  PageShortcutAction,
   ResolvedMenuItem,
   SidebarConfiguration,
   SidebarMenuItem,
 } from './types'
+// Types
+export { PAGE_SHORTCUT_ACTIONS } from './types'

--- a/app/apps/client/src/features/sidebar-config/types.ts
+++ b/app/apps/client/src/features/sidebar-config/types.ts
@@ -49,6 +49,19 @@ export interface NativeWindowSettings {
 /**
  * Settings for a sidebar item (shortcuts, navigation behavior)
  */
+/**
+ * Presentation actions a page can bind its own keys to. They fire only while
+ * that page is open, so "F5" can show the selected slide on Songs and the
+ * selected verse on Bible without the two ever getting in each other's way.
+ */
+export type PageShortcutAction = 'showSlide' | 'nextSlide' | 'prevSlide'
+
+export const PAGE_SHORTCUT_ACTIONS: PageShortcutAction[] = [
+  'showSlide',
+  'nextSlide',
+  'prevSlide',
+]
+
 export interface SidebarItemSettings {
   /** Keyboard/MIDI shortcuts that navigate to this page */
   shortcuts: string[]
@@ -56,6 +69,12 @@ export interface SidebarItemSettings {
   focusSearchOnNavigate: boolean
   /** Keyboard/MIDI shortcuts that navigate to this page AND focus the search input */
   focusSearchShortcuts?: string[]
+  /**
+   * Keyboard shortcuts for presentation actions that only work while this
+   * page is open (keyboard only — MIDI is dispatched by the server, which
+   * does not know which page is showing).
+   */
+  pageShortcuts?: Partial<Record<PageShortcutAction, string[]>>
   /** Native window settings (Tauri only) */
   nativeWindow?: NativeWindowSettings
   /** Icon color for the sidebar item (predefined colors) */

--- a/app/apps/client/src/features/songs/components/SongSlidesPanel.tsx
+++ b/app/apps/client/src/features/songs/components/SongSlidesPanel.tsx
@@ -12,6 +12,7 @@ import { useTranslation } from 'react-i18next'
 
 import { SlideCounter } from './SlideCounter'
 import { useDividerPosition } from '../../../hooks/useDividerPosition'
+import { isTypingTarget } from '../../../utils/isTypingTarget'
 import type { SongSlide, SongWithSlides } from '../types'
 import { expandSongSlidesWithChoruses } from '../utils/expandSongSlides'
 import {
@@ -167,6 +168,14 @@ export function SongSlidesPanel({
         elementRect.top - containerRect.top + container.scrollTop
       const targetScrollTop = Math.max(0, elementTop - SCROLL_OFFSET_TOP)
       container.scrollTo({ top: targetScrollTop, behavior: 'smooth' })
+      // Hand the keyboard to the live slide as well. Presenting opens the
+      // projection window, which takes the keyboard as it appears; what the
+      // control window gets back has to land on something in the page, or the
+      // next arrow key goes nowhere until the operator clicks a slide. Never
+      // taken from a field the operator is typing in.
+      if (!isTypingTarget(document.activeElement)) {
+        element.focus({ preventScroll: true })
+      }
     }
   }, [presentedSlideIndex, isEditMode])
 
@@ -448,6 +457,7 @@ export function SongSlidesPanel({
                   ref={getRef()}
                   type="button"
                   data-testid={`song-slide-${index}`}
+                  aria-current={isPresented ? 'true' : undefined}
                   onClick={() => !isPresented && onSlideClick(slide, index)}
                   onDoubleClick={() =>
                     previewMode &&

--- a/app/apps/client/src/features/songs/components/stage-editor/SongStageBoard.tsx
+++ b/app/apps/client/src/features/songs/components/stage-editor/SongStageBoard.tsx
@@ -9,6 +9,7 @@ import {
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
+import { usePageShortcutEvent } from '~/features/keyboard-shortcuts/utils'
 import {
   useClearTemporaryContent,
   useNavigateTemporary,
@@ -265,10 +266,20 @@ export function SongStageBoard({ song }: SongStageBoardProps) {
     [flushSave, displayIndexByPosition, presentSong, song.id],
   )
 
+  // The page's own "show the selected slide" shortcut (Settings → Shortcuts →
+  // Songs): project the slide on the canvas, like its green button.
+  const activeIndexRef = useRef(0)
+  const handleShowActiveSlide = useCallback(() => {
+    if (slides.length === 0) return
+    handleProjectSlide(activeIndexRef.current)
+  }, [slides.length, handleProjectSlide])
+  usePageShortcutEvent('songs', 'showSlide', handleShowActiveSlide)
+
   // Speaker note for the slide currently on the canvas. Clamp the index so a
   // deletion can't point past the end of the list.
   const activeIndex =
     slides.length === 0 ? 0 : Math.min(activeSlideIndex, slides.length - 1)
+  activeIndexRef.current = activeIndex
   const activeNote = slides[activeIndex]?.notes ?? ''
   const handleNoteChange = useCallback(
     (value: string) => {

--- a/app/apps/client/src/features/songs/components/stage-editor/SongStageEditor.tsx
+++ b/app/apps/client/src/features/songs/components/stage-editor/SongStageEditor.tsx
@@ -8,6 +8,7 @@ import type { TemporaryContent } from '~/features/presentation'
 import { usePreviewScreen } from '~/features/presentation'
 import { useDividerPosition } from '~/hooks/useDividerPosition'
 import { ConfirmModal } from '~/ui/modal'
+import { isTypingTarget } from '~/utils/isTypingTarget'
 import { SlideFilmstrip } from './SlideFilmstrip'
 import { StageCanvas } from './StageCanvas'
 import { plainTextToSlideHtml } from '../../utils/plainTextToSlideHtml'
@@ -227,19 +228,26 @@ export function SongStageEditor({
     }
   }, [activeIndex, slides.length])
 
-  // Navigating while live also hands the keyboard to the active thumbnail.
+  // Presenting or navigating hands the keyboard to the active thumbnail.
   // Presenting opens the projection window, which takes the keyboard as it
   // appears; what the control window gets back has to land on something in
   // the page, or the next arrow key goes nowhere until the operator clicks a
   // slide. The thumbnail is a plain button, so the shortcut handlers see its
   // keys like any other.
+  //
+  // Keyed on the projected slide as well as on navigation: "Present" and the
+  // green per-slide button change what is live before the local navigation
+  // counter (if any) catches up, and the first projection of a session is
+  // exactly when the projection window appears and takes the keyboard.
+  // Never taken from a field the operator is typing in.
   useEffect(() => {
-    if (navSeq === 0 || !navStateRef.current.isPresenting) return
+    if (navSeq === 0 && presentedSlideId == null) return
+    if (isTypingTarget(document.activeElement)) return
     const thumbnail = filmstripScrollRef.current?.querySelector<HTMLElement>(
       `[data-slide-index="${activeIndex}"] [data-testid="stage-thumbnail"]`,
     )
     thumbnail?.focus({ preventScroll: true })
-  }, [navSeq, activeIndex])
+  }, [navSeq, activeIndex, presentedSlideId])
 
   const previewContent = useMemo<TemporaryContent>(
     () => ({

--- a/app/apps/client/src/i18n/locales/en/settings.json
+++ b/app/apps/client/src/i18n/locales/en/settings.json
@@ -158,13 +158,57 @@
         "switchDescription": "Shortcut to navigate to this page",
         "focusSearchTitle": "Focus Search",
         "focusSearchDescription": "Shortcut to navigate to this page and focus the search input",
-        "showSlideTitle": "Display Selected Slide",
-        "showSlideDescription": "Shortcut to display the currently selected slide on screen",
         "sameShortcutHint": "You can use the same shortcut for switching to the page and focusing search.",
         "duplicateError": "Shortcut already exists",
         "conflictGlobal": "Already used by global action \"{{action}}\"",
         "conflictScene": "Already used by scene \"{{scene}}\"",
-        "conflictSidebar": "Already used by \"{{item}}\""
+        "conflictSidebar": "Already used by \"{{item}}\"",
+        "page": {
+          "title": "Only on this page",
+          "description": "These keys work only while this page is open, so the same key can do something else on another page. Keyboard only — MIDI buttons are global.",
+          "default": {
+            "showSlide": {
+              "title": "Show the selected item",
+              "description": "Put the selected item on screen"
+            },
+            "nextSlide": {
+              "title": "Next",
+              "description": "Go to the next item on screen"
+            },
+            "prevSlide": {
+              "title": "Previous",
+              "description": "Go to the previous item on screen"
+            }
+          },
+          "songs": {
+            "showSlide": {
+              "title": "Show the selected slide",
+              "description": "Put the selected slide of the open song on screen"
+            },
+            "nextSlide": {
+              "title": "Next slide",
+              "description": "Go to the next slide of the song on screen"
+            },
+            "prevSlide": {
+              "title": "Previous slide",
+              "description": "Go to the previous slide of the song on screen"
+            }
+          },
+          "bible": {
+            "showSlide": {
+              "title": "Show the selected verse",
+              "description": "Put the selected verse on screen"
+            },
+            "nextSlide": {
+              "title": "Next verse",
+              "description": "Go to the next verse on screen"
+            },
+            "prevSlide": {
+              "title": "Previous verse",
+              "description": "Go to the previous verse on screen"
+            }
+          }
+        }
       },
       "visibility": {
         "label": "Visible in Sidebar",
@@ -200,7 +244,7 @@
         "livestream": "Livestream",
         "livestreamDescription": "Start and stop the live stream with a key or MIDI button.",
         "pages": "Pages",
-        "pagesDescription": "Jump to a page and focus its search."
+        "pagesDescription": "Switch to a page, focus its search, and keys that only work while that page is open."
       },
       "actions": {
         "startLive": {

--- a/app/apps/client/src/i18n/locales/ro/settings.json
+++ b/app/apps/client/src/i18n/locales/ro/settings.json
@@ -158,13 +158,57 @@
         "switchDescription": "Scurtătură pentru a naviga la această pagină",
         "focusSearchTitle": "Focusează Căutarea",
         "focusSearchDescription": "Scurtătură pentru a naviga la pagină și a focusa câmpul de căutare",
-        "showSlideTitle": "Afișează Slide-ul Selectat",
-        "showSlideDescription": "Scurtătură pentru a afișa slide-ul selectat pe ecran",
         "sameShortcutHint": "Poți folosi aceeași scurtătură pentru a comuta la pagină și a focusa căutarea.",
         "duplicateError": "Scurtătura există deja",
         "conflictGlobal": "Folosită deja de acțiunea globală \"{{action}}\"",
         "conflictScene": "Folosită deja de scena \"{{scene}}\"",
-        "conflictSidebar": "Folosită deja de \"{{item}}\""
+        "conflictSidebar": "Folosită deja de \"{{item}}\"",
+        "page": {
+          "title": "Doar pe această pagină",
+          "description": "Aceste taste funcționează doar cât timp pagina e deschisă, așa că aceeași tastă poate face altceva pe altă pagină. Doar tastatură — butoanele MIDI sunt globale.",
+          "default": {
+            "showSlide": {
+              "title": "Afișează elementul selectat",
+              "description": "Pune elementul selectat pe ecran"
+            },
+            "nextSlide": {
+              "title": "Următorul",
+              "description": "Trece la următorul element de pe ecran"
+            },
+            "prevSlide": {
+              "title": "Anteriorul",
+              "description": "Trece la elementul anterior de pe ecran"
+            }
+          },
+          "songs": {
+            "showSlide": {
+              "title": "Afișează slide-ul selectat",
+              "description": "Pune pe ecran slide-ul selectat din cântarea deschisă"
+            },
+            "nextSlide": {
+              "title": "Slide-ul următor",
+              "description": "Trece la slide-ul următor al cântării de pe ecran"
+            },
+            "prevSlide": {
+              "title": "Slide-ul anterior",
+              "description": "Trece la slide-ul anterior al cântării de pe ecran"
+            }
+          },
+          "bible": {
+            "showSlide": {
+              "title": "Afișează versetul selectat",
+              "description": "Pune versetul selectat pe ecran"
+            },
+            "nextSlide": {
+              "title": "Versetul următor",
+              "description": "Trece la versetul următor de pe ecran"
+            },
+            "prevSlide": {
+              "title": "Versetul anterior",
+              "description": "Trece la versetul anterior de pe ecran"
+            }
+          }
+        }
       },
       "visibility": {
         "label": "Vizibil în Bara Laterală",
@@ -200,7 +244,7 @@
         "livestream": "Live Stream",
         "livestreamDescription": "Pornește și oprește transmisiunea cu o tastă sau buton MIDI.",
         "pages": "Pagini",
-        "pagesDescription": "Navighează la o pagină și focusează căutarea."
+        "pagesDescription": "Comută la o pagină, focusează căutarea și taste care funcționează doar cât timp pagina e deschisă."
       },
       "actions": {
         "startLive": {

--- a/app/apps/client/src/routes/bible/index.tsx
+++ b/app/apps/client/src/routes/bible/index.tsx
@@ -32,13 +32,17 @@ import {
   useSelectedBibleTranslations,
   useVerses,
 } from '~/features/bible'
-import { useFocusSearchEvent } from '~/features/keyboard-shortcuts/utils'
+import {
+  useFocusSearchEvent,
+  usePageShortcutEvent,
+} from '~/features/keyboard-shortcuts/utils'
 import { getBibleLastVisited, setBibleLastVisited } from '~/features/navigation'
 import {
   useClearSlide,
   useNavigateTemporary,
   usePresentationState,
   usePresentTemporaryBible,
+  useShowSlide,
 } from '~/features/presentation'
 import type { ScheduleItem } from '~/features/schedules'
 import {
@@ -134,6 +138,7 @@ function BiblePage() {
   const { data: primaryBooks = [] } = useBooks(primaryTranslation?.id)
   const presentTemporaryBible = usePresentTemporaryBible()
   const clearSlide = useClearSlide()
+  const showSlide = useShowSlide()
   const navigateTemporary = useNavigateTemporary()
   const addToHistory = useAddToHistory()
   const addItemToSchedule = useAddItemToSchedule()
@@ -1007,6 +1012,31 @@ function BiblePage() {
       }
     }
   }, [navigation, verses, presentVerseToScreen, urlSelectOnly, navigate])
+
+  // The page's own "show the selected verse" shortcut (Settings → Shortcuts →
+  // Bible): the verse the search landed on, or the highlighted one; when that
+  // is already what is live, just bring it back on screen.
+  const handleShowSelectedVerse = useCallback(() => {
+    const { searchedIndex, presentedIndex } = navigation.state
+    if (searchedIndex !== null && searchedIndex !== presentedIndex) {
+      void handlePresentSearched()
+      return
+    }
+    const index = searchedIndex ?? presentedIndex
+    const verse = index !== null ? verses[index] : undefined
+    if (verse && index !== null && index !== presentedIndex) {
+      void presentVerseToScreen(verse, index)
+      return
+    }
+    showSlide.mutate()
+  }, [
+    navigation.state,
+    verses,
+    handlePresentSearched,
+    presentVerseToScreen,
+    showSlide,
+  ])
+  usePageShortcutEvent('bible', 'showSlide', handleShowSelectedVerse)
 
   // Handle go back - use browser history when navigated internally, hierarchical when external
   const handleGoBack = useCallback(() => {

--- a/app/apps/client/src/routes/songs/$songId/index.tsx
+++ b/app/apps/client/src/routes/songs/$songId/index.tsx
@@ -24,6 +24,7 @@ import {
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
+import { usePageShortcutEvent } from '~/features/keyboard-shortcuts/utils'
 import {
   clearSectionLastVisited,
   setSongsLastVisited,
@@ -642,6 +643,15 @@ function SongPreviewPage() {
     onGoBack: handleGoBack,
     enabled: classicKeyboard && presentedSlideIndex === null,
   })
+
+  // The page's own "show the selected slide" shortcut (Settings → Shortcuts →
+  // Songs). In PowerPoint mode the stage board answers it instead.
+  usePageShortcutEvent(
+    'songs',
+    'showSlide',
+    handlePresentSelectedSlide,
+    classicKeyboard,
+  )
 
   // Divider drag handlers
   const handleDividerMouseDown = useCallback(

--- a/app/apps/client/src/utils/__tests__/isTypingTarget.test.ts
+++ b/app/apps/client/src/utils/__tests__/isTypingTarget.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest'
+
+import { isTypingTarget } from '../isTypingTarget'
+
+describe('isTypingTarget', () => {
+  it('recognises the elements that take typed text', () => {
+    expect(isTypingTarget(document.createElement('input'))).toBe(true)
+    expect(isTypingTarget(document.createElement('textarea'))).toBe(true)
+    expect(isTypingTarget(document.createElement('select'))).toBe(true)
+
+    const editable = document.createElement('div')
+    editable.setAttribute('contenteditable', 'true')
+    document.body.appendChild(editable)
+    expect(isTypingTarget(editable)).toBe(true)
+    editable.remove()
+  })
+
+  it('leaves buttons, plain elements and nothing alone', () => {
+    expect(isTypingTarget(document.createElement('button'))).toBe(false)
+    expect(isTypingTarget(document.createElement('div'))).toBe(false)
+    expect(isTypingTarget(null)).toBe(false)
+  })
+})

--- a/app/apps/client/src/utils/isTypingTarget.ts
+++ b/app/apps/client/src/utils/isTypingTarget.ts
@@ -1,0 +1,22 @@
+/**
+ * Whether keystrokes aimed at this element are text being typed — an input,
+ * a textarea, a select or a contenteditable — and must not be taken away from
+ * it by moving focus elsewhere.
+ */
+export function isTypingTarget(element: Element | null): boolean {
+  if (!element) return false
+  if (
+    element instanceof HTMLInputElement ||
+    element instanceof HTMLTextAreaElement ||
+    element instanceof HTMLSelectElement
+  ) {
+    return true
+  }
+  if (!(element instanceof HTMLElement)) return false
+  if (element.isContentEditable) return true
+  // Some DOM implementations (jsdom) do not compute isContentEditable.
+  const attribute = element.getAttribute('contenteditable')
+  return (
+    attribute === '' || attribute === 'true' || attribute === 'plaintext-only'
+  )
+}


### PR DESCRIPTION
## Summary

Two operator complaints.

### 1. After "Present from the beginning" the arrows / remote were dead until a slide was clicked
The projection window takes the keyboard as it appears, and what the control window got back landed on the button that was clicked — or on nothing. The stage editor did try to hand focus to the live thumbnail, but only on a navigation tick while it *already* believed the song was live — which "Present" races (the projection lands before the local counter does). The first projection of a single slide had no focus handling at all.

- The **live slide takes focus whenever the projected slide changes** — in the PowerPoint stage (thumbnail) and in the classic list (slide row) — never stealing it from a field being typed in (`isTypingTarget`).
- The **projection window itself drives navigation** with the arrows, PageUp/PageDown, Space and the remote's `b`/`.` black-screen key. On a single monitor the projection is what has the keyboard after it opens (the existing focus-reclaim is deliberately multi-monitor only), so now the keys work wherever they land. Both windows call the same server navigation; only one ever receives a keystroke.

### 2. Shortcuts fired regardless of which page was open
A key meant to show a verse showed it from the song page too. Pages now own presentation shortcuts of their own — **show the selected slide/verse, next, previous** — under *"Only on this page"* in Settings → Shortcuts, stored on the page's sidebar item (`settings.pageShortcuts`).

- The shortcut manager registers each page key once, resolves it against the **open route**, and raises a page event the mounted page acts on with its own meaning: Songs → the selected slide (both layouts); Bible → the searched/highlighted verse, or bring the live one back. Anywhere else the key does nothing.
- The **same key may be bound on Songs and on Bible**; it may not be bound twice on one page or clash with a global action — refused with a visible message (the recorder used to signal a conflict with a red border only).
- Page keys are keyboard-only: MIDI is dispatched by the server, which does not know which page is showing, so the recorder does not take a MIDI button for them.
- Global "Presentation" shortcuts keep working from anywhere, as documented.

## Test plan
- [x] Unit: page-event routing (`usePageShortcutEvent`), `isTypingTarget` (jsdom-safe).
- [x] E2E `presentation-focus.spec.ts`: Present focuses the live thumbnail and arrows advance; projecting via the slide button focuses too; classic layout click focuses the live row; `/screen/:id` navigates with ArrowRight/PageDown/ArrowLeft/PageUp.
- [x] E2E `page-scoped-shortcuts.spec.ts`: F9 bound on Songs and Bible both stored, no conflict; F9 on another Songs action → conflict shown; the Songs event presents the selected slide while a Bible event on the song page does nothing.
- [x] Full e2e suite green; vitest 1053 pass.
- [ ] Desktop build: Present from Songs with the projector on a second monitor → ArrowRight advances without clicking; on a single monitor → arrows work from the projection window; bind F5 under Songs and under Bible → each works only on its page.
